### PR TITLE
Fix Flux alerts: add forgotten "> 0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `> 0` to FluxCD rules.
+
 ## [0.31.1] - 2021-11-09
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -15,7 +15,7 @@ spec:
         description: |-
           {{`Flux HelmRelease on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-helmrelease/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease"}
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease"} > 0
       for: 10m
       labels:
         area: kaas
@@ -27,7 +27,7 @@ spec:
         description: |-
           {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization"}
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization"} > 0
       for: 10m
       labels:
         area: kaas
@@ -39,7 +39,7 @@ spec:
         description: |-
           {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-source/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket"}
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket"} > 0
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
