### PR TITLE
Increase alert timeout for ArgoCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase timeout for ArgoCD alerts.
+
 ## [0.13.0] - 2021-08-18
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/argocd.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/argocd.rules.yml
@@ -16,7 +16,7 @@ spec:
           {{`ArgoCD application {{ $labels.namespace }}/{{ $labels.name }} is {{ $labels.health_status }}.`}}
         opsrecipe: argocd-application-unhealthy/
       expr: argocd_app_info{health_status!~"Healthy|Suspended"}
-      for: 15m
+      for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
@@ -29,7 +29,7 @@ spec:
           {{`ArgoCD application {{ $labels.namespace }}/{{ $labels.name }} is {{ $labels.sync_status }}.`}}
         opsrecipe: argocd-application-out-of-sync/
       expr: argocd_app_info{sync_status!="Synced"}
-      for: 15m
+      for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
This PR increases timeout for ArgoCD alerts. Towards https://github.com/giantswarm/giantswarm/issues/17444.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
