### PR TITLE
Silence `ClusterAutoscalerErrors` if cluster has no workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Silence `ClusterAutoscalerErrors` if cluster has no workers because `CoreDNS isn't running and that makes the autoscaler fail.
+
 ### Fixed
 
 - Fix `aggregation:kubelet:version` and `aggregation:kubernetes:version` not showing kubernetes version.

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -24,6 +24,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         team: phoenix
         topic: cluster-autoscaler


### PR DESCRIPTION
 because CoreDNS isn't running and that makes the autoscaler fail.

