### PR TITLE
Add inhibition when cluster has no workers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add inhibition when cluster has no workers.
+- Add inhibition when cluster has no workers (AWS and Azure only).
 
 ## [0.38.0] - 2021-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add inhibition when cluster has no workers.
+
 ## [0.38.0] - 2021-11-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -36,7 +36,7 @@ spec:
       {{- if eq .Values.managementCluster.provider.kind "azure" }}
       expr: azure_operator_cluster_worker_nodes == 0
       {{- else if eq .Values.managementCluster.provider.kind "aws" }}
-      expr: sum(aws_operator_asg_desired_count{asg=~".*-tcnp-.*"}) == 0
+      expr: sum(aws_operator_asg_desired_count) by (cluster_id) - on(cluster_id) sum(aws_operator_asg_desired_count{asg=~".*-tccpn-.*"}) by (cluster_id) == 0
       {{- end }}
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -29,6 +29,17 @@ spec:
         kube_state_metrics_down: "true"
         team: phoenix
         topic: status
+    {{- if eq .Values.managementCluster.provider.kind "azure" }}
+    - alert: InhibitionClusterWithoutWorkerNodes
+      annotations:
+        description: '{{`Cluster ({{ $labels.cluster_id }}) has no worker nodes.`}}'
+      expr: azure_operator_cluster_worker_nodes == 0
+      labels:
+        area: kaas
+        has_worker_nodes: "false"
+        team: phoenix
+        topic: status
+    {{- end }}
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: InhibitionKiamErrors
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -29,11 +29,15 @@ spec:
         kube_state_metrics_down: "true"
         team: phoenix
         topic: status
-    {{- if eq .Values.managementCluster.provider.kind "azure" }}
+    {{- if or (eq .Values.managementCluster.provider.kind "azure") (eq .Values.managementCluster.provider.kind "aws") }}
     - alert: InhibitionClusterWithoutWorkerNodes
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) has no worker nodes.`}}'
+      {{- if eq .Values.managementCluster.provider.kind "azure" }}
       expr: azure_operator_cluster_worker_nodes == 0
+      {{- else if eq .Values.managementCluster.provider.kind "aws" }}
+      expr: sum(aws_operator_asg_desired_count{asg=~".*-tcnp-.*"}) == 0
+      {{- end }}
       labels:
         area: kaas
         has_worker_nodes: "false"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/546

This PR adds a new inhibition alert that fires when a workload cluster has no worker nodes.
This is currently only supported in Azure and AWS as a POC.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
