### PR TITLE
Add alert for blackbox exporter endpoint down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rule for `grafana_analytics_sessions_total`
+
 ### Changed
 
 - Include `DaemonSetNotSatisfiedChinaFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert for daemonsets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add recording rule for `grafana_analytics_sessions_total`
+- Add alerting rule for blackbox exporter endpoint down on KVM.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -12,6 +12,17 @@ spec:
   groups:
   - name: kvm
     rules:
+    - alert: BlackboxExporterEndpointDown
+      annotations:
+        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is down.`}}'
+        opsrecipe: blackbox-exporter-endpoint-down/
+      expr: up{job="management-cluster-blackbox-ingress-http"} == 0
+      for: 15m
+      labels:
+        area: kaas
+        severity: page
+        team: rocket
+        topic: observability
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -23,6 +23,17 @@ spec:
         severity: page
         team: rocket
         topic: observability
+    - alert: BlackboxExporterEndpointNotResponding
+      annotations:
+        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is not responding.`}}'
+        opsrecipe: blackbox-exporter-endpoint-down/
+      expr: sum by(instance) (avg_over_time(probe_http_duration_seconds[5m])) > 0.2
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: rocket
+        topic: observability
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -210,3 +210,5 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."})
       record: aggregation:dex_requests_status_ok
+    - expr: grafana_analytics_sessions_total
+      record: aggregation:grafana_analytics_sessions_total


### PR DESCRIPTION
Towards https://github.com/giantswarm/telekom-panamax/issues/104

This PR:

- Adds an alerting rule for blackbox exporter endpoint down on KVM.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
