### PR TITLE
do not alert WorkloadClusterEtcdHasNoLeader for etcd metrics exported…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `WorkloadClusterEtcdHasNoLeader` will not fire for loki or promtail pods any more.
+
 ## [0.2.0] - 2021-07-02
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -85,7 +85,7 @@ spec:
       annotations:
         description: '{{`Etcd has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
-      expr: etcd_server_has_leader{cluster_type="workload_cluster"} == 0
+      expr: etcd_server_has_leader{cluster_type="workload_cluster", container!~"loki|promtail"} == 0
       for: 35m
       labels:
         area: kaas


### PR DESCRIPTION
Towards giantswarm/giantswarm#17947 

This PR changes the `WorkloadClusterEtcdHasNoLeader` alert to ignore pods with containers named `loki` or `promtail`. These two export etcd metrics. Related upstream issue: https://github.com/grafana/loki/issues/3262

@giantswarm/team-atlas Do you think it is neccesary to also include this mitigation in the other etcd alerts?

### Checklist

- [x] Update changelog in CHANGELOG.md.
