### PR TITLE
Add recording rules to send the total of ready and not ready pods to cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
+- Add recording rules to send the total of ready and not ready pods to Cortex to be able to investigate outages when a prometheus is gone or missing.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -140,6 +140,10 @@ spec:
       record: aggregation:kubernetes:top10_pod_resource_requests_memory_bytes
     - expr: count(kube_pod_created) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:pod_total
+    - expr: sum(kube_pod_status_ready{condition="false"}) by (cluster_type, cluster_id)
+      record: aggregation:kubernetes:pod_status_not_ready_total
+    - expr: sum(kube_pod_status_ready{condition="true"}) by (cluster_type, cluster_id)
+      record: aggregation:kubernetes:pod_status_ready_total
     - expr: sum(kube_replicaset_spec_replicas) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:replicaset_replicas_desired
     - expr: sum(kube_replicaset_status_ready_replicas) by (cluster_type, cluster_id)


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18310

This PR:

- adds recording rules to send the total of ready and not ready pods to Cortex to be able to investigate outages when a prometheus is gone or missing

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
