### PR TITLE
fix slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `NoHealthyJumphost` alert routing.
 
+### Fixed
+
+- Fix `ServiceLevelBurnRateTooHigh` alert failure : many-to-many matching not allowed.
+
 ## [0.57.0] - 2022-01-25
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -16,15 +16,15 @@ spec:
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
         (
-          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_high
+          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_high
         and
-          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_high
+          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_high
         )
         or
         (
-          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_low
+          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_low
         and
-          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_low
+          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_low
         )
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -16,15 +16,15 @@ spec:
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
         (
-          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_high
+          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_right slo_threshold_high
         and
-          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_high
+          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_right slo_threshold_high
         )
         or
         (
-          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_low
+          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_right slo_threshold_low
         and
-          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) slo_threshold_low
+          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_right slo_threshold_low
         )
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -16,15 +16,15 @@ spec:
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
         (
-          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
+          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_high
         and
-          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_high
+          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_high
         )
         or
         (
-          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
+          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_low
         and
-          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > on (service) group_left slo_threshold_low
+          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"} > slo_threshold_low
         )
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -276,7 +276,7 @@ spec:
         provider: aws
       record: raw_slo_errors
       # -- 99% availability
-    - expr: "vector((1 - 0.99))"
+    - expr: label_replace(group(cloudprovider_aws_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, app), "service", "$1", "app", "(.*)") * 0 + 1 - 0.99
       labels:
         area: kaas
         provider: aws

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -238,7 +238,7 @@ spec:
         class: MEDIUM
       record: raw_slo_errors
       # -- 99% availability
-    - expr: "vector((1 - 0.99))"
+    - expr: label_replace(group(rest_client_requests_total{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, app), "service", "$1", "app", "(.*)") * 0 + 1 - 0.99
       labels:
         area: kaas
       record: slo_target

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -237,11 +237,6 @@ spec:
         area: kaas
         class: MEDIUM
       record: raw_slo_errors
-      # -- 99% availability
-    - expr: "vector((1 - 0.99))"
-      labels:
-        area: kaas
-      record: slo_target
 
     # core k8s components azure API requests
     # record number of requests.

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -265,7 +265,7 @@ spec:
         provider: azure
       record: slo_target
 
-    # core k8s components azure API requests
+    # core k8s components aws API requests
     # record number of requests.
     - expr: label_replace(sum(cloudprovider_aws_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id,app), "service", "$1", "app", "(.*)")
       labels:

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -237,6 +237,11 @@ spec:
         area: kaas
         class: MEDIUM
       record: raw_slo_errors
+      # -- 99% availability
+    - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+      record: slo_target
 
     # core k8s components azure API requests
     # record number of requests.

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -254,7 +254,7 @@ spec:
         provider: azure
       record: raw_slo_errors
       # -- 99% availability
-    - expr: "vector((1 - 0.99))"
+    - expr: label_replace(group(cloudprovider_azure_api_request_duration_seconds_count{app=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, app), "service", "$1", "app", "(.*)") * 0 + 1 - 0.99
       labels:
         area: kaas
         provider: azure


### PR DESCRIPTION
I believe we only need to 1 to 1 matching and not 1 to many/many to 1.

As on one side we have ...

![image](https://user-images.githubusercontent.com/6536819/151810274-3a81e984-ce01-4378-aba8-d8a49abb01dd.png)

... and this on the other side

![image](https://user-images.githubusercontent.com/6536819/151810336-cc35a01f-d4d7-4035-8f3c-edc49b23fc40.png)

So we are matching each `slo_errors_per_request` with its corresponding `slo_threshold`.
