### PR TITLE
fix grafana query - sum without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix CI by upgrading architect-orb to 4.2.0
+- Fix aggregation:grafana_analytics_sessions_total error. #85
 
 ## [0.17.0] - 2021-08-30
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -210,15 +210,8 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."})
       record: aggregation:dex_requests_status_ok
-    - expr: increase(grafana_analytics_sessions_total[60s]) / (132 / 99)
+    - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_locale, user_login, user_name, user_role, user_theme, user_timezone)
       record: aggregation:grafana_analytics_sessions_total
-      labels:
-        user_locale: "none"
-        user_login: "none"
-        user_name: "none"
-        user_role: "none"
-        user_theme: "none"
-        user_timezone: "none"
     # Falco event counts
     - expr: sum(falco_events{priority=~"0|1|2|3|4|5|6|7"}) by (cluster_type, cluster_id, priority, rule)
       record: aggregation:falco_events


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/383

Fix the following error

```
level=warn ts=2021-08-30T14:31:03.749Z caller=manager.go:603 component="rule manager" group=cortex.recording msg="Evaluating rule failed" rule="record: aggregation:grafana_analytics_sessions_total\nexpr: increase(grafana_analytics_sessions_total[1m]) / (132 / 99)\nlabels:\n  user_locale: none\n  user_login: none\n  user_name: none\n  user_role: none\n  user_theme: none\n  user_timezone: none\n" err="vector contains metrics with the same labelset after applying rule labels"
```