### PR TITLE
 Adjust time frame for error reports in cluster-autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Adjust time frame for error reports in `cluster-autoscaler`.
 
 ## [0.25.0] - 2021-09-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adjust time frame for error reports in `cluster-autoscaler`.
+
 ## [0.25.0] - 2021-09-28
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has increased errors.`}}'
         opsrecipe: cluster-autoscaler-scaling/
-      expr: increase(cluster_autoscaler_errors_total[1h]) > 0
+      expr: increase(cluster_autoscaler_errors_total[10m]) > 0
       for: 15m
       labels:
         area: managedservices


### PR DESCRIPTION
This PR:

- Changes the time frame for error reports in cluster-autoscaler to 10m so the alert resolves earlier if no more errors appear.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
