### PR TITLE
Show node instead of instance in cert expiration alert description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Report affected node instead of cert-exporter instance in certificate expiration alerts (WC and MC).
+
 ## [0.29.0] - 2021-10-19
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
@@ -13,7 +13,7 @@ spec:
     rules:
     - alert: ManagementClusterKVMCertificateWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="kvm", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
@@ -25,7 +25,7 @@ spec:
         topic: security
     - alert: ManagementClusterAWSCertificateWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="aws", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
@@ -37,7 +37,7 @@ spec:
         topic: security
     - alert: ManagementClusterAzureCertificateWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="azure", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -13,7 +13,7 @@ spec:
     rules:
     - alert: WorkloadClusterCertificateWillExpireInLessThanAMonth
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than a month.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than a month.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="workload_cluster", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 4 * 7 * 24 * 60 * 60
       for: 5m


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/19363

This PR:

- Changes cert expiration alert description to show node instead of instance (i.e. reporting cert-exporter pod IP)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
