### PR TITLE
add recording rule for scheduled upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rule for scheduled cluster upgrades `aggregation:giantswarm:cluster_scheduled_upgrades_time`
+
 ## [0.23.0] - 2021-09-16
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -58,6 +58,9 @@ spec:
       record: aggregation:giantswarm:cluster_transition_create
     - expr: avg_over_time(cluster_operator_cluster_update_transition[1w])
       record: aggregation:giantswarm:cluster_transition_update
+    # Scheduled cluster upgrade times
+    - expr: upgrade_schedule_operator_cluster_scheduled_upgrades_time
+      record: aggregation:giantswarm:cluster_scheduled_upgrades_time
     # Happa requests
     - expr: sum(rate(nginx_ingress_controller_requests{namespace="giantswarm", ingress="happa"}[5m])) by (status)
       record: aggregation:giantswarm:happa_requests


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18077

This PR:

- adds a recording rule for the scheduled upgrade times of clusters so we can see the schedule across installations.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
