### PR TITLE
inhibit `PrometheusCantCommunicateWithKubernetesAPI` during cluster creation and upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Inhibit `PrometheusCantCommunicateWithKubernetesAPI` during cluster creating and upgrade.
+
 ## [0.54.0] - 2022-01-21
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -19,6 +19,8 @@ spec:
       labels:
         area: empowerment
         cancel_if_any_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"
         severity: page
         team: atlas


### PR DESCRIPTION
While cluster is transitioning bad things can happen and its highly likely that the Kubernetes API will be down. This is not a Prometheus problem so we should ignore this alert during cluster transitions: creation, upgrade, and delete