### PR TITLE
Preserve labels to expose some user data to analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only drop PII labels from `aggregation:grafana_analytics_sessions_total`,
+  preserve the others so they can be used in analytics dashboard.
+
 ## [0.17.1] - 2021-08-30
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -210,7 +210,7 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."})
       record: aggregation:dex_requests_status_ok
-    - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_locale, user_login, user_name, user_role, user_theme, user_timezone)
+    - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_email, user_name)
       record: aggregation:grafana_analytics_sessions_total
     # Falco event counts
     - expr: sum(falco_events{priority=~"0|1|2|3|4|5|6|7"}) by (cluster_type, cluster_id, priority, rule)


### PR DESCRIPTION
Specifically, only drop personally identifiable information -
`user_name` and `user_email`. This leaves `user_role`, `user_locale`,
`user_theme` and `user_timezone` in.

Towards: https://github.com/giantswarm/roadmap/issues/448

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
