### PR TITLE
Add app_version label to app_deployed_workload_cluster_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `app_version` label to `aggregation:giantswarm:app_deployed_workload_cluster_total`.
+
 ### Changed
 
 - Cancel `PrometheusCantCommunicateWithKubernetesAPI` for deleting clusters.

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -46,7 +46,7 @@ spec:
       record: aggregation:giantswarm:api_requests
     - expr: count(app_operator_app_info{status="deployed",namespace="giantswarm"}) by (app,name,version,catalog)
       record: aggregation:giantswarm:app_deployed_management_cluster_total
-    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (app,name,version,catalog)
+    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (app,app_version,name,version,catalog)
       record: aggregation:giantswarm:app_deployed_workload_cluster_total
     - expr: count(app_operator_app_info{upgrade_available="true"}) by (app,catalog,latest_version,namespace,version)
       record: aggregation:giantswarm:app_upgrade_available


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/322

This PR:

- Adds app_version label to app_deployed_workload_cluster_total.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
