### PR TITLE
exclude already expired certificates from CertificateSecretWillExpireInLessThanTwoWeeks rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude expired certificates in secrets for `CertificateSecretWillExpireInLessThanTwoWeeks`.
+
 ## [0.4.0] - 2021-07-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/
-      expr: (cert_exporter_secret_not_after{type="secret"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_secret_not_after{type="secret"} - time()) < 2 * 7 * 24 * 60 * 60 and cert_exporter_secret_not_after{type="secret"} > time()
       for: 5m
       labels:
         area: managedapps


### PR DESCRIPTION
This PR:

Changes alert query of `CertificateSecretWillExpireInLessThanTwoWeeks` to exclude already expired certificates to reduce the amount of alerts.

Once, released, the `Only on Mondays: CertificateSecretWillExpireInLessThanTwoWeeks` global policy should be removed.

### Checklist

- [x] Update changelog in CHANGELOG.md.
