### PR TITLE
test MatchingNumberOfPrometheusAndCluster

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -22,7 +22,7 @@ spec:
         description: This alert is used to ensure the entire alerting pipeline is functional.
     - alert: MatchingNumberOfPrometheusAndCluster
       annotations:
-        description: "{{ $labels.installation }}/{{ $labels.cluster_id}} prometheus server is missing."
+        description: "{{`{{ $labels.installation }}/{{ $labels.cluster_id}} prometheus server is missing.`}}"
         opsrecipe: matching-number-of-prometheus-and-cluster/
       # This expression list all the cluster IDs that exist and are not being deleted and compares them (using unless) to the running prometheus pods.
       # If a prometheus is missing, this alert will fire. This alert will not check if a prometheus is running when it should not (e.g. deleted cluster)

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -39,8 +39,6 @@ spec:
         ) > 0
       labels:
         area: "empowerment"
-        cancel_if_mc_kube_state_metrics_down: "true"
-        cancel_if_cluster_status_creating: "true"
         installation: {{ .Values.managementCluster.name }}
         severity: "page"
         team: "atlas"

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -28,9 +28,9 @@ spec:
       # If a prometheus is missing, this alert will fire. This alert will not check if a prometheus is running when it should not (e.g. deleted cluster)
       expr: |
         (
-          sum by(cluster_id) (
+          sum by(cluster_id,installation) (
             {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status", status!="Deleting"}
-          ) unless sum by(cluster_id) (
+          ) unless sum by(cluster_id,installation) (
             label_replace(
               kube_pod_container_status_running{container="prometheus", namespace!="{{ .Values.managementCluster.name }}-prometheus", namespace=~".*-prometheus"},
               "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)"

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -37,7 +37,6 @@ spec:
             )
           )
         ) > 0
-      for: 10m
       labels:
         area: "empowerment"
         cancel_if_mc_kube_state_metrics_down: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -20,9 +20,9 @@ spec:
         type: "heartbeat"
       annotations:
         description: This alert is used to ensure the entire alerting pipeline is functional.
-    - alert: "MatchingNumberOfPrometheusAndCluster"
+    - alert: MatchingNumberOfPrometheusAndCluster
       annotations:
-        description: This alert is used to ensure we have as many workload cluster prometheus as we have workload cluster CR.
+        description: "{{ $labels.installation }}/{{ $labels.cluster_id}} prometheus server is missing."
         opsrecipe: matching-number-of-prometheus-and-cluster/
       # This expression list all the cluster IDs that exist and are not being deleted and compares them (using unless) to the running prometheus pods.
       # If a prometheus is missing, this alert will fire. This alert will not check if a prometheus is running when it should not (e.g. deleted cluster)


### PR DESCRIPTION
Test to reduce alert fatigue and group alerts in OpsGenie.

### Actual state

Getting 1 alert per cluster is very exhausting, as you have to acknowledge every single alert. This is getting worst as we get more customer/clusters.

### Desired state

Get 1 alert for all cluster, where the description hold information about affected cluster. So I can acknowledge only 1 alert for all failing instances.