### PR TITLE
include china installations in daemonset slo alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Include `DaemonSetNotSatisfiedChinaFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert for daemonsets.
+
 ## [0.10.0] - 2021-08-09
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
@@ -34,21 +34,6 @@ spec:
         severity: notify
         team: atlas
         topic: managementcluster
-    {{- if eq .Values.managementCluster.provider.kind "aws" }}
-    # We split up the alerts for unsatisfied daemon sets because of network
-    # bandwidth issues in China. The alert here is for all CHINA installations
-    # with relaxed rules.
-    - alert: ManagementClusterDaemonSetNotSatisfiedChinaFirecracker
-      annotations:
-        description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id=~"argali|giraffe", daemonset=~"aws-node"} > 0
-      for: 3h
-      labels:
-        area: kaas
-        severity: notify
-        team: firecracker
-        topic: managementcluster
-    {{- end }}
     - alert: ManagementClusterDaemonSetNotSatisfiedLudacris
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -41,7 +41,7 @@ spec:
       # -- daemonset
     - expr: |
         label_replace(
-          kube_daemonset_status_desired_number_scheduled{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
         "service", "$1", "workload_name", "(.*)" )
       labels:
         class: MEDIUM
@@ -54,11 +54,11 @@ spec:
         (
           (
             label_replace(
-              kube_daemonset_status_number_unavailable{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
               "service", "$1", "workload_name", "(.*)" ) > 0
             and on (daemonset, node)
             label_replace(
-              kube_daemonset_status_number_unavailable{cluster_id!="argali|giraffe", namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"} offset 10m,
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"} offset 10m,
               "service", "$1", "workload_name", "(.*)" ) > 0
           )
           and


### PR DESCRIPTION
This PR:

-  Includes `DaemonSetNotSatisfiedChinaFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert for daemonsets.

We don't think the distinction is needed anymore. Especially since `akita` has never been included in the first place and it only affected the management cluster daemonsets.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
