### PR TITLE
Add alerts for the cluster-autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alerts for the `cluster-autoscaler`.
+
 ## [0.24.0] - 2021-09-16
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -1,0 +1,45 @@
+{{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "workload_cluster"
+  name: cluster-autoscaler.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: cluster-autoscaler
+    rules:
+    - alert: ClusterAutoscalerErrors
+      annotations:
+        description: 'Cluster-Autoscaler on {{ $labels.cluster_id }} has increased errors.`}}'
+        opsrecipe: cluster-autoscaler-scaling/
+      expr: increase(cluster_autoscaler_errors_total[1h]) > 0
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: firecracker
+        topic: cluster-autoscaler
+    - alert: ClusterAutoscalerFailedScaling
+      annotations:
+        description: 'Cluster-Autoscaler on {{ $labels.cluster_id }} has failed scaling up.`}}'
+        opsrecipe: cluster-autoscaler-scaling/
+      expr: increase(cluster_autoscaler_failed_scale_ups_total[1h]) > 0
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: firecracker
+        topic: cluster-autoscaler
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -14,7 +14,7 @@ spec:
     rules:
     - alert: ClusterAutoscalerErrors
       annotations:
-        description: 'Cluster-Autoscaler on {{ $labels.cluster_id }} has increased errors.`}}'
+        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has increased errors.`}}'
         opsrecipe: cluster-autoscaler-scaling/
       expr: increase(cluster_autoscaler_errors_total[1h]) > 0
       for: 15m
@@ -29,7 +29,7 @@ spec:
         topic: cluster-autoscaler
     - alert: ClusterAutoscalerFailedScaling
       annotations:
-        description: 'Cluster-Autoscaler on {{ $labels.cluster_id }} has failed scaling up.`}}'
+        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has failed scaling up.`}}'
         opsrecipe: cluster-autoscaler-scaling/
       expr: increase(cluster_autoscaler_failed_scale_ups_total[1h]) > 0
       for: 15m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18766

This PR:

- Adds alerts for the cluster-autoscaler

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
