### PR TITLE
inhibit MatchingNumberOfPrometheusAndCluster during cluster creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.50.0] - 2022-01-13
+### Changed
 
+- Inhibit `MatchingNumberOfPrometheusAndCluster` during cluster creation.
+
+## [0.50.0] - 2022-01-13
 
 ### Added
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -41,6 +41,7 @@ spec:
       labels:
         area: "empowerment"
         cancel_if_mc_kube_state_metrics_down: "true"
+        cancel_if_cluster_status_creating: "true"
         installation: {{ .Values.managementCluster.name }}
         severity: "page"
         team: "atlas"


### PR DESCRIPTION
`MatchingNumberOfPrometheusAndCluster` currently fires even if the cluster is being created, which is wrong. We need the cluster to be up before we can create a `Prometheus` pod for it, because we need the cluster certificates to configure `Prometheus`.

This PR inhibit the `MatchingNumberOfPrometheusAndCluster` while the cluster is being created.