### PR TITLE
Add `NginxIngressDown`, `ExternalDNSDown` and `CertManagerDown` alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't page KaaS with `DeploymentNotSatisfiedKaas` when monitoring deployments are not satisfied on management clusters.
 - Don't page KaaS with `DeploymentNotSatisfiedKaas` when app platform deployments are not satisfied on management clusters.
 - Remove `IngressControllerSSLCertificateWillExpireSoon`. It is covered by alert `CertificateSecretWillExpireInLessThanTwoWeeks`.
+- Add `NginxIngressDown`, `ExternalDNSDown` and `CertManagerDown` alerts.
 
 ## [0.46.2] - 2022-01-03
 

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -24,3 +24,17 @@ spec:
         severity: notify
         team: cabbage
         topic: observability
+    - alert: CertManagerDown
+      annotations:
+        description: '{{`cert-manager on {{ $labels.installation }})/{{ $labels.cluster_id }} in namespace {{ $labels.namespace }}) is down.`}}'
+        opsrecipe: cert-manager-down/
+      expr: up{app="cert-manager-app"} == 0
+      for: 15m
+      labels:
+        area: managedapps
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        severity: page
+        team: cabbage
+        topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/external-dns.rules.yml
@@ -42,4 +42,19 @@ spec:
         severity: page
         team: cabbage
         topic: external-dns
+    - alert: ExternalDNSDown
+      annotations:
+        description: '{{`external-dns on {{ $labels.installation }})/{{ $labels.cluster_id }} in namespace {{ $labels.namespace }}) is down.`}}'
+        opsrecipe: external-dns-down/
+      expr: up{app="external-dns-app"} == 0
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_kiam_has_errors: "true"
+        severity: page
+        team: cabbage
+        topic: external-dns
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -59,3 +59,16 @@ spec:
         severity: page
         team: cabbage
         topic: ingress
+    - alert: NginxIngressDown
+      annotations:
+        description: '{{`nginx-ingress-controller-app on {{ $labels.installation }})/{{ $labels.cluster_id }} in namespace {{ $labels.namespace }}) is down.`}}'
+        opsrecipe: nginx-ingress-controller-app-down/
+      expr: up{app="nginx-ingress-controller-app"} == 0
+      for: 15m
+      labels:
+        area: managedapps
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        severity: page
+        team: cabbage
+        topic: ingress


### PR DESCRIPTION
This PR:

- Adds `NginxIngressDown`, `ExternalDNSDown` and `CertManagerDown` alerts

@giantswarm/team-cabbage please check and comment

Towards https://github.com/giantswarm/roadmap/issues/601

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
