### PR TITLE
Make WorkloadClusterEtcdDBSizeTooLarge only alert during business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `WorkloadClusterEtcdDBSizeTooLarge` only alert during business hours.
+
 ## [0.34.0] - 2021-11-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -59,6 +59,7 @@ spec:
       labels:
         area: kaas
         severity: page
+        cancel_if_outside_working_hours: "true"
         {{- if eq .Values.managementCluster.provider.kind "aws" }}
         team: phoenix
         {{- else if eq .Values.managementCluster.provider.kind "azure" }}


### PR DESCRIPTION
This PR:

- Make WorkloadClusterEtcdDBSizeTooLarge only alert during business hours



### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [X] Alerting rules must have a comment documenting why it needs to exist.
