### PR TITLE
Add KiamSTSIssuingErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+### Added 
 
 - Added KiamSTSIssuingErrors for AWS workload clusters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Added KiamSTSIssuingErrors for AWS workload clusters.
+
+### Removed
+
 - Removed custom alerts for `dragon` and `dinosaur` installations.
 
 ## [0.5.0] - 2021-07-19

--- a/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
@@ -33,7 +33,7 @@ spec:
       annotations:
         description: '{{`Kiam pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has increased STS issuing errors.`}}'
         opsrecipe: kiam_sts_issuing_errors_total/
-      expr: increase(kiam_sts_issuing_errors_total[10m]) > 0
+      expr: increase(kiam_sts_issuing_errors_total[10m]) > 5
       for: 15m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
@@ -27,4 +27,21 @@ spec:
         severity: page
         team: firecracker
         topic: kiam
+  - name: kiam
+    rules:
+    - alert: KiamSTSIssuingErrors
+      annotations:
+        description: '{{`Kiam pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has increased STS issuing errors.`}}'
+        opsrecipe: kiam_sts_issuing_errors_total/
+      expr: increase(kiam_sts_issuing_errors_total[10m]) > 0
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: firecracker
+        topic: kiam
 {{- end }}


### PR DESCRIPTION
This hopefully will block `ExternalDNSCantAccessRegistry` paging during the night, by adding STSIssue alert.

`ExternalDNSCantAccessRegistry` uses `cancel_if_kiam_has_errors`, see
 https://github.com/giantswarm/prometheus-rules/blob/master/helm/prometheus-rules/templates/alerting-rules/external-dns.rules.yml#L26, which should be inhibited here https://github.com/giantswarm/prometheus-rules/blob/master/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml#L32-L40.
### Checklist

- [x] Update changelog in CHANGELOG.md.