### PR TITLE
fix kubernetes version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `aggregation:kubelet:version` and `aggregation:kubernetes:version` not showing kubernetes version.
+
 ## [0.41.0] - 2021-12-06
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -76,7 +76,7 @@ spec:
       record: aggregation:kubelet:running_container_total
     - expr: sum(kubelet_running_pod_count) by (cluster_type, cluster_id)
       record: aggregation:kubelet:running_pod_total
-    - expr: sum(kubernetes_build_info{app="kubelet"}) by (cluster_type, gitVersion, cluster_id)
+    - expr: sum(kubernetes_build_info{app="kubelet"}) by (cluster_type, git_version, cluster_id)
       record: aggregation:kubelet:version
     - expr: sum(apiserver_request_total) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:apiserver_request_count
@@ -172,7 +172,7 @@ spec:
       record: aggregation:kubernetes:up
     - expr: sum(up{app="kubernetes"}) by (cluster_type, cluster_id) / count(up{app="kubernetes"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:up_bool
-    - expr: sum(kubernetes_build_info{app="kubernetes"}) by (cluster_type, gitVersion)
+    - expr: sum(kubernetes_build_info{app="kubernetes"}) by (cluster_type, git_version)
       record: aggregation:kubernetes:version
     - expr: count(node_cpu_seconds_total{mode="idle"}) by (cluster_type, cluster_id)
       record: aggregation:node:cpu_cores_total


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20233


`kubernetes_build_info` label changed from `gitVersion` to `git_version`.

![image](https://user-images.githubusercontent.com/6536819/147085192-024ad0a1-1b17-489c-9963-976c1bb5837b.png)

## Before

![image](https://user-images.githubusercontent.com/6536819/147085275-49f63610-31a3-4536-897b-0dfe0273c97b.png)

## After

![image](https://user-images.githubusercontent.com/6536819/147085301-9873b7fd-0050-4095-bb11-26a055b2585d.png)
