### PR TITLE
Add paging alerts for docker and containerd being down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ManagementClusterRuntimeSystemdUnitFailed` and `WorkloadClusterRuntimeSystemdUnitFailed`.
+
 ## [0.2.0] - 2021-07-02
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
@@ -33,3 +33,14 @@ spec:
         severity: page
         team: biscuit
         topic: infrastructure
+    - alert: ManagementClusterRuntimeSystemdUnitFailed
+      annotations:
+        description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
+        opsrecipe: critical-systemd-unit-failed/
+      expr: node_systemd_unit_state{cluster_type="management_cluster",name=~"docker.service|containerd.service", state="failed"} == 1
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: biscuit
+        topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
@@ -37,7 +37,7 @@ spec:
       annotations:
         description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
         opsrecipe: critical-systemd-unit-failed/
-      expr: node_systemd_unit_state{cluster_type="management_cluster",name=~"docker.service|containerd.service", state="failed"} == 1
+      expr: node_systemd_unit_state{cluster_type="management_cluster",name=~"docker.service|containerd.service",state!="active"} == 1
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
@@ -38,7 +38,7 @@ spec:
         description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
         opsrecipe: critical-systemd-unit-failed/
       expr: node_systemd_unit_state{cluster_type="management_cluster",name=~"docker.service|containerd.service",state!="active"} == 1
-      for: 5m
+      for: 15m
       labels:
         area: kaas
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
@@ -37,7 +37,7 @@ spec:
       annotations:
         description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
         opsrecipe: critical-systemd-unit-failed/
-      expr: node_systemd_unit_state{cluster_type="workload_cluster",name=~"docker.service|containerd.service", state="failed"} == 1
+      expr: node_systemd_unit_state{cluster_type="workload_cluster",name=~"docker.service|containerd.service",state!="active"} == 1
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
@@ -33,3 +33,14 @@ spec:
         severity: page
         team: ludacris
         topic: infrastructure
+    - alert: WorkloadClusterRuntimeSystemdUnitFailed
+      annotations:
+        description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
+        opsrecipe: critical-systemd-unit-failed/
+      expr: node_systemd_unit_state{cluster_type="workload_cluster",name=~"docker.service|containerd.service", state="failed"} == 1
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: ludacris
+        topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
@@ -38,7 +38,7 @@ spec:
         description: '{{`Runtime systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
         opsrecipe: critical-systemd-unit-failed/
       expr: node_systemd_unit_state{cluster_type="workload_cluster",name=~"docker.service|containerd.service",state!="active"} == 1
-      for: 5m
+      for: 15m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/737.

Tested on `gorgoth` - [MC](https://giantswarm.app.opsgenie.com/alert/detail/253c85ba-d05a-4b57-8877-819f1d33d384-1625643077580/details) and [WC](https://giantswarm.app.opsgenie.com/alert/detail/1575e647-4964-4364-b1b5-74ef1017dace-1625652122970/details).

### Checklist

- [x] Update changelog in CHANGELOG.md.
