### PR TITLE
adding alert for high dex error rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adding alert for high dex error rate.
+
 ## [0.48.0] - 2022-01-11
 
 

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: dex.rules
   namespace: {{ .Values.namespace  }}
 spec:

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: dex.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: dex
+    rules:
+    - alert: DexErrorRateHigh
+      annotations:
+        description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
+        opsrecipe: dex-error-rate-high/
+      expr: sum(increase(http_requests_total{service="dex", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
+      for: 10m
+      labels:
+        area: managedapps
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: rainbow
+        topic: dex


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17038
This PR:

- adds alert for high dex error rate so that we can move forward making it a managed app

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
