### PR TITLE
Bring back WorkloadClusterCriticalPodNotRunningAWS alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Bring back `WorkloadClusterCriticalPodNotRunningAWS` alert.
+
 ## [0.25.1] - 2021-09-29
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -27,20 +27,20 @@ spec:
         severity: page
         team: firecracker
         topic: kubernetes
-          #    - alert: WorkloadClusterCriticalPodNotRunningAWS
-          #annotations:
-          #description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
-          #opsrecipe: critical-pod-is-not-running/
-          #expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-          #for: 5m
-          #labels:
-          #area: kaas
-          #cancel_if_cluster_status_creating: "true"
-          #cancel_if_cluster_status_deleting: "true"
-          #cancel_if_cluster_status_updating: "true"
-          #severity: page
-          #team: firecracker
-          #topic: kubernetes
+    - alert: WorkloadClusterCriticalPodNotRunningAWS
+      annotations:
+        description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: firecracker
+        topic: kubernetes
     # WorkloadClusterMasterNodeMissingFirecracker in this file is AWS specific and thus
     # assigned to Team Firecracker. The alert is also defined for all the other
     # providers with other team assignments.


### PR DESCRIPTION
This PR: 

Towards https://github.com/giantswarm/giantswarm/issues/19035
- adds back `WorkloadClusterCriticalPodNotRunningAWS` alert as we were not alerted during the night when one `k8s-api-server` pod was crashlooping after a scheduled upgrade.
- 
<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
