### PR TITLE
SLO alerts for k8s core components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added SLO alert for internal API request errors in kube-scheduler and kube-controller-manager.
+- Added SLO alert for cloud (Azure and AWS) API request errors in kube-scheduler and kube-controller-manager.
+
 ## [0.53.0] - 2022-01-20
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -224,6 +224,69 @@ spec:
     - expr: sum by (service, area) (raw_slo_errors{area="managed-apps"} - raw_slo_errors{area="managed-apps"}) + 1-0.99
       record: slo_target
 
+    # core k8s components internal API requests
+    # record number of requests.
+    - expr: sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+      labels:
+        class: MEDIUM
+        area: kaas
+      record: raw_slo_requests
+      # record number of errors.
+    - expr: sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler", code=~"5..|<error>"}) by (cluster_id,app)
+      labels:
+        area: kaas
+        class: MEDIUM
+      record: raw_slo_errors
+      # -- 99% availability
+    - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+      record: slo_target
+
+    # core k8s components azure API requests
+    # record number of requests.
+    - expr: sum(cloudprovider_azure_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+      labels:
+        class: MEDIUM
+        area: kaas
+        provider: azure
+      record: raw_slo_requests
+      # record number of errors.
+    - expr: sum(cloudprovider_azure_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+      labels:
+        area: kaas
+        class: MEDIUM
+        provider: azure
+      record: raw_slo_errors
+      # -- 99% availability
+    - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+        provider: azure
+      record: slo_target
+
+    # core k8s components azure API requests
+    # record number of requests.
+    - expr: sum(cloudprovider_aws_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+      labels:
+        class: MEDIUM
+        area: kaas
+        provider: aws
+      record: raw_slo_requests
+      # record number of errors.
+    - expr: sum(cloudprovider_aws_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+      labels:
+        area: kaas
+        class: MEDIUM
+        provider: aws
+      record: raw_slo_errors
+      # -- 99% availability
+    - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+        provider: aws
+      record: slo_target
+
       # -- generic stuff
       # -- standard burnrates based on https://sre.google/workbook/alerting-on-slos/#6-multiwindow-multi-burn-rate-alerts
     - expr: "vector(36)"

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -226,13 +226,13 @@ spec:
 
     # core k8s components internal API requests
     # record number of requests.
-    - expr: sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+    - expr: label_replace(sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         class: MEDIUM
         area: kaas
       record: raw_slo_requests
       # record number of errors.
-    - expr: sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler", code=~"5..|<error>"}) by (cluster_id,app)
+    - expr: label_replace(sum(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler", code=~"5..|<error>"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         area: kaas
         class: MEDIUM
@@ -245,14 +245,14 @@ spec:
 
     # core k8s components azure API requests
     # record number of requests.
-    - expr: sum(cloudprovider_azure_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+    - expr: label_replace(sum(cloudprovider_azure_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         class: MEDIUM
         area: kaas
         provider: azure
       record: raw_slo_requests
       # record number of errors.
-    - expr: sum(cloudprovider_azure_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+    - expr: label_replace(sum(cloudprovider_azure_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         area: kaas
         class: MEDIUM
@@ -267,14 +267,14 @@ spec:
 
     # core k8s components azure API requests
     # record number of requests.
-    - expr: sum(cloudprovider_aws_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+    - expr: label_replace(sum(cloudprovider_aws_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         class: MEDIUM
         area: kaas
         provider: aws
       record: raw_slo_requests
       # record number of errors.
-    - expr: sum(cloudprovider_aws_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app)
+    - expr: label_replace(sum(cloudprovider_aws_api_request_errors{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:
         area: kaas
         class: MEDIUM


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18315

This PR adds 3 more SLO alerts to catch errors in controller-manager and scheduler.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
