### PR TITLE
Add namespace to AppOperatorNotReady alert description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add namespace to `AppOperatorNotReady` alert description.
+
 ## [0.2.0] - 2021-07-02
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -210,7 +210,7 @@ spec:
         topic: releng
     - alert: AppOperatorNotReady
       annotations:
-        description: '{{`app CR version ({{ $labels.version }}) has no ready app-operator.`}}'
+        description: '{{`app CR version ({{ $labels.version }}) in namespace {{ $labels.namespace }} has no ready app-operator.`}}'
         opsrecipe: app-operator-not-ready/
       expr: app_operator_ready_total != 1
       for: 15m


### PR DESCRIPTION
This PR:

- Fixes AppOperatorNotReady alert description so it includes the namespace app-operator is deployed in.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
