### PR TITLE
webhook errors for management clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix alert rule webhook errors for management clusters.
+
 ## [0.40.0] - 2021-11-30
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
@@ -33,7 +33,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type!="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
I might be wrong, just want to hear some opinion. We only get paged for clusters which are not cluster_type management cluster which is wrong IMHO. We would never be notified in case there's something wrong with kyverno webhook

Example, the metric before changing "!=":
![image](https://user-images.githubusercontent.com/1936982/144223366-5d5d9035-17fb-4c39-99dc-5d16d056981e.png)

Changing it to "=":
![image](https://user-images.githubusercontent.com/1936982/144223240-12f50ecf-82ab-4ffd-ae1b-7435954e8466.png)


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.