### PR TITLE
Remove HighNumberOfTimeWaitSockets alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.48.0] - 2022-01-11
+### Removed
 
+- Delete unhelpful `HighNumberOfTimeWaitSockets` alert.
+
+## [0.48.0] - 2022-01-11
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -99,17 +99,3 @@ spec:
         severity: page
         team: rocket
         topic: network
-    - alert: HighNumberOfTimeWaitSockets
-      annotations:
-        description: '{{`Over 50 percent of available ports are in time wait state on {{ $labels.instance }}.`}}'
-        opsrecipe: high-port-usage/
-      # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
-      expr: node_sockstat_TCP_tw > ( 0.5 * ( 60999 - 32768 ) )
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: rocket
-        topic: network
-


### PR DESCRIPTION
This PR:

- Remove `HighNumberOfTimeWaitSockets` alert as it indicates a problem with a workload and nothing can be done about it. Additionally, it routes to Team Rocket even when it occurs on AWS.

Discussed in https://gigantic.slack.com/archives/C02TSUYUGUU

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
