### PR TITLE
Add missing opsrecipe for PrometheusFailsToCommunicateWithRemoteStora…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
+
 ## [0.7.2] - 2021-07-26
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -26,6 +26,7 @@ spec:
     - alert: PrometheusFailsToCommunicateWithRemoteStorageAPI
       annotations:
         description: '{{`Prometheus can''t communicate with Remote Storage API at {{ $labels.url }}.`}}'
+        opsrecipe: prometheus-cant-communicate-with-remote-storage-api/
       expr: rate(prometheus_remote_storage_samples_failed_total[1h]) > 0.10 or rate(prometheus_remote_storage_samples_total[1h]) == 0 or rate(prometheus_remote_storage_metadata_retried_total[5m]) > 0
       for: 1h
       labels:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16811

This PR:

- adds an opsrecipe for the PrometheusFailsToCommunicateWithRemoteStorageAPI alert

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
