### PR TITLE
Silence some alerts when the workload cluster has 0 worker nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Silence some alerts when the workload cluster has 0 worker nodes.
+
 ## [0.43.0] - 2021-12-14
 
 ## [0.42.0] - 2021-12-13

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: phoenix
         topic: kubernetes
@@ -100,7 +100,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_kube_state_metrics_down: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: phoenix
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -24,6 +24,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         team: phoenix
         topic: kubernetes
@@ -99,6 +100,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_kube_state_metrics_down: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         team: phoenix
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -56,6 +56,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_has_no_workers: "true"
         severity: notify
         team: phoenix
         topic: kubernetes
@@ -84,6 +85,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_has_no_workers: "true"
         master_node_down: "true"
         severity: page
         team: phoenix

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -56,7 +56,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: notify
         team: phoenix
         topic: kubernetes
@@ -85,7 +85,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         master_node_down: "true"
         severity: page
         team: phoenix

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -22,6 +22,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -41,6 +42,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -62,6 +64,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
+        cancel_if_has_no_workers: "true"
         cancel_if_nodes_down: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -22,7 +22,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -42,7 +42,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}
         team: rocket
@@ -64,7 +64,7 @@ spec:
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_cluster_with_scaling_nodepools: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         cancel_if_nodes_down: "true"
         severity: page
         {{- if or (eq .Values.managementCluster.provider.kind "kvm") (eq .Values.managementCluster.provider.kind "vmware") }}

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -23,7 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -23,6 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -31,5 +31,5 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -31,4 +31,5 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_has_no_workers: "true"
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/tiller.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/tiller.all.rules.yml
@@ -20,6 +20,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/tiller.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/tiller.all.rules.yml
@@ -20,7 +20,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/tiller.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/tiller.workload-cluster.rules.yml
@@ -21,6 +21,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/tiller.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/tiller.workload-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -23,6 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
+        cancel_if_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng
@@ -37,6 +38,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
+        cancel_if_has_no_workers: "true"
         severity: notify
         team: atlas
         topic: observability
@@ -53,6 +55,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_any_kube_state_metrics_down: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability
@@ -69,6 +72,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_any_kube_state_metrics_down: "true"
+        cancel_if_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -23,7 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: notify
         team: honeybadger
         topic: releng
@@ -38,7 +38,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: notify
         team: atlas
         topic: observability
@@ -55,7 +55,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_any_kube_state_metrics_down: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability
@@ -72,7 +72,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_any_kube_state_metrics_down: "true"
-        cancel_if_has_no_workers: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/546

I silenced a few alerts when a cluster has no nodes.
Just a starting point, let's iterate on this!