### PR TITLE
Move event-exporter-.* to firecracker and grafana.* to atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move event-exporter-.* to firecracker.
+- Move grafana.* to atlas.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move event-exporter-.* to firecracker.
+
 ### Fixed
 
 - Adjust `ServiceLevelBurnRateTooHigh` metric to avoid "multiple matches for labels" error.

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|grafana.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
       for: 30m
       labels:
         area: kaas
@@ -29,7 +29,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|grafana.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
       for: 30m
       labels:
         area: kaas
@@ -68,7 +68,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|azure-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|azure-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|grafana.*|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
       for: 30m
       labels:
         area: kaas
@@ -82,7 +82,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied-china/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|nginx-ingress-controller.*|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|grafana.*|nginx-ingress-controller.*|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
       for: 3h
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -68,7 +68,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|azure-operator-.+|cluster-operator-.+|coredns-.+|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|azure-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
       for: 30m
       labels:
         area: kaas
@@ -82,7 +82,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied-china/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|cluster-operator-.+|coredns-.+|nginx-ingress-controller.*|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"aws-operator-.+|cluster-operator-.+|coredns-.+|event-exporter-.+|nginx-ingress-controller.*|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id=~"argali|giraffe"} > 0
       for: 3h
       labels:
         area: kaas
@@ -118,7 +118,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator.*|cluster-operator.*|cluster-api-core-webhook.*|upgrade-schedule-operator.*|event-exporter-app.*"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator.*|cluster-operator.*|cluster-api-core-webhook.*|event-exporter-.*|upgrade-schedule-operator.*|event-exporter-app.*"} > 0
       for: 30m
       labels:
         area: kaas
@@ -132,7 +132,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator.*|cluster-operator.*|cluster-api-core-webhook.*|upgrade-schedule-operator.*|event-exporter-app.*", cluster_id=~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator.*|cluster-operator.*|cluster-api-core-webhook.*|event-exporter-.*|upgrade-schedule-operator.*|event-exporter-app.*", cluster_id=~"argali|giraffe"} > 0
       for: 3h
       labels:
         area: kaas


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/18876
Fixes https://github.com/giantswarm/giantswarm/issues/18623

This PR:

- Moves event-exporter-.* to firecracker
- Moves grafana.* to atlas

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
