### PR TITLE
Revert capi components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert cluster-api deployments to the `ManagementClusterDeploymentMissingFirecracker` alert rule.
+
 ## [0.27.1] - 2021-10-05
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -136,14 +136,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/
-      ## `label_replace` used when using a regex match to ensure the general name of the missing deployment is passed through to the alert
-      expr: |
-        absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name="aws-admission-controller"}) or
-        absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name="cluster-api-core-webhook"}) or
-        label_replace(absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name=~"cluster-api-core-\\d+-\\d+-\\d+-gs\\d"}), "workload_name", "cluster-api-core", "", "") or
-        label_replace(absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name=~"cluster-api-provider-aws-.+"}), "workload_name", "cluster-api-provider-aws", "", "") or
-        label_replace(absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name=~"cluster-api-control-plane-.+"}), "workload_name", "cluster-api-control-plane", "", "") or
-        label_replace(absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name=~"cluster-api-bootstrap-provider-kubeadm-.+"}), "workload_name", "cluster-api-bootstrap-provider-kubeadm", "", "")
+      expr: absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", workload_name="aws-admission-controller"})
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Got paged for all installations, this needs to get reverted :(

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.