### PR TITLE
add giant swarm deployment recording rules + change ingress alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Alert `IngressControllerDeploymentNotSatisfied` uses newly introduced recording rules and selects on app label
+
+### Added
+
+- Recording rules `kube_deployment_status_replicas_available_gs` and `kube_deployment_status_replicas_unavailable_gs` for deployments with label `giantswarm.io/service-type: "managed"`
+
 ## [0.1.1] - 2021-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Recording rules `kube_deployment_status_replicas_available_gs` and `kube_deployment_status_replicas_unavailable_gs` for deployments with label `giantswarm.io/service-type: "managed"`
+- Recording rules `managed_app_deployment_status_replicas_available` and `managed_app_deployment_status_replicas_unavailable` for deployments with label `giantswarm.io/service-type: "managed"`
 
 ## [0.1.1] - 2021-06-24
 

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: ingress-controller-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} / (kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} + kube_deployment_status_replicas_unavailable{deployment="nginx-ingress-controller"}) * 100 < 51
+      expr: kube_deployment_status_replicas_available_gs{label_app="nginx-ingress-controller"} / (kube_deployment_status_replicas_available_gs{label_app="nginx-ingress-controller"} + kube_deployment_status_replicas_unavailable_gs{label_app="nginx-ingress-controller"}) * 100 < 51
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: ingress-controller-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_available_gs{label_app="nginx-ingress-controller"} / (kube_deployment_status_replicas_available_gs{label_app="nginx-ingress-controller"} + kube_deployment_status_replicas_unavailable_gs{label_app="nginx-ingress-controller"}) * 100 < 51
+      expr: managed_app_deployment_status_replicas_available{label_app="nginx-ingress-controller"} / (managed_app_deployment_status_replicas_available{label_app="nginx-ingress-controller"} + managed_app_deployment_status_replicas_unavailable{label_app="nginx-ingress-controller"}) * 100 < 51
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: ingress-controller-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_available{label_app="nginx-ingress-controller"} / (managed_app_deployment_status_replicas_available{label_app="nginx-ingress-controller"} + managed_app_deployment_status_replicas_unavailable{label_app="nginx-ingress-controller"}) * 100 < 51
+      expr: managed_app_deployment_status_replicas_available{managed_app="nginx-ingress-controller"} / (managed_app_deployment_status_replicas_available{managed_app="nginx-ingress-controller"} + managed_app_deployment_status_replicas_unavailable{managed_app="nginx-ingress-controller"}) * 100 < 51
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/recording-rules/gs-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-deployment-status.rules.yml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: gs-deployment-status.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: ingress-controller
+    rules:
+    - expr: kube_deployment_status_replicas_available *
+            on (deployment) group_left(label_giantswarm_io_service_type, label_app)
+            kube_deployment_labels{label_giantswarm_io_service_type="managed"}
+      record: kube_deployment_status_replicas_available_gs
+    - expr: kube_deployment_status_replicas_unavailable *
+            on (deployment) group_left(label_giantswarm_io_service_type, label_app)
+            kube_deployment_labels{label_giantswarm_io_service_type="managed"}
+      record: kube_deployment_status_replicas_unavailable_gs

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -9,11 +9,15 @@ spec:
   groups:
   - name: gs-managed-app-deployments
     rules:
-    - expr: kube_deployment_status_replicas_available *
-            on (deployment) group_left(label_giantswarm_io_service_type, label_app)
-            kube_deployment_labels{label_giantswarm_io_service_type="managed"}
+    - expr: label_replace(
+              kube_deployment_status_replicas_available *
+              on (deployment) group_left(label_app_kubernetes_io_name)
+              kube_deployment_labels{label_giantswarm_io_service_type="managed"},
+            "managed_app", "$1", "label_app_kubernetes_io_name", "(.*)" )
       record: managed_app_deployment_status_replicas_available
-    - expr: kube_deployment_status_replicas_unavailable *
-            on (deployment) group_left(label_giantswarm_io_service_type, label_app)
-            kube_deployment_labels{label_giantswarm_io_service_type="managed"}
+    - expr: label_replace(
+              kube_deployment_status_replicas_unavailable *
+              on (deployment) group_left(label_app_kubernetes_io_name)
+              kube_deployment_labels{label_giantswarm_io_service_type="managed"},
+            "managed_app", "$1", "label_app_kubernetes_io_name", "(.*)" )
       record: managed_app_deployment_status_replicas_unavailable

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -12,8 +12,8 @@ spec:
     - expr: kube_deployment_status_replicas_available *
             on (deployment) group_left(label_giantswarm_io_service_type, label_app)
             kube_deployment_labels{label_giantswarm_io_service_type="managed"}
-      record: kube_deployment_status_replicas_available_gs
+      record: managed_app_deployment_status_replicas_available
     - expr: kube_deployment_status_replicas_unavailable *
             on (deployment) group_left(label_giantswarm_io_service_type, label_app)
             kube_deployment_labels{label_giantswarm_io_service_type="managed"}
-      record: kube_deployment_status_replicas_unavailable_gs
+      record: managed_app_deployment_status_replicas_unavailable

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: gs-deployment-status.rules
+  name: gs-managed-app-deployment-status.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: ingress-controller
+  - name: gs-managed-app-deployments
     rules:
     - expr: kube_deployment_status_replicas_available *
             on (deployment) group_left(label_giantswarm_io_service_type, label_app)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17284

This PR attempts to solve:

- Current `IngressControllerDeploymentNotSatisfied` missing some deployments. Filtering on `deployment` breaks when customer chooses an own name or installs additional `nginx-ingress-controller-app` instances. We change to filtering on label `app: "nginx-ingress-controller"`.
- Notifying for non-giantswarm nginx ingress controller installations by introducing recording rules which select based on label `giantswarm.io/service-type: "managed"`


We tested this by 

- Changing the `App` CR on `ginger` to use the test catalog and `15df160` from this PR
- Installing the `nginx-ingress-controller-app` onto a WC on `ginger` with only a single node.
- The deployment requires two pod replicas on different nodes, thus the deployment was not satisfied.
- Alert worked

### Checklist

- [x] Update changelog in CHANGELOG.md.
