### PR TITLE
Split Flux alerts based on MC/WC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split Flux alerts based on `cluster_type`
+- Extend trigger period for Flux Workload Cluster alerts
+- Prevent Flux Workload Cluster alerts from paging outside business hours
+
 ## [0.38.0] - 2021-11-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -15,11 +15,24 @@ spec:
         description: |-
           {{`Flux HelmRelease on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-helmrelease/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease"} > 0
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="management_cluster"} > 0
       for: 10m
       labels:
         area: kaas
         severity: page
+        team: honeybadger
+        topic: releng
+    - alert: FluxWorkloadClusterHelmReleaseFailed
+      annotations:
+        description: |-
+          {{`Flux HelmRelease on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+        opsrecipe: fluxcd-failing-helmrelease/
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="workload_cluster"} > 0
+      for: 2h
+      labels:
+        area: kaas
+        severity: page
+        cancel_if_outside_working_hours: "true"
         team: honeybadger
         topic: releng
     - alert: FluxKustomizationFailed
@@ -27,11 +40,24 @@ spec:
         description: |-
           {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization"} > 0
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="management_cluster"} > 0
       for: 10m
       labels:
         area: kaas
         severity: page
+        team: honeybadger
+        topic: releng
+    - alert: FluxWorkloadClusterKustomizationFailed
+      annotations:
+        description: |-
+          {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+        opsrecipe: fluxcd-failing-kustomization/
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="workload"} > 0
+      for: 2h
+      labels:_cluster"
+        area: kaas
+        severity: page
+        cancel_if_outside_working_hours: "true"
         team: honeybadger
         topic: releng
     - alert: FluxSourceFailed
@@ -44,6 +70,31 @@ spec:
       labels:
         area: kaas
         severity: page
+        team: honeybadger
+        topic: releng
+    - alert: FluxSourceFailed
+      annotations:
+        description: |-
+          {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+        opsrecipe: fluxcd-failing-source/
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster"} > 0
+      for: 2h
+      labels:
+        area: kaas
+        severity: page
+        team: honeybadger
+        topic: releng
+    - alert: FluxWorkloadClusterSourceFailed
+      annotations:
+        description: |-
+          {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+        opsrecipe: fluxcd-failing-source/
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="workload_cluster"} > 0
+      for: 2h
+      labels:
+        area: kaas
+        severity: page
+        cancel_if_outside_working_hours: "true"
         team: honeybadger
         topic: releng
     - alert: FluxReconciliationTakingTooLong

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -52,9 +52,9 @@ spec:
         description: |-
           {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="workload"} > 0
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="workload_cluster"} > 0
       for: 2h
-      labels:_cluster"
+      labels:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -65,18 +65,6 @@ spec:
         description: |-
           {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-source/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket"} > 0
-      for: 2h
-      labels:
-        area: kaas
-        severity: page
-        team: honeybadger
-        topic: releng
-    - alert: FluxSourceFailed
-      annotations:
-        description: |-
-          {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
-        opsrecipe: fluxcd-failing-source/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster"} > 0
       for: 2h
       labels:


### PR DESCRIPTION
Resolves https://github.com/giantswarm/giantswarm/issues/19958

This PR:

- Splits Flux alerts based on `cluster_type`
- Extends trigger period for Flux Workload Cluster alerts
- Prevents Flux Workload Cluster alerts from paging outside business hours

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
