### PR TITLE
Remove IngressControllerSSLCertificateWillExpireSoon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't page KaaS with `DeploymentNotSatisfiedKaas` when monitoring deployments are not satisfied on management clusters.
 - Don't page KaaS with `DeploymentNotSatisfiedKaas` when app platform deployments are not satisfied on management clusters.
+- Remove `IngressControllerSSLCertificateWillExpireSoon`. It is covered by alert `CertificateSecretWillExpireInLessThanTwoWeeks`.
 
 ## [0.46.2] - 2022-01-03
 

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -46,17 +46,6 @@ spec:
         severity: notify
         team: cabbage
         topic: ingress
-    - alert: IngressControllerSSLCertificateWillExpireSoon
-      annotations:
-        description: '{{`SSL certificate for {{ $labels.host }} will expire in less than 10 days.`}}'
-        opsrecipe: ic-ssl-is-going-to-expire/
-      expr: avg without(instance) (nginx_ingress_controller_ssl_expire_time_seconds{cluster_type="management_cluster",control_plane!~"(etcd|api).*"}) < (time() + (10 * 24 * 3600))
-      for: 5m
-      labels:
-        area: managedservices
-        severity: notify
-        team: cabbage
-        topic: ingress
     - alert: IngressControllerServiceHasNoEndpoints
       annotations:
         description: '{{`Ingress Controller has no live endpoints.`}}'


### PR DESCRIPTION
This PR removes `IngressControllerSSLCertificateWillExpireSoon`. I think its covered by `CertificateSecretWillExpireInLessThanTwoWeeks`


### Checklist

- [x] Update changelog in CHANGELOG.md.
