### PR TITLE
cancel_if_outside_working_hours ElasticsearchDataVolumeSpaceTooLow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only alert during working hours for `ElasticsearchDataVolumeSpaceTooLow`
+
 ## [0.1.1] - 2021-06-24
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/elasticsearch.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/elasticsearch.rules.yml
@@ -51,6 +51,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: batman
         topic: logging


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17523

This PR:

- Makes `ElasticsearchDataVolumeSpaceTooLow ` only alert during working hours

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
