### PR TITLE
turn firecracker daemonset alert into an SLO alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Turn `DaemonSetNotSatisfiedFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert.
+
 ### Added
 
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
@@ -35,16 +35,6 @@ spec:
         team: atlas
         topic: managementcluster
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
-    - alert: ManagementClusterDaemonSetNotSatisfiedFirecracker
-      annotations:
-        description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id!="argali|giraffe", daemonset=~"aws-node"} > 0
-      for: 30m
-      labels:
-        area: kaas
-        severity: notify
-        team: firecracker
-        topic: managementcluster
     # We split up the alerts for unsatisfied daemon sets because of network
     # bandwidth issues in China. The alert here is for all CHINA installations
     # with relaxed rules.

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.workload-cluster.rules.yml
@@ -11,23 +11,6 @@ spec:
   groups:
   - name: daemonset
     rules:
-    {{- if eq .Values.managementCluster.provider.kind "aws" }}
-    - alert: WorkloadClusterDaemonSetNotSatisfiedFirecracker
-      expr: kube_daemonset_status_number_unavailable{cluster_type="workload_cluster", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"} > 0
-      for: 30m
-      labels:
-        severity: page
-        area: kaas
-        team: firecracker
-        topic: workloadcluster
-        cancel_if_any_kubelet_down: true
-        cancel_if_any_kubelet_not_ready: true
-        cancel_if_instance_state_not_running: true
-        cancel_if_kube_state_metrics_down: true
-      annotations:
-        description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-        opsrecipe: daemonset-not-satisfied/
-    {{- end }}
     - alert: WorkloadClusterDaemonSetNotSatisfiedLudacris
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -38,6 +38,45 @@ spec:
         service: api-server
       record: slo_target
 
+      # -- daemonset
+    - expr: |
+        label_replace(
+          kube_daemonset_status_desired_number_scheduled{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+        "service", "$1", "workload_name", "(.*)" )
+      labels:
+        class: MEDIUM
+        area: kaas
+      record: raw_slo_requests
+      # -- the errors are counted as follows: 
+      # -- pods in a daemonset that are UNAVAILABLE NOW and have been UNAVAILABLE 10 MINUTES AGO 
+      # -- which are on a SCHEDULABLE node that was CREATED AT LEAST 10 MINUTES AGO
+    - expr: |
+        (
+          (
+            label_replace(
+              kube_daemonset_status_number_unavailable{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+              "service", "$1", "workload_name", "(.*)" ) > 0
+            and on (daemonset, node)
+            label_replace(
+              kube_daemonset_status_number_unavailable{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"} offset 10m,
+              "service", "$1", "workload_name", "(.*)" ) > 0
+          )
+          and
+          on (node) kube_node_spec_unschedulable == 0
+        )
+        and
+        on (node) time() - kube_node_created > 10 * 60
+      labels:
+        class: MEDIUM
+        area: kaas
+      record: raw_slo_errors
+      # -- 99% availability
+      # -- this expression collects all the daemonsets and assigns the same slo target to all of them
+    - expr: sum by (service, area) (raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent"} - raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent"}) + 1-0.99
+      labels:
+        area: kaas
+      record: slo_target
+
       # -- kubelet
     - expr: "kube_node_status_condition{condition='Ready'}"
       labels:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17885

This PR:

- Turns `DaemonSetNotSatisfiedFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert.

We have a lot more instances of `DaemonSetNotSatisfied` alerts. However, let's try with this one and see if it works better as an SLO alert. Right now the availability is 99% and we only count daemonsets that have been not satisfied for 10 minutes as error. Furthermore, we do not count on new or unschedulable nodes. The original alert pages after 30 minutes so there is a chance that this one is actually more sensitive than before. We may have to adjust it.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
