### PR TITLE
Distinguish host-level falco events from pod-level events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.48.0] - 2022-01-11
+### Changed
 
+- Change description of Falco alerts to differentiate between host- and pod-level events.
+
+## [0.48.0] - 2022-01-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2022-01-11
+
 
 ### Fixed
 
@@ -507,7 +509,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add existing rules from https://github.com/giantswarm/prometheus-meta-operator/pull/637/commits/bc6a26759eb955de92b41ed5eb33fa37980660f2
 
-[Unreleased]: https://github.com/giantswarm/prometheus-rules/compare/v0.47.0...HEAD
+[Unreleased]: https://github.com/giantswarm/prometheus-rules/compare/v0.48.0...HEAD
+[0.48.0]: https://github.com/giantswarm/prometheus-rules/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/giantswarm/prometheus-rules/compare/v0.46.2...v0.47.0
 [0.46.2]: https://github.com/giantswarm/prometheus-rules/compare/v0.46.1...v0.46.2
 [0.46.1]: https://github.com/giantswarm/prometheus-rules/compare/v0.46.0...v0.46.1

--- a/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
@@ -13,7 +13,10 @@ spec:
     rules:
     - alert: FalcoCriticalAlertFiring
       annotations:
-        description: '{{`Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }}.`}}'
+        description: '{{` \
+            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
+            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
+          `}}'
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"0|1|2|3"}[10m] ) > 0
       labels:
@@ -27,7 +30,10 @@ spec:
         topic: security
     - alert: FalcoMediumAlertFiring
       annotations:
-        description: '{{`Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }}.`}}'
+        description: '{{` \
+            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
+            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
+          `}}'
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"4|5"}[10m] ) > 0
       labels:
@@ -40,7 +46,10 @@ spec:
         topic: security
     - alert: FalcoInformationalAlert
       annotations:
-        description: '{{`Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }}.`}}'
+        description: '{{` \
+            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
+            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
+          `}}'
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority="6"}[10m] ) > 0
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
@@ -13,10 +13,9 @@ spec:
     rules:
     - alert: FalcoCriticalAlertFiring
       annotations:
-        description: '{{` \
-            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
-            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
-          `}}'
+        description: |-
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"0|1|2|3"}[10m] ) > 0
       labels:
@@ -30,10 +29,9 @@ spec:
         topic: security
     - alert: FalcoMediumAlertFiring
       annotations:
-        description: '{{` \
-            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
-            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
-          `}}'
+        description: |-
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"4|5"}[10m] ) > 0
       labels:
@@ -46,10 +44,9 @@ spec:
         topic: security
     - alert: FalcoInformationalAlert
       annotations:
-        description: '{{` \
-            {{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}. \
-            {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}. {{ end }} \
-          `}}'
+        description: |-
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority="6"}[10m] ) > 0
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
@@ -14,8 +14,8 @@ spec:
     - alert: FalcoCriticalAlertFiring
       annotations:
         description: |-
-          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
-          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"0|1|2|3"}[10m] ) > 0
       labels:
@@ -30,8 +30,8 @@ spec:
     - alert: FalcoMediumAlertFiring
       annotations:
         description: |-
-          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
-          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority=~"4|5"}[10m] ) > 0
       labels:
@@ -45,8 +45,8 @@ spec:
     - alert: FalcoInformationalAlert
       annotations:
         description: |-
-          {{`{{ if eq $labels.k8s_pod_name "<NA>" }} The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
-          {{else}} Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
+          {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
+          {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
         opsrecipe: falco-alerts/
       expr: increase(falco_events{priority="6"}[10m] ) > 0
       labels:


### PR DESCRIPTION
This PR:

- Changes the description text of all Falco alerts to better differentiate host-level alerts (which have no associated Pod) from pod-level alerts

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
