### PR TITLE
Exclude apps in giantswarm namespace from app_upgrade_available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exclude apps in giantswarm namespace from `aggregation:giantswarm:app_upgrade_available`.
+
 ## [0.22.0] - 2021-09-10
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -48,7 +48,7 @@ spec:
       record: aggregation:giantswarm:app_deployed_management_cluster_total
     - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (app,app_version,name,version,catalog)
       record: aggregation:giantswarm:app_deployed_workload_cluster_total
-    - expr: count(app_operator_app_info{upgrade_available="true"}) by (app,catalog,latest_version,namespace,version)
+    - expr: count(app_operator_app_info{upgrade_available="true",namespace!="giantswarm"}) by (app,catalog,latest_version,namespace,version)
       record: aggregation:giantswarm:app_upgrade_available
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)
       record: aggregation:giantswarm:cluster_certificate_not_after_seconds


### PR DESCRIPTION
This PR:

- Exclude apps in giantswarm namespace from `aggregation:giantswarm:app_upgrade_available`.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
