### PR TITLE
Removes invalid labelling schema alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove 'InvalidLabellingSchema' alert.
+
 ## [0.19.0] - 2021-09-02
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -45,26 +45,3 @@ spec:
         severity: "page"
         team: "atlas"
         topic: "observability"
-  - name: "labelling-schema"
-    rules:
-      - alert: "InvalidLabellingSchema"
-        expr: |
-          up{cluster_type!~"management_cluster|workload_cluster"}
-          or up{app=""}
-          or up{installation=""}
-          or up{cluster_id=""}
-          or up{provider!~"aws|azure|kvm|vmware"}
-          or up{instance!~"(\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+)|vault.*|bastion.*"}
-        for: "10m"
-        labels:
-          area: "empowerment"
-          cancel_if_cluster_status_creating: "true"
-          cancel_if_cluster_status_updating: "true"
-          cancel_if_cluster_status_deleting: "true"
-          cancel_if_cluster_with_notready_nodepools: "true"
-          installation: {{ .Values.managementCluster.name }}
-          team: "atlas"
-          topic: "observability"
-        annotations:
-          description: Labelling schema is invalid.
-      


### PR DESCRIPTION
This PR:

- removes invalid labelling schema alert, due to it being unused

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
