### PR TITLE
Change ownership of rules from firecracker to phoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change ownership of rules from `firecracker` to `phoenix`.
+
 ## [0.28.0] - 2021-10-18
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/alertmanager-dashboard.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/alertmanager-dashboard.rules.yml
@@ -24,6 +24,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: monitoring
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -75,7 +75,7 @@ spec:
         sig: none
         team: celestial
         topic: releng
-    - alert: ManagementClusterAppFailedAWSPhoenix
+    - alert: ManagementClusterAppFailedPhoenix
       annotations:
         description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -75,7 +75,7 @@ spec:
         sig: none
         team: celestial
         topic: releng
-    - alert: ManagementClusterAppFailedPhoenix
+    - alert: ManagementClusterAppFailedAWSPhoenix
       annotations:
         description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -75,11 +75,11 @@ spec:
         sig: none
         team: celestial
         topic: releng
-    - alert: ManagementClusterAppFailedFirecracker
+    - alert: ManagementClusterAppFailedPhoenix
       annotations:
         description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      expr: app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog=~"control-plane-.*",team="firecracker"}
+      expr: app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog=~"control-plane-.*",team="phoenix"}
       for: 30m
       labels:
         area: managedservices
@@ -89,7 +89,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         severity: page
         sig: none
-        team: firecracker
+        team: phoenix
         topic: releng
     - alert: ManagementClusterAppFailedLudacris
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -23,7 +23,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         cancel_if_stack_failed: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: aws
     - alert: AWSClusterUpdateFailed
       annotations:
@@ -36,7 +36,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         cancel_if_stack_failed: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: aws
     - alert: CloudFormationStackFailed
       annotations:
@@ -49,7 +49,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         stack_failed: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: aws
     - alert: CloudFormationStackRollback
       annotations:
@@ -62,7 +62,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         stack_failed: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: aws
     - alert: ELBHostsOutOfService
       annotations:
@@ -76,9 +76,9 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: aws
-    - alert: ManagementClusterPodPendingFirecracker
+    - alert: ManagementClusterPodPendingPhoenix
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
@@ -92,7 +92,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: managementcluster
     - alert: NATGatewaysPerVPCApproachingLimit
       annotations:
@@ -116,7 +116,7 @@ spec:
         severity: notify
         team: se
         topic: aws
-    - alert: ManagementClusterContainerIsRestartingTooFrequentlyFirecracker
+    - alert: ManagementClusterContainerIsRestartingTooFrequentlyPhoenix
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -130,9 +130,9 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
-    - alert: ManagementClusterDeploymentMissingFirecracker
+    - alert: ManagementClusterDeploymentMissingPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/
@@ -144,6 +144,6 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -78,7 +78,7 @@ spec:
         severity: page
         team: phoenix
         topic: aws
-    - alert: ManagementClusterPodPendingPhoenix
+    - alert: ManagementClusterPodPendingAWSPhoenix
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
@@ -116,7 +116,7 @@ spec:
         severity: notify
         team: se
         topic: aws
-    - alert: ManagementClusterContainerIsRestartingTooFrequentlyPhoenix
+    - alert: ManagementClusterContainerIsRestartingTooFrequentlyAWSPhoenix
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -132,7 +132,7 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    - alert: ManagementClusterDeploymentMissingPhoenix
+    - alert: ManagementClusterDeploymentMissingAWSPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -78,7 +78,7 @@ spec:
         severity: page
         team: phoenix
         topic: aws
-    - alert: ManagementClusterPodPendingAWSPhoenix
+    - alert: ManagementClusterPodPendingAWS
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
@@ -116,7 +116,7 @@ spec:
         severity: notify
         team: se
         topic: aws
-    - alert: ManagementClusterContainerIsRestartingTooFrequentlyAWSPhoenix
+    - alert: ManagementClusterContainerIsRestartingTooFrequentlyAWS
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -132,7 +132,7 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    - alert: ManagementClusterDeploymentMissingAWSPhoenix
+    - alert: ManagementClusterDeploymentMissingAWS
       annotations:
         description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -12,7 +12,7 @@ spec:
   groups:
   - name: aws
     rules:
-    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyAWSPhoenix
+    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyAWS
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -41,8 +41,8 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingAWSPhoenix in this file is AWS specific and thus
-    # assigned to Team AWSPhoenix. The alert is also defined for all the other
+    # WorkloadClusterMasterNodeMissingAWS in this file is AWS specific and thus
+    # assigned to Team Phoenix. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
@@ -55,7 +55,7 @@ spec:
     #     there are no kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingAWSPhoenix
+    - alert: WorkloadClusterMasterNodeMissingAWS
       annotations:
         description: '{{`Master node is missing.`}}'
         opsrecipe: master-node-missing/
@@ -86,7 +86,7 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterPodPendingAWSPhoenix
+    - alert: WorkloadClusterPodPendingAWS
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -12,7 +12,7 @@ spec:
   groups:
   - name: aws
     rules:
-    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyFirecracker
+    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyPhoenix
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -25,7 +25,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
     - alert: WorkloadClusterCriticalPodNotRunningAWS
       annotations:
@@ -39,10 +39,10 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingFirecracker in this file is AWS specific and thus
-    # assigned to Team Firecracker. The alert is also defined for all the other
+    # WorkloadClusterMasterNodeMissingPhoenix in this file is AWS specific and thus
+    # assigned to Team Phoenix. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
@@ -55,7 +55,7 @@ spec:
     #     there are no kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingFirecracker
+    - alert: WorkloadClusterMasterNodeMissingPhoenix
       annotations:
         description: '{{`Master node is missing.`}}'
         opsrecipe: master-node-missing/
@@ -68,7 +68,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         master_node_down: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
     - alert: WorkloadClusterHAMasterDownForTooLong
       annotations:
@@ -84,9 +84,9 @@ spec:
         cancel_if_outside_working_hours: "true"
         master_node_down: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterPodPendingFirecracker
+    - alert: WorkloadClusterPodPendingPhoenix
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
@@ -100,6 +100,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: managementcluster
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -12,7 +12,7 @@ spec:
   groups:
   - name: aws
     rules:
-    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyPhoenix
+    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyAWSPhoenix
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
@@ -41,8 +41,8 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingPhoenix in this file is AWS specific and thus
-    # assigned to Team Phoenix. The alert is also defined for all the other
+    # WorkloadClusterMasterNodeMissingAWSPhoenix in this file is AWS specific and thus
+    # assigned to Team AWSPhoenix. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
@@ -55,7 +55,7 @@ spec:
     #     there are no kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingPhoenix
+    - alert: WorkloadClusterMasterNodeMissingAWSPhoenix
       annotations:
         description: '{{`Master node is missing.`}}'
         opsrecipe: master-node-missing/
@@ -86,7 +86,7 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterPodPendingPhoenix
+    - alert: WorkloadClusterPodPendingAWSPhoenix
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: cluster-autoscaler
     - alert: ClusterAutoscalerFailedScaling
       annotations:
@@ -40,6 +40,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: cluster-autoscaler
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/credentiald.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/credentiald.rules.yml
@@ -19,7 +19,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: orchestration
     - alert: DefaultCredentialsMissing
       annotations:
@@ -29,7 +29,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: orchestration
     - alert: TooManyCredentialsForOrganization
       annotations:
@@ -39,5 +39,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: orchestration

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -112,9 +112,9 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedFirecracker
+    - alert: DeploymentNotSatisfiedPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
@@ -126,9 +126,9 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedChinaFirecracker
+    - alert: DeploymentNotSatisfiedChinaPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
@@ -140,7 +140,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: managementcluster
     {{- end }}
     {{- if eq .Values.managementCluster.provider.kind "azure" }}

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -114,7 +114,7 @@ spec:
         severity: notify
         team: phoenix
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedAWSPhoenix
+    - alert: DeploymentNotSatisfiedAWS
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -114,7 +114,7 @@ spec:
         severity: notify
         team: phoenix
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedPhoenix
+    - alert: DeploymentNotSatisfiedAWSPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -128,7 +128,7 @@ spec:
         severity: page
         team: phoenix
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedChinaPhoenix
+    - alert: DeploymentNotSatisfiedChina
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_master_node_down: "true"
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -42,7 +42,7 @@ spec:
         area: kaas
         severity: notify
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -59,7 +59,7 @@ spec:
         area: kaas
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -74,7 +74,7 @@ spec:
         area: kaas
         severity: notify
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -91,7 +91,7 @@ spec:
         area: kaas
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}

--- a/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
@@ -22,5 +22,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -36,6 +36,6 @@ spec:
       labels:
         area: kaas
         kiam_has_errors: "true"
-        team: firecracker
+        team: phoenix
         topic: kiam
     {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -75,7 +75,7 @@ spec:
       labels:
         area: kaas
         cluster_with_no_nodepools: "true"
-        team: firecracker
+        team: phoenix
         topic: status
     - alert: InhibitionClusterScalingNodePools
       annotations:
@@ -84,7 +84,7 @@ spec:
       labels:
         area: kaas
         cluster_with_scaling_nodepools: "true"
-        team: firecracker
+        team: phoenix
         topic: status
     - alert: InhibitionClusterNodePoolsNotReady
       annotations:
@@ -93,7 +93,7 @@ spec:
       labels:
         area: kaas
         cluster_with_notready_nodepools: "true"
-        team: firecracker
+        team: phoenix
         topic: status
     - alert: InhibitionInstanceStateNotRunning
       annotations:
@@ -102,6 +102,6 @@ spec:
       labels:
         area: kaas
         instance_state_not_running: "true"
-        team: firecracker
+        team: phoenix
         topic: status
     {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/job.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/job.rules.yml
@@ -31,6 +31,6 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: firecracker
+        team: phoenix
         topic: managementcluster
     {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kiam
     - alert: KiamSTSIssuingErrors
       annotations:
@@ -40,6 +40,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kiam
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -117,7 +117,7 @@ spec:
         topic: managementcluster
     {{- end }}
     - alert: ManagementClusterContainerIsRestartingTooFrequently
-      # Prometheus and firecracker containers are excluded
+      # Prometheus and phoenix containers are excluded
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/

--- a/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
@@ -56,7 +56,7 @@ spec:
     # replacing `version` with `reconciled_version` is only done if the latter
     # is non-empty and is done to work with old operator versions using
     # microendpoint < 0.1.0 (i.e. before VOO)
-    - alert: CollidingOperatorsPhoenix
+    - alert: CollidingOperatorsAWSPhoenix
       annotations:
         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
         opsrecipe: multiple-operators-running-same-version/

--- a/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
@@ -56,7 +56,7 @@ spec:
     # replacing `version` with `reconciled_version` is only done if the latter
     # is non-empty and is done to work with old operator versions using
     # microendpoint < 0.1.0 (i.e. before VOO)
-    - alert: CollidingOperatorsAWSPhoenix
+    - alert: CollidingOperatorsAWS
       annotations:
         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
         opsrecipe: multiple-operators-running-same-version/

--- a/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/microendpoint.rules.yml
@@ -56,7 +56,7 @@ spec:
     # replacing `version` with `reconciled_version` is only done if the latter
     # is non-empty and is done to work with old operator versions using
     # microendpoint < 0.1.0 (i.e. before VOO)
-    - alert: CollidingOperatorsFirecracker
+    - alert: CollidingOperatorsPhoenix
       annotations:
         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
         opsrecipe: multiple-operators-running-same-version/
@@ -65,7 +65,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: firecracker
+        team: phoenix
         topic: releng
     - alert: CollidingOperatorsLudacris
       # replacing `version` with `reconciled_version` is only done if the latter

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_cluster_with_scaling_nodepools: "true"
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -45,7 +45,7 @@ spec:
         cancel_if_cluster_with_scaling_nodepools: "true"
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
@@ -69,7 +69,7 @@ spec:
         cancel_if_nodes_down: "true"
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         severity: notify
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else }}
@@ -43,7 +43,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: firecracker
+        team: phoenix
         topic: kubernetes
     - alert: NodeStateFlappingUnderLoad
       # Check if the kubelet status is flapping, unless the node is under load.
@@ -123,6 +123,6 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: kubernetes
     {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -76,7 +76,7 @@ spec:
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorkitErrorRateTooHighAWSPhoenix
+    - alert: OperatorkitErrorRateTooHighAWS
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
@@ -91,7 +91,7 @@ spec:
     # It might happen that CRs get orphaned or deletion gets kind of stuck during
     # the cleanup process. Then we want to get notified and figure out what went
     # wrong to fix the root cause eventually.
-    - alert: OperatorkitCRNotDeletedAWSPhoenix
+    - alert: OperatorkitCRNotDeletedAWS
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
         opsrecipe: check-not-deleted-object/
@@ -104,7 +104,7 @@ spec:
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorNotReconcilingAWSPhoenix
+    - alert: OperatorNotReconcilingAWS
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'
         opsrecipe: operator-not-reconciling/

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -76,7 +76,7 @@ spec:
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorkitErrorRateTooHighPhoenix
+    - alert: OperatorkitErrorRateTooHighAWSPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
@@ -91,7 +91,7 @@ spec:
     # It might happen that CRs get orphaned or deletion gets kind of stuck during
     # the cleanup process. Then we want to get notified and figure out what went
     # wrong to fix the root cause eventually.
-    - alert: OperatorkitCRNotDeletedPhoenix
+    - alert: OperatorkitCRNotDeletedAWSPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
         opsrecipe: check-not-deleted-object/
@@ -104,7 +104,7 @@ spec:
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorNotReconcilingPhoenix
+    - alert: OperatorNotReconcilingAWSPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'
         opsrecipe: operator-not-reconciling/

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -76,7 +76,7 @@ spec:
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorkitErrorRateTooHighFirecracker
+    - alert: OperatorkitErrorRateTooHighPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
@@ -85,13 +85,13 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: qa
-    # Firecracker
+    # Phoenix
     # It might happen that CRs get orphaned or deletion gets kind of stuck during
     # the cleanup process. Then we want to get notified and figure out what went
     # wrong to fix the root cause eventually.
-    - alert: OperatorkitCRNotDeletedFirecracker
+    - alert: OperatorkitCRNotDeletedPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
         opsrecipe: check-not-deleted-object/
@@ -100,11 +100,11 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorNotReconcilingFirecracker
+    - alert: OperatorNotReconcilingPhoenix
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'
         opsrecipe: operator-not-reconciling/
@@ -114,7 +114,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: firecracker
+        team: phoenix
         topic: qa
 
     # In case something stops an operator from reconciling CRs we want to

--- a/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
@@ -20,7 +20,7 @@ spec:
         area: kaas
         severity: page
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: firecracker
+        team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}
         team: celestial
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}


### PR DESCRIPTION
Change ownership of teams from firecracker to phoenix.

I thought as a first step, take all firecracker alerts into phoenix and in the second step looking at the Azure alerts and merge them into it. 

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.