### PR TITLE
Cancel PrometheusCantCommunicateWithKubernetesAPI for deleting clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cancel `PrometheusCantCommunicateWithKubernetesAPI` for deleting clusters.
+
 ## [0.20.0] - 2021-09-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -19,6 +19,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_any_apiserver_down: "true"
+        cancel_if_cluster_status_deleting: "true"
         severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
This PR:

- Cancels `PrometheusCantCommunicateWithKubernetesAPI` alert for deleting clusters

Prompted by [#inc-2021-09-05-otter-esuq4-prometheuscantcommunicatewithkubernetesapi](https://gigantic.slack.com/archives/C02DTU9K1G9) and [#inc-2021-09-03-otter-centraldev-prometheuscantcommunicatewithkubernetesapi](https://gigantic.slack.com/archives/C02DE0GR3EX).
<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
