### PR TITLE
Add prometheus operator alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
+- Add new alerts for the Prometheus Operator.
 
 ## [0.7.2] - 2021-07-26
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -1,0 +1,105 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: prometheus-operator.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: prometheus-operator
+    rules:
+    - alert: PrometheusOperatorDown
+      annotations:
+        description: '{{`Prometheus-operator ({{ $labels.instance }}) is down.`}}'
+      expr: up{app="prometheus-operator"} == 0
+      for: 15m
+      labels:
+        area: empowerment
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        severity: page
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorListErrors
+      annotations:
+        description: Errors while performing List operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
+      expr: (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[10m]))) > 0.4
+      for: 15m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorWatchErrors
+      annotations:
+        description: Errors while performing watch operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
+      expr: (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[10m]))) > 0.4
+      for: 15m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorSyncFailed
+      annotations:
+        description: Controller {{`{{`}} $labels.controller {{`}}`}} in {{`{{`}} $labels.namespace {{`}}`}} namespace fails to reconcile {{`{{`}} $value {{`}}`}} objects.
+      expr: min_over_time(prometheus_operator_syncs{status="failed",app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]) > 0
+      for: 10m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorReconcileErrors
+      annotations:
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconciling operations failed for {{`{{`}} $labels.controller {{`}}`}} controller in {{`{{`}} $labels.namespace {{`}}`}} namespace.'
+      expr: (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]))) > 0.1
+      for: 10m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorNodeLookupErrors
+      annotations:
+        description: Errors while reconciling Prometheus in {{`{{`}} $labels.namespace {{`}}`}} Namespace.
+      expr: rate(prometheus_operator_node_address_lookup_errors_total{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]) > 0.1
+      for: 10m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorNotReady
+      annotations:
+        description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace isn't ready to reconcile {{`{{`}} $labels.controller {{`}}`}} resources.
+      expr: min by(namespace, controller) (max_over_time(prometheus_operator_ready{app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]) == 0)
+      for: 5m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: PrometheusOperatorRejectedResources
+      annotations:
+        description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace rejected {{`{{`}} printf "%0.0f" $value {{`}}`}} {{`{{`}} $labels.controller {{`}}`}}/{{`{{`}} $labels.resource {{`}}`}} resources.
+      expr: min_over_time(prometheus_operator_managed_resources{state="rejected",app="prometheus-operator",namespace="{{ .Values.namespace  }}"}[5m]) > 0
+      for: 5m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/15600

This PR:

- adds prometheus operator alerts from https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
- depends on https://github.com/giantswarm/config/pull/309

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
