### PR TITLE
Fix changelog for falco rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add basic Falco alerting rules.
+
 ### Changed
 
 - Upgrade AppPendingUpdate alerts to page during working hours.
@@ -34,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add recording rules for IP exhaustion on AWS.
 - Add missing opsrecipe for `PrometheusFailsToCommunicateWithRemoteStorageAPI`.
-- Add basic Falco alerting rules.
 
 ### Removed
 


### PR DESCRIPTION
I messed up the conflict resolution in https://github.com/giantswarm/prometheus-rules/pull/41

This PR:

- moves the falco changelog to the right release

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
