### PR TITLE
Add cortex recording rule for starboard vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push unique CVE counts to cortex.
+
 ## [0.55.1] - 2022-01-21
 
 - Removes `aggregation:prometheus:targets_count` recording rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push unique CVE counts to cortex.
+
 ## [0.56.0] - 2022-01-25
 
 ### Added
 
-- Push unique CVE counts to cortex.
 - Add alert for workload cluster certificates about to expire.
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -222,3 +222,6 @@ spec:
     # Falco event counts
     - expr: sum(falco_events{priority=~"0|1|2|3|4|5|6|7"}) by (cluster_type, cluster_id, priority, rule)
       record: aggregation:falco_events
+    # Starboard unique vulnerability counts by severity
+    - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)
+      record: aggregation:starboard_unique_vulnerability_count


### PR DESCRIPTION
This PR:

- adds a rule pushing the number of unique vulnerabilities per severity to cortex

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
