### PR TITLE
Moved WorkloadClusterDaemonSetNotSatisfiedLudacris to ServiceLevelBurnRateTooHigh for calico daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved `WorkloadClusterDaemonSetNotSatisfiedLudacris` to `ServiceLevelBurnRateTooHigh` for calico daemonset. 
+
 ## [0.27.2] - 2021-10-05
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
@@ -37,7 +37,7 @@ spec:
     - alert: ManagementClusterDaemonSetNotSatisfiedLudacris
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id!="giraffe|argali", daemonset=~"calico-node|kube-proxy|cert-exporter|net-exporter|node-exporter-app-.+"} > 0
+      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id!="giraffe|argali", daemonset=~"kube-proxy|cert-exporter|net-exporter|node-exporter-app-.+"} > 0
       for: 30m
       labels:
         area: kaas
@@ -50,7 +50,7 @@ spec:
     - alert: ManagementClusterDaemonSetNotSatisfiedChinaLudacris
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id="giraffe|argali", daemonset=~"calico-node|kube-proxy|cert-exporter|net-exporter|node-exporter-app-.+"} > 0
+      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id="giraffe|argali", daemonset=~"kube-proxy|cert-exporter|net-exporter|node-exporter-app-.+"} > 0
       for: 3h
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.workload-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
         opsrecipe: daemonset-not-satisfied/
-      expr: kube_daemonset_status_number_unavailable{cluster_type="workload_cluster", namespace=~"giantswarm|kube-system", daemonset=~"calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter"} > 0
+      expr: kube_daemonset_status_number_unavailable{cluster_type="workload_cluster", namespace=~"giantswarm|kube-system", daemonset=~"cert-exporter|kube-proxy|net-exporter|node-exporter"} > 0
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -41,7 +41,7 @@ spec:
       # -- daemonset
     - expr: |
         label_replace(
-          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent|calico-node"},
         "service", "$1", "workload_name", "(.*)" )
       labels:
         class: MEDIUM
@@ -54,11 +54,11 @@ spec:
         (
           (
             label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"},
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent|calico-node"},
               "service", "$1", "workload_name", "(.*)" ) > 0
             and on (daemonset, node)
             label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent"} offset 10m,
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|kiam-server|kiam-agent|calico-node"} offset 10m,
               "service", "$1", "workload_name", "(.*)" ) > 0
           )
           and
@@ -72,7 +72,7 @@ spec:
       record: raw_slo_errors
       # -- 99% availability
       # -- this expression collects all the daemonsets and assigns the same slo target to all of them
-    - expr: sum by (service, area) (raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent"} - raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent"}) + 1-0.99
+    - expr: sum by (service, area) (raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent|calico-node"} - raw_slo_errors{area="kaas", service=~"aws-node|kiam-server|kiam-agent|calico-node"}) + 1-0.99
       labels:
         area: kaas
       record: slo_target


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19205

This PR:

- Moves WorkloadClusterDaemonSetNotSatisfiedLudacris to ServiceLevelBurnRateTooHigh for calico daemonset

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
