### PR TITLE
Route alerts based on the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Route some alerts based on the provider.
+
 ## [0.35.0] - 2021-11-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
@@ -21,7 +21,11 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -32,7 +36,11 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -44,7 +52,11 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -56,7 +68,11 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -68,5 +84,9 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: storage

--- a/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
@@ -21,5 +21,9 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -24,9 +24,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_master_node_down: "true"
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -42,9 +40,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -60,9 +56,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -75,9 +69,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -92,9 +84,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket

--- a/helm/prometheus-rules/templates/alerting-rules/kubelet.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kubelet.workload-cluster.rules.yml
@@ -24,7 +24,11 @@ spec:
         cancel_if_instance_state_not_running: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: KubeletDockerOperationsErrorsTooHigh
       annotations:
@@ -38,7 +42,11 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
@@ -52,7 +60,11 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
@@ -66,5 +78,9 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -23,9 +23,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -44,9 +42,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -68,9 +64,7 @@ spec:
         cancel_if_cluster_with_scaling_nodepools: "true"
         cancel_if_nodes_down: "true"
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket

--- a/helm/prometheus-rules/templates/alerting-rules/network.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.workload-cluster.rules.yml
@@ -19,7 +19,11 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: network
     - alert: Network95thPercentileLatencyTooHigh
       annotations:
@@ -29,7 +33,11 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: network
     - alert: SYNRetransmissionRateTooHigh
       annotations:
@@ -39,5 +47,9 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: network

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -65,7 +65,11 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: NodeHasConstantOOMKills
       annotations:
@@ -78,7 +82,11 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
@@ -89,7 +97,11 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     - alert: MachineEntropyTooLow
       annotations:
@@ -100,7 +112,11 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: infrastructure
     - alert: MachineAllocatedFileDescriptorsTooHigh
       annotations:
@@ -111,7 +127,11 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: infrastructure
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: WorkloadClusterNodeUnexpectedTaintNodeWithImpairedVolumes
@@ -123,6 +143,10 @@ spec:
       labels:
         area: kaas
         severity: notify
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: kubernetes
     {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
@@ -20,7 +20,11 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: infrastructure
     - alert: WorkloadClusterDisabledSystemdUnitActive
       annotations:
@@ -31,5 +35,9 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
@@ -19,9 +19,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        {{- if eq .Values.managementCluster.provider.kind "aws" }}
-        team: phoenix
-        {{- else if eq .Values.managementCluster.provider.kind "azure" }}
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
         {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket


### PR DESCRIPTION
We have alerts like `RootVolumeSpaceTooLow` that are being routed to team phoenix, but they could be coming from a KVM installation. With these changes we route some alerts based on the provider.

This PR:

- Route alerts based on the provider

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [X] Alerting rules must have a comment documenting why it needs to exist.
