### PR TITLE
increase time for WorkloadClusterCriticalPodNotRunningAWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase time for `WorkloadClusterCriticalPodNotRunningAWS` alert.
+
 ## [0.26.0] - 2021-10-01
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-      for: 5m
+      for: 1h
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
As discussed in the SUP

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.