### PR TITLE
Fix labels on Batman operatorkit alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix labels on Batman operatorkit alerts.
+
 ## [0.16.0] - 2021-08-19
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -13,7 +13,7 @@ spec:
     rules:
     - alert: OperatorkitErrorRateTooHighBatman
       annotations:
-        description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
+        description: '{{`{{ $labels.namespace }}/{{ $labels.app }} has reported errors. Please check logs.`}}'
         opsrecipe: check-operator-error-rate-high/
       expr: operatorkit_controller_error_total{app=~"app-operator.*|chart-operator.*"} > 5
       for: 1m
@@ -24,10 +24,7 @@ spec:
         topic: qa
     - alert: OperatorNotReconcilingBatman
       annotations:
-        description: |-
-          {{`{{$labels.app_name}} (version {{$labels.app_version}}) not reconciling controller
-          {{$labels.controller}}.
-          `}}
+        description: '{{`{{ $labels.namespace }}/{{ $labels.app }} not reconciling controller {{$labels.controller}}. Please check logs.`}}'
       expr: (time() - operatorkit_controller_last_reconciled{app=~"app-operator.*|chart-operator.*"}) / 60 > 30
       for: 10m
       labels:


### PR DESCRIPTION
This PR:

- Fix labels on Batman operatorkit alerts.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
