### PR TITLE
Trigger  only during working hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Trigger `ETCDBackupJobFailedOrStuck` only during working hours.
+
 ## [0.7.1] - 2021-07-23
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -19,6 +19,7 @@ spec:
       for: 30m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: celestial
         topic: etcd


### PR DESCRIPTION
This PR:

- changes ETCDBackupJobFailedOrStuck to trigger only during business hours

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
