### PR TITLE
Reduce sensitivity of blackbox exporter service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce blackbox-exporter service level target from 99.999% to 99.99%.
+
 ## [0.24.0] - 2021-09-16
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -147,7 +147,7 @@ spec:
         service: blackbox-exporter
       record: raw_slo_errors
       # -- 99.999% availability
-    - expr: "vector((1 - 0.99999))"
+    - expr: "vector((1 - 0.9999))"
       labels:
         area: kaas
         service: blackbox-exporter


### PR DESCRIPTION
This PR:

- Reduces blackbox-exporter service level target from 99.999% to 99.99% to reduce the number of spurious pages during temporary network hiccups.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
