### PR TITLE
Only alert for failed etcd v2 backups on kvm management clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only alert for failed etcd v2 backups on kvm management clusters.
+
 ## [0.4.0] - 2021-07-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -56,7 +56,7 @@ spec:
       annotations:
         description: '{{`{{ $labels.cluster_id }} management cluster''s ETCD backup was unsuccessful.`}}'
         opsrecipe: etcd-backup-failed/
-      expr: time() - etcd_backup_latest_success{etcd_version="V2",tenant_cluster_id="Control Plane"} > 60*60*24 or time() - etcd_backup_latest_success{etcd_version="V3",tenant_cluster_id="Control Plane"} > 60*60*24
+      expr: time() - etcd_backup_latest_success{etcd_version="V2",tenant_cluster_id="Control Plane", provider="kvm"} > 60*60*24 or time() - etcd_backup_latest_success{etcd_version="V3",tenant_cluster_id="Control Plane"} > 60*60*24
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18112

This PR:

- disables paging for failed etcd v2 alerts for non-kvm clusters

### Checklist

- [x] Update changelog in CHANGELOG.md.
