### PR TITLE
Don't page kaas when monitoring deployments are not satisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't page KaaS with `DeploymentNotSatisfiedKaas` when monitoring deployments are not satisfied on management clusters.
+
 ## [0.46.2] - 2022-01-03
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -68,7 +68,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator-.+|azure-admission-controller-.+|azure-operator.*|azure-collector.*|cluster-operator-.+|cluster-api-core-webhook.*|coredns-.+|event-exporter-.*|upgrade-schedule-operator.*|grafana.*|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller|alertmanager.*|prometheus.*|promxy.*", cluster_id!~"argali|giraffe"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator-.+|azure-admission-controller-.+|azure-operator.*|azure-collector.*|cluster-operator-.+|cluster-api-core-webhook.*|coredns-.+|event-exporter-.*|upgrade-schedule-operator.*|nginx-ingress-controller-.+|worker-.+|master-.+|app-operator-.+|chart-operator-.+|.+-admission-controller", cluster_id!~"argali|giraffe"} > 0
       for: 30m
       labels:
         area: kaas


### PR DESCRIPTION
This PR:

- Don't page KaaS with `DeploymentNotSatisfiedKaas` when monitoring deployments are not satisfied on management clusters.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
