### PR TITLE
Add alert for workload cluster certificates about to expire.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert for workload cluster certificates about to expire.
+
 ### Changed
 
 - Send SE alerts to correct KaaS teams.

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -23,6 +23,18 @@ spec:
         severity: notify
         team: {{ include "providerTeam" . }}
         topic: security
+    - alert: WorkloadClusterCertificateWillExpireInLessThanAMonth
+      annotations:
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than a week.`}}'
+        opsrecipe: renew-certificates/
+      expr: (cert_exporter_not_after{cluster_type="workload_cluster", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 7 * 24 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: security
     - alert: WorkloadClusterCertificateWillExpireMetricMissing
       annotations:
         description: '{{`Certificate metrics are missing for cluster {{ $labels.cluster_id }}.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -23,7 +23,7 @@ spec:
         severity: notify
         team: {{ include "providerTeam" . }}
         topic: security
-    - alert: WorkloadClusterCertificateWillExpireInLessThanAMonth
+    - alert: WorkloadClusterCertificateWillExpireInLessThanAWeek
       annotations:
         description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than a week.`}}'
         opsrecipe: renew-certificates/


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/733

Added a new alert that pages when a workload cluster certificate is expiring in less than 1 week.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
