### PR TITLE
Ignore certificate secrets expiring for WCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `CertificateSecretWillExpireInLessThanTwoWeeks` only alert for certificate secrets expriry on management clusters.
+
 ## [0.32.0] - 2021-11-10
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_secret_not_after{name!~"kiam.*"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_secret_not_after{name!~"kiam.*",cluster_type="management_cluster"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: managedapps


### PR DESCRIPTION
This PR:

changes the `CertificateSecretWillExpireInLessThanTwoWeeks` alert to only report for management clusters.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
