### PR TITLE
Ownership efk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added per-team ownership (alerts go to relevant teams, not Honeybadger) of efk-stack-app and
+  nginx-ingress-controller-app for the WorkloadClusterAppFailed alert
+
 ## [0.43.0] - 2021-12-14
 
 ## [0.42.0] - 2021-12-13

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -124,11 +124,12 @@ spec:
         team: honeybadger
         topic: releng
     ## Workload cluster app rules only available on the management cluster Prometheus because the source is app-exporter
+    ## By default they go to Honeybadger, unless there's an explicit team configured below for specific apps.
     - alert: WorkloadClusterAppFailed
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog!~"control-plane-.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog!~"control-plane-.*", app!~"(efk-stack-app)|(nginx-ingress-controller-app)"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 30m
       labels:
         area: managedservices
@@ -139,6 +140,38 @@ spec:
         severity: page
         sig: none
         team: honeybadger
+        topic: releng
+    - alert: WorkloadClusterAppFailed
+      annotations:
+        description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
+        opsrecipe: app-failed/
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog!~"control-plane-.*", app="efk-stack-app"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        sig: none
+        team: atlas
+        topic: releng
+    - alert: WorkloadClusterAppFailed
+      annotations:
+        description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
+        opsrecipe: app-failed/
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog!~"control-plane-.*", app="nginx-ingress-controller-app"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        sig: none
+        team: cabbage
         topic: releng
     - alert: WorkloadClusterAppPendingUpdate
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -142,7 +142,7 @@ spec:
         team: honeybadger
         topic: releng
     # Alert Atlas about EFK deployment failed as detected by app platform.
-    - alert: WorkloadClusterAppFailed
+    - alert: WorkloadClusterAppFailedEFK
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
@@ -159,7 +159,7 @@ spec:
         team: atlas
         topic: releng
           # Alert Cabbage about nginx-IC deployment failed as detected by app platform.
-    - alert: WorkloadClusterAppFailed
+    - alert: WorkloadClusterAppFailedNginxIC
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -141,6 +141,7 @@ spec:
         sig: none
         team: honeybadger
         topic: releng
+    # Alert Atlas about EFK deployment failed as detected by app platform.
     - alert: WorkloadClusterAppFailed
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
@@ -157,6 +158,7 @@ spec:
         sig: none
         team: atlas
         topic: releng
+          # Alert Cabbage about nginx-IC deployment failed as detected by app platform.
     - alert: WorkloadClusterAppFailed
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -38,7 +38,7 @@ spec:
     - alert: FluxKustomizationFailed
       annotations:
         description: |-
-          {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux Kustomization {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="management_cluster"} > 0
       for: 10m

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: FluxHelmReleaseFailed
       annotations:
         description: |-
-          {{`Flux HelmRelease on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-helmrelease/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="management_cluster"} > 0
       for: 10m
@@ -25,7 +25,7 @@ spec:
     - alert: FluxWorkloadClusterHelmReleaseFailed
       annotations:
         description: |-
-          {{`Flux HelmRelease on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-helmrelease/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="workload_cluster"} > 0
       for: 2h
@@ -50,7 +50,7 @@ spec:
     - alert: FluxWorkloadClusterKustomizationFailed
       annotations:
         description: |-
-          {{`Flux Kustomization on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux Kustomization {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind="Kustomization", cluster_type="workload_cluster"} > 0
       for: 2h
@@ -63,7 +63,7 @@ spec:
     - alert: FluxSourceFailed
       annotations:
         description: |-
-          {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-source/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster"} > 0
       for: 2h
@@ -75,7 +75,7 @@ spec:
     - alert: FluxWorkloadClusterSourceFailed
       annotations:
         description: |-
-          {{`Flux {{ $labels.kind }} on {{ $labels.installation }}/{{ $labels.cluster_id }} in {{ $labels.namespace }}/{{ $labels.name }} is stuck in Failed state.`}}
+          {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-source/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="workload_cluster"} > 0
       for: 2h


### PR DESCRIPTION
This PR:

- adds per-team ownership of `efk-stack-app` and `nginx-ingress-controller-app` for the `WorkloadClusterAppFailed` alert

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
