### PR TITLE
Change ManagementClusterHasLessThanThreeNodes alert to use a metric with reliable `role` label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Alerts for EBS CSI.
 
+### Changed
+
+- Change ManagementClusterHasLessThanThreeNodes alert to use a metrics with reliable `role` label.
+
 ## [0.40.2] - 2021-12-03
 
 

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -38,7 +38,7 @@ spec:
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} has less than 3 nodes.`}}'
         opsrecipe: management-cluster-less-than-three-workers/
-      expr: sum(kube_node_labels{cluster_type="management_cluster", label_role="worker"}) < 3
+      expr: sum(kubelet_node_name{cluster_type="management_cluster", role="worker"}) < 3
       for: 1h
       labels:
         area: kaas


### PR DESCRIPTION
Because of https://github.com/giantswarm/prometheus-meta-operator/pull/762 the `role` metric will be missing from a whole bunch of metrics, including the one `ManagementClusterHasLessThanThreeNodes` alert was based on. This PR changes the metric used for `ManagementClusterHasLessThanThreeNodes` to use one that has a value for the `role` label.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
