### PR TITLE
alert if felix cannot save or restore iptables rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alert when Calico cannot save or restore iptables rules (KVM only).
+
 ### Removed
 
 - Removed custom alerts for `dragon` and `dinosaur` installations.

--- a/helm/prometheus-rules/templates/alerting-rules/calico.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/calico.rules.yml
@@ -35,3 +35,35 @@ spec:
         severity: notify
         team: ludacris
         topic: kubernetes
+{{- if eq .Values.managementCluster.provider.kind "kvm" }}
+    - alert: CalicoNodeFailingToSaveIptables
+      annotations:
+        description: '{{`calico-node {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} is failing to save iptables rules.`}}'
+        opsrecipe: calico-iptables-failing/
+      expr: increase(felix_iptables_save_errors[10m]) > 0
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: rocket
+        topic: kubernetes
+    - alert: CalicoNodeFailingToRestoreIptables
+      annotations:
+        description: '{{`calico-node {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} is failing to restore iptables rules.`}}'
+        opsrecipe: calico-iptables-failing/
+      expr: increase(felix_iptables_restore_errors[10m]) > 0
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: rocket
+        topic: kubernetes
+{{- end }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/18140

This PR:

- Adds alerts if Calico is failing to update or restore iptables rules in KVM clusters.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
