### PR TITLE
Add blackbox exporter SLO recording rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rule for `grafana_analytics_sessions_total`
+
 ### Changed
 
 - Include `DaemonSetNotSatisfiedChinaFirecracker` into `ServiceLevelBurnRateTooHigh` SLO alert for daemonsets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add recording rule for `grafana_analytics_sessions_total`
+- Add alerting rule for blackbox exporter endpoint down on KVM.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -16,22 +16,11 @@ spec:
       annotations:
         description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is down.`}}'
         opsrecipe: blackbox-exporter-endpoint-down/
-      expr: up{job="management-cluster-blackbox-ingress-http"} == 0
-      for: 15m
-      labels:
-        area: kaas
-        severity: page
-        team: rocket
-        topic: observability
-    - alert: BlackboxExporterEndpointNotResponding
-      annotations:
-        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is not responding.`}}'
-        opsrecipe: blackbox-exporter-endpoint-down/
-      expr: sum by(instance) (avg_over_time(probe_http_duration_seconds[5m])) > 0.2
+      expr: up{job=~"blackbox-exporter-.*"} == 0
       for: 5m
       labels:
         area: kaas
-        severity: notify
+        severity: page
         team: rocket
         topic: observability
     - alert: ManagementClusterPodPendingFor15Min

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -12,6 +12,7 @@ spec:
   groups:
   - name: kvm
     rules:
+    # If the blackbox-exporter itself goes down, we are blind to endpoint issues and should be alerted.
     - alert: BlackboxExporterEndpointDown
       annotations:
         description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is down.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -12,6 +12,17 @@ spec:
   groups:
   - name: kvm
     rules:
+    - alert: BlackboxExporterEndpointDown
+      annotations:
+        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is down.`}}'
+        opsrecipe: blackbox-exporter-endpoint-down/
+      expr: up{job="management-cluster-blackbox-ingress-http"} == 0
+      for: 15m
+      labels:
+        area: kaas
+        severity: page
+        team: rocket
+        topic: observability
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -23,6 +23,17 @@ spec:
         severity: page
         team: rocket
         topic: observability
+    - alert: BlackboxExporterEndpointNotResponding
+      annotations:
+        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is not responding.`}}'
+        opsrecipe: blackbox-exporter-endpoint-down/
+      expr: sum by(instance) (avg_over_time(probe_http_duration_seconds[5m])) > 0.2
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: rocket
+        topic: observability
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -210,3 +210,5 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."})
       record: aggregation:dex_requests_status_ok
+    - expr: grafana_analytics_sessions_total
+      record: aggregation:grafana_analytics_sessions_total

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -140,7 +140,7 @@ spec:
         service: blackbox-exporter
       record: raw_slo_requests
       # record of number of endpoints that are down.
-    - expr: sum(1 - probe_success == 0) by (cluster_id, cluster_type)
+    - expr: sum(1 - probe_success) by (cluster_id, cluster_type)
       labels:
         area: kaas
         class: MEDIUM

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -131,6 +131,28 @@ spec:
         service: node-exporter
       record: slo_target
 
+      # -- blackbox-exporter
+      # record number of endpoints.
+    - expr: count(probe_success) by (cluster_id, cluster_type)
+      labels:
+        class: MEDIUM
+        area: kaas
+        service: blackbox-exporter
+      record: raw_slo_requests
+      # record of number of endpoints that are down.
+    - expr: sum(1 - probe_success == 0) by (cluster_id, cluster_type)
+      labels:
+        area: kaas
+        class: MEDIUM
+        service: blackbox-exporter
+      record: raw_slo_errors
+      # -- 99.999% availability
+    - expr: "vector((1 - 0.99999))"
+      labels:
+        area: kaas
+        service: blackbox-exporter
+      record: slo_target
+
     # -- managed-apps
     # -- error recording rules
     # record when pods of a daemonset with label "label_giantswarm_io_monitoring_basic_sli" are down


### PR DESCRIPTION
Towards https://github.com/giantswarm/telekom-panamax/issues/104

This PR:

- Adds SLO alerts for endpoints exposed by the blackbox-exporter (if it exists)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
