### PR TITLE
Ignore non GS deployments in WorkloadClusterManagedDeploymentNotSatisfied alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore non GS deployments in `WorkloadClusterManagedDeploymentNotSatisfied` alert.
+
 ## [0.22.0] - 2021-09-10
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -37,7 +37,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"cert-manager|external-dns"} > 0
+      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager|external-dns"} > 0
       for: 30m
       labels:
         area: managedservices


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18866

This PR:

Changes the expression of `WorkloadClusterManagedDeploymentNotSatisfied` alert rule to use the `managed_app_deployment_status_replicas_unavailable` recording rule 

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
