### PR TITLE
Upgrade pending app alerts to page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade AppPendingUpdate alerts to page.
+
 ## [0.9.1] - 2021-08-05
 
 ### Fixed
@@ -91,11 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `WorkloadClusterEtcdHasNoLeader` will not fire for loki or promtail pods any more.
-<<<<<<< HEAD
-- Upgrade AppPendingUpdate alerts to page.
-=======
 - Use configuration management instead of `Installation.V1` values.
->>>>>>> master
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade AppPendingUpdate alerts to page.
+- Upgrade AppPendingUpdate alerts to page during working hours.
 
 ## [0.9.1] - 2021-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `WorkloadClusterEtcdHasNoLeader` will not fire for loki or promtail pods any more.
+- Upgrade AppPendingUpdate alerts to page.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -135,6 +135,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: batman
         topic: releng
@@ -167,6 +168,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: batman
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -126,6 +126,7 @@ spec:
     - alert: ManagementClusterAppPendingUpdate
       annotations:
         description: 'Current version of {{`App {{ $labels.name }} is {{ $labels.deployed_version }} but it should be {{ $labels.version }}.`}}'
+        opsrecipe: app-pending-update/
       expr: app_operator_app_info{catalog=~"control-plane-.*", deployed_version!="", status="deployed", version_mismatch="true"}
       for: 40m
       labels:
@@ -134,7 +135,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        severity: notify
+        severity: page
         team: batman
         topic: releng
     ## Workload cluster app rules only available on the management cluster Prometheus because the source is app-exporter
@@ -157,6 +158,7 @@ spec:
     - alert: WorkloadClusterAppPendingUpdate
       annotations:
         description: 'Current version of {{`App {{ $labels.name }} is {{ $labels.deployed_version }} but it should be {{ $labels.version }}.`}}'
+        opsrecipe: app-pending-update/
       expr: label_replace(app_operator_app_info{catalog!~"control-plane-.*", deployed_version!="", status="deployed", version_mismatch="true"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 40m
       labels:
@@ -165,21 +167,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        severity: notify
-        team: batman
-        topic: releng
-    - alert: AppPendingUpdate
-      annotations:
-        description: 'Current version of {{`App {{ $labels.name }} is {{ $labels.deployed_version }} but it should be {{ $labels.version }}.`}}'
-      expr: app_operator_app_info{deployed_version!="", status="deployed", version_mismatch="true"}
-      for: 40m
-      labels:
-        area: managedservices
-        cancel_if_apiserver_down: "true"
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        severity: notify
+        severity: page
         team: batman
         topic: releng
     - alert: AppWithoutTeamLabel


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/17944

This PR:

- Upgrades AppPendingUpdate alerts to page during working hours.
 
This alert detects when chart-operator cannot reconcile an upgrade. We should then handle the error so we get an app failed alert.

See https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-pending-update/ for more details.
 

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
