### PR TITLE
Add recording in recording Prometheus Rules to avoid conflicts with alerting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add recording in recording Prometheus Rules to avoid conflicts with alerting rules.
+
 ## [0.6.0] - 2021-07-22
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: cortex.rules
+  name: cortex.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: cortex
+  - name: cortex.recording
     rules:
     - expr: sum(alertmanager_alerts{state="active"})
       record: aggregation:alertmanager:alerts_active_total

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: gs-managed-app-deployment-status.rules
+  name: gs-managed-app-deployment-status.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: gs-managed-app-deployments
+  - name: gs-managed-app-deployments.recording
     rules:
     - expr: label_replace(
               kube_deployment_status_replicas_available *

--- a/helm/prometheus-rules/templates/recording-rules/helm-operations.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/helm-operations.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: helm-operations.rules
+  name: helm-operations.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: helm-operations
+  - name: helm-operations.recording
     rules:
     - expr: "sum by (cluster_id, release, event) (helmclient_library_event_total{release!=''})"
       record: monitoring:helm:number_of_operations_on_release

--- a/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: kube-mixins.rules
+  name: kube-mixins.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: node.rules
+  - name: node.recording.rules
     rules:
     - expr: |-
         topk by(namespace, pod) (1,
@@ -33,7 +33,7 @@ spec:
           )
         ) by (cluster)
       record: :node_memory_MemAvailable_bytes:sum
-  - name: node-exporter.rules
+  - name: node-exporter.recording.rules
     rules:
     - expr: |-
         count without (cpu) (
@@ -87,7 +87,7 @@ spec:
           rate(node_network_transmit_drop_total{ device!="lo"}[1m])
         )
       record: instance:node_network_transmit_drop_excluding_lo:rate1m
-  - name: kube-prometheus-node-recording.rules
+  - name: kube-prometheus-node.recording.rules
     rules:
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m])) BY (instance)
       record: instance:node_cpu:rate:sum
@@ -101,13 +101,13 @@ spec:
       record: cluster:node_cpu:sum_rate5m
     - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))
       record: cluster:node_cpu:ratio
-  - name: kube-prometheus-general.rules
+  - name: kube-prometheus-general.recording.rules
     rules:
     - expr: count without(instance, pod, node) (up == 1)
       record: count:up1
     - expr: count without(instance, pod, node) (up == 0)
       record: count:up0
-  - name: kube-apiserver.rules
+  - name: kube-apiserver.recording.rules
     rules:
     - expr: |-
         (
@@ -441,7 +441,7 @@ spec:
         quantile: '0.5'
       record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
   - interval: 3m
-    name: kube-apiserver-availability.rules
+    name: kube-apiserver-availability.recording.rules
     rules:
     - expr: |-
         1 - (
@@ -575,7 +575,7 @@ spec:
       labels:
         verb: write
       record: code:apiserver_request_total:increase30d
-  - name: k8s.rules
+  - name: k8s.recording.rules
     rules:
     - expr: |-
         sum by (cluster, namespace, pod, container) (

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -3,11 +3,11 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: service-level.rules
+  name: service-level.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: service-level
+  - name: service-level.recording
     rules:
       # -- api-server
     - expr: "count(up{app='kubernetes'}) by (cluster_type,cluster_id)"


### PR DESCRIPTION

This PR:

- Adds recording in recording Prometheus Rules to avoid conflicts with alerting rules.

We need this because the service level recording rules overwrite the service level alerting rules.

![giphy](https://user-images.githubusercontent.com/2787548/126636624-c370d1fd-beeb-451e-9dc5-39e369666e27.gif)


### Checklist

- [x] Update changelog in CHANGELOG.md.
