### PR TITLE
Silence `WorkloadClusterCriticalPodNotRunningAzure` and `WorkloadClus…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Silence `WorkloadClusterCriticalPodNotRunningAzure` and `WorkloadClusterCriticalPodNotRunningAWS` if `kube-state-metrics` is down.
+
 ## [0.45.0] - 2021-12-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -39,6 +39,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: phoenix
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -31,6 +31,7 @@ spec:
       for: 5m
       labels:
         area: kaas
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: phoenix
         topic: kubernetes


### PR DESCRIPTION
…terCriticalPodNotRunningAWS` if `kube-state-metrics` is down.

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
