### PR TITLE
fix/20233/broken version metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fix Kubernetes and kubelet versions in cortex aggregations.
+
 ## [0.47.0] - 2022-01-07
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -76,7 +76,7 @@ spec:
       record: aggregation:kubelet:running_container_total
     - expr: sum(kubelet_running_pod_count) by (cluster_type, cluster_id)
       record: aggregation:kubelet:running_pod_total
-    - expr: sum(kubernetes_build_info{app="kubelet"}) by (cluster_type, git_version, cluster_id)
+    - expr: sum by(cluster_type, git_version, cluster_id) (label_replace(kubernetes_build_info{app="kubelet"}, "git_version", "$1", "gitVersion", "(.+)"))
       record: aggregation:kubelet:version
     - expr: sum(apiserver_request_total) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:apiserver_request_count
@@ -172,7 +172,7 @@ spec:
       record: aggregation:kubernetes:up
     - expr: sum(up{app="kubernetes"}) by (cluster_type, cluster_id) / count(up{app="kubernetes"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:up_bool
-    - expr: sum(kubernetes_build_info{app="kubernetes"}) by (cluster_type, git_version)
+    - expr: sum by(cluster_type, git_version, cluster_id) (label_replace(kubernetes_build_info{app="kubernetes"}, "git_version", "$1", "gitVersion", "(.+)"))
       record: aggregation:kubernetes:version
     - expr: count(node_cpu_seconds_total{mode="idle"}) by (cluster_type, cluster_id)
       record: aggregation:node:cpu_cores_total


### PR DESCRIPTION
This PR:

- fixes invalid version aggregations after `gitVersion` was renamed to `git_version` in Kubernetes (closes https://github.com/giantswarm/giantswarm/issues/20233)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
