### PR TITLE
Removes target count recording rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removes `aggregation:prometheus:targets_count` recording rule.
+
 ## [0.55.0] - 2022-01-21
 
 - Inhibit `PrometheusCantCommunicateWithKubernetesAPI` during cluster creating and upgrade.

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -205,8 +205,6 @@ spec:
       record: aggregation:prometheus:memory_percentage
     - expr: sum(label_replace(container_memory_working_set_bytes{container='prometheus', namespace=~'.*-prometheus'}, "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)")) by (cluster_type , cluster_id)
       record: aggregation:prometheus:memory_usage
-    - expr: count(up) by (cluster_type, cluster_id)
-      record: aggregation:prometheus:targets_count
     # Managed apps basic SLI metrics
     - expr: sum(monitoring:managed_apps:service_level:primary:error_budget_used) by (cluster_type, cluster_id,workload_name,workload_type) >= 1
       record: aggregation:managed_apps:service_level:basic:error_budget_depleted


### PR DESCRIPTION
This PR removes target count recording rule due to:

```
ts=2022-01-21T14:56:02.345Z caller=dedupe.go:112 component=remote level=error remote_name=gollum url=https://prometheus-us-central1.grafana.net/api/prom/push msg="non-recoverable error" count=28 exemplarCount=0 err="server returned HTTP status 400 Bad Request: user=10755: err: duplicate sample for timestamp. timestamp=2022-01-21T14:55:57.795Z, series={__name__=\"aggregation:prometheus:targets_count\", cluster_id=\"gollum\", cluster_type=\"management_cluster\", customer=\"giantswarm\", installation=\"gollum\", pipeline=\"stable\", prometheus=\"gollum-prometheus/gollum\", prometheus_replica=\"prometheus-gollum-0\", provider=\"azure\", region=\"westeurope\"}"
ts=2022-01-21T14:56:32.663Z caller=dedupe.go:112 component=remote level=error remote_name=gollum url=https://prometheus-us-central1.grafana.net/api/prom/push msg="non-recoverable error" count=28 exemplarCount=0 err="server returned HTTP status 400 Bad Request: user=10755: err: duplicate sample for timestamp. timestamp=2022-01-21T14:56:27.795Z, series={__name__=\"aggregation:prometheus:targets_count\", cluster_id=\"gollum\", cluster_type=\"management_cluster\", customer=\"giantswarm\", installation=\"gollum\", pipeline=\"stable\", prometheus=\"gollum-prometheus/gollum\", prometheus_replica=\"prometheus-gollum-0\", provider=\"azure\", region=\"westeurope\"}"
```

i'll fix this properly next week

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
