### PR TITLE
Fix opsrecipe for `CertOperatorVaultTokenAlmostExpired`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix opsrecipe for `CertOperatorVaultTokenAlmostExpired`.
+
 ## [0.46.0] - 2021-12-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -59,7 +59,7 @@ spec:
     - alert: CertOperatorVaultTokenAlmostExpired
       annotations:
         description: '{{`Vault token for {{ $labels.app }} ({{ $labels.instance }}) is about to expire.`}}'
-        opsrecipe: recreate-vault-tokens/
+        opsrecipe: cert-operator-vault-token-expired/
       expr: sum((cert_operator_vault_token_expire_time_seconds - time()) < (60 * 60 * 24 * 7)) BY (app, instance)
       for: 5m
       labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/657

this PR fixes a wrong link to an opsrecipe