### PR TITLE
Remove the severity from the InvalidLabellingSchema alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
 
+### Removed
+
+- Remove the severity from the `InvalidLabellingSchema` alert.
+
 ## [0.7.2] - 2021-07-26
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -63,7 +63,6 @@ spec:
           cancel_if_cluster_status_deleting: "true"
           cancel_if_cluster_with_notready_nodepools: "true"
           installation: {{ .Values.managementCluster.name }}
-          severity: "notify"
           team: "atlas"
           topic: "observability"
         annotations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18321

This PR:

- removes the severity from the InvalidLabellingSchema alert as we ignore this alert anyway. We want to keep it in Prometheus though for when we have the time to address the issues

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
