### PR TITLE
Add recording rules for IP exhaustion on AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add recording rules for IP exhaustion on AWS.
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
 
 ### Removed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -22,6 +22,11 @@ spec:
     # Instance types used
     - expr: count(sum(aws_operator_ec2_instance_status) by (ec2_instance, instance_type)) by (instance_type)
       record: aggregation:aws:instance_types
+    # Available IPs
+    - expr: min(aws_operator_subnet_available_ips_percentage{subnet_type="aws-cni"}) by (cluster_type, cluster_id, availability_zone)
+      record: aggregation:aws:available_ip_count
+    - expr: min(aws_operator_subnet_available_ips{subnet_type="aws-cni"}) by (cluster_type, cluster_id, availability_zone)
+      record: aggregation:aws:available_ip_percentage
     # Spot Instances being used
     - expr: count(sum(aws_operator_ec2_instance_status{lifecycle != ""}) by (ec2_instance, lifecycle)) by  (lifecycle)
       record: aggregation:aws:instance_lifecycle


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17562
This PR:

- Adds recording rules for IP exhaustion on AWS.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
