### PR TITLE
added alerts for missing MC deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ManagementClusterDeploymentMissingFirecracker` alert added to notify on missing critical MC deployments.
+
 ## [0.26.1] - 2021-10-05
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -132,4 +132,18 @@ spec:
         severity: page
         team: firecracker
         topic: kubernetes
+    - alert: ManagementClusterDeploymentMissingFirecracker
+      annotations:
+        description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
+        opsrecipe: management-cluster-deployment-is-missing/
+      expr: absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name="aws-admission-controller"})
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: firecracker
+        topic: kubernetes
 {{- end }}


### PR DESCRIPTION
This PR:

- adds `ManagementClusterDeploymentMissingFirecracker` and `ManagementClusterDeploymentMissing` alerts added to notify on missing critical MC deployments.

Related issue: https://github.com/giantswarm/giantswarm/issues/18665

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
