### PR TITLE
add `PrometheusRuleFailures`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `PrometheusRuleFailures` alert rule.
+
 ## [0.57.0] - 2022-01-25
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -43,6 +43,7 @@ spec:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.0f" $value }} time(s).`}}
         summary: Prometheus is failing rule evaluations.
       expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
+      for: 1h
       labels:
         area: empowerment
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -42,7 +42,7 @@ spec:
       annotations:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.0f" $value }} time(s).`}}
         summary: Prometheus is failing rule evaluations.
-      expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
+      expr: rate(prometheus_rule_evaluation_failures_total[30m]) > 0
       for: 1h
       labels:
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -38,3 +38,11 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: PrometheusRuleFailures
+      annotations:
+        description: {{`Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf "%.0f" $value }} rules.`}}
+        summary: Prometheus is failing rule evaluations.
+      expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
+      for: 1h
+      labels:
+        severity: critical

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -40,7 +40,7 @@ spec:
         topic: observability
     - alert: PrometheusRuleFailures
       annotations:
-        description: {{`Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf "%.0f" $value }} rules.`}}
+        description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.0f" $value }} time(s).`}}
         summary: Prometheus is failing rule evaluations.
       expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -43,6 +43,5 @@ spec:
         description: {{`Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf "%.0f" $value }} rules.`}}
         summary: Prometheus is failing rule evaluations.
       expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
-      for: 1h
       labels:
         severity: critical

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -44,4 +44,8 @@ spec:
         summary: Prometheus is failing rule evaluations.
       expr: increase(prometheus_rule_evaluation_failures_total[30m]) > 0
       labels:
-        severity: critical
+        area: empowerment
+        severity: page
+        team: atlas
+        topic: observability
+        cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20510

This PR adds the `PrometheusRuleFailures` alert which will notify us when prometheus rules evaluation fails. This is bad because if prometheus can't evaluate a rule we will never get alerted for it.

i.e. currently failing SLO rules is failing and went unoticed

```
msg="Evaluating rule failed" rule="alert: ServiceLevelBurnRateTooHigh ...
```