### PR TITLE
drop specific rules for dead installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed custom alerts for `dragon` and `dinosaur` installations.
+
 ## [0.5.0] - 2021-07-19
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -130,19 +130,4 @@ spec:
         severity: notify
         team: rocket
         topic: kvm
-    {{- if or (eq .Values.managementCluster.name "dragon") (eq .Values.managementCluster.name "dinosaur") }}
-    - alert: BackendServerUP
-      annotations:
-        description: '{{`Backend {{ $labels.server }} is not reachable from haproxy load balancer.`}}'
-      expr: haproxy_server_up{app="haproxy-exporter",cluster_type="management_cluster"} == 0
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        severity: notify
-        team: rocket
-        topic: managementcluster
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR:

- removed custom alerts for `dragon` and `dinosaur` installations. 

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
