### PR TITLE
prefix grafana_analytics_sessions_total with aggregation:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `-unique` suffix from app, deployment, and daemonset names used in multiple alerts.
-- Update grafana analytics recoding rule.
+- Update grafana analytics recoding rule. #76 #80
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -210,7 +210,7 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."})
       record: aggregation:dex_requests_status_ok
-    - expr: grafana_analytics_sessions_total
+    - expr: aggregation:grafana_analytics_sessions_total
       record: increase(grafana_analytics_sessions_total[60s]) / (132 / 99)
       labels:
         user_locale: "none"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/383

Prefix the grafana_analytics_sessions_total metrics with aggregation to allow remote write.