### PR TITLE
make dex error rate alert less sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make `DexErrorRateHigh` alert less sensitive.
 - Add `NginxIngressDown`, `ExternalDNSDown` and `CertManagerDown` alerts.
 - Include installaton, cluster and namespace in existing external-dns alerts.
 

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -16,7 +16,7 @@ spec:
         description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
         opsrecipe: dex-error-rate-high/
       expr: sum(increase(http_requests_total{service="dex", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
-      for: 10m
+      for: 30m
       labels:
         area: managedapps
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
