### PR TITLE
Route more KaaS alerts based on the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Trigger `FluxSourceFailed` if it has been ongoing for 2h.
+- Route more KaaS alerts based on the provider.
 
 ## [0.36.0] - 2021-11-24
 

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -64,7 +64,7 @@ spec:
         severity: page
         team: honeybadger
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedPhoenix
+    - alert: DeploymentNotSatisfiedKaas
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
@@ -76,9 +76,13 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: managementcluster
-    - alert: DeploymentNotSatisfiedChinaPhoenix
+    - alert: DeploymentNotSatisfiedChinaKaas
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied-china/
@@ -87,7 +91,11 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: managementcluster
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: AWSManagementClusterDeploymentScaledDownToZero

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -22,7 +22,7 @@ spec:
         severity: page
         team: honeybadger
         topic: releng
-    - alert: WorkloadClusterDeploymentNotSatisfiedPhoenix
+    - alert: WorkloadClusterDeploymentNotSatisfiedKaas
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-deployment-not-satisfied/
@@ -31,7 +31,11 @@ spec:
       labels:
         area: kaas
         severity: page
+        {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
         team: phoenix
+        {{- else if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
+        team: rocket
+        {{- end }}
         topic: observability
     - alert: WorkloadClusterManagedDeploymentNotSatisfied
       annotations:


### PR DESCRIPTION
This PR:

- Route more KaaS alerts based on the provider
- Renamed route to use "KaaS" instead of "Phoenix"

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [X] Alerting rules must have a comment documenting why it needs to exist.
