### PR TITLE
Remove labels from group_left for SLO alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust `ServiceLevelBurnRateTooHigh` metric to avoid "multiple matches for labels" error.
+
 ## [0.23.0] - 2021-09-16
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -16,7 +16,6 @@ spec:
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
         (
-        (
           slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
         and
           slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
@@ -26,7 +25,6 @@ spec:
           slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
         and
           slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
-        )
         )
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -15,16 +15,18 @@ spec:
         description: '{{`Service level burn rate is too high for {{ $labels.service }} service.`}}'
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
-        slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"}
-        and on (service)
         (
-        slo_errors_per_request:ratio_rate1h > on (service) group_left slo_threshold_high
+        (
+          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
         and
-        slo_errors_per_request:ratio_rate5m > on (service) group_left slo_threshold_high
+          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
+        )
         or
-        slo_errors_per_request:ratio_rate6h > on (service) group_left slo_threshold_low
+        (
+          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
         and
-        slo_errors_per_request:ratio_rate30m > on (service) group_left slo_threshold_low
+          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
+        )
         )
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -18,13 +18,13 @@ spec:
         slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"}
         and on (service)
         (
-        slo_errors_per_request:ratio_rate1h > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate1h > on (service) group_left slo_threshold_high
         and
-        slo_errors_per_request:ratio_rate5m > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate5m > on (service) group_left slo_threshold_high
         or
-        slo_errors_per_request:ratio_rate6h > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_low
+        slo_errors_per_request:ratio_rate6h > on (service) group_left slo_threshold_low
         and
-        slo_errors_per_request:ratio_rate30m > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_low
+        slo_errors_per_request:ratio_rate30m > on (service) group_left slo_threshold_low
         )
       for: 5m
       labels:


### PR DESCRIPTION
This PR:

- attempts to resolve the problem reported [in Slack](https://gigantic.slack.com/archives/C0E0V16DC/p1631628887005100) when blackbox-exporter SLO alert fires for multiple clusters at once

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
