### PR TITLE
Fix description for alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve `WorkloadClusterCriticalPodNotRunningAWS` by ensuring the expected pod that is not missing is included in the description.
+
 ## [0.46.1] - 2022-01-03
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
-      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
+      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or label_replace(absent(kube_pod_container_status_running{container="k8s-api-server"}), "pod", "$1", "container", "(.+)") == 1 or label_replace(absent(kube_pod_container_status_running{container="k8s-controller-manager"}), "pod", "$1", "container", "(.+)") == 1 or label_replace(absent(kube_pod_container_status_running{container="k8s-scheduler"}), "pod", "$1", "container", "(.+)") == 1
       for: 1h
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/664

This alert sometimes does not contain the name of the critical pod that triggered the alert in the description:

![Screenshot_20220103_171548](https://user-images.githubusercontent.com/868430/147953914-004a7965-e208-4f78-829e-7aecf9698d26.png)

I noticed this happens when the `absent(...)` query is triggering the alert.
In fact, the `absent` query result only contains the `container` label, but we use the `pod` label to populate the description.

This PR adds a few `label_replace` clauses to ensure the `pod` label is always set and thus the description contains useful data.
