### PR TITLE
split apiserver rules for onprem and cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix `NoHealthyJumphost` alert routing.
+- Split apiserver routing for onprem and cloud.
+- Replaced deprecated apiserver latency metric
 
 ## [0.57.0] - 2022-01-25
 

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
@@ -14,11 +14,11 @@ spec:
     # expr produces 95th percentile latency for requests to the api server, by request verb.
     # verb WATCH is excluded because it produces a flat line and is not relevant.
     # apiserver_request_latencies_bucket are expressed in microseconds, dividing by 1e+06 bring this to seconds.
-    - alert: ManagementClusterAPIServerLatencyTooHighCloud
+    - alert: ManagementClusterAPIServerLatencyTooHigh
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
         opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"aws|azure|google"}[1h])) by (verb, le)) > 1
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT"}[1h])) by (verb, le)) > 1
       for: 1h
       labels:
         area: kaas
@@ -27,64 +27,27 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
-    - alert: ManagementClusterAPIServerLatencyTooHighOnprem
-      annotations:
-        description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
-        opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"kvm|openstack|vsphere"}[1h])) by (verb, le)) > 1
-      for: 1h
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_cluster_with_notready_nodepools: "true"
-        severity: notify
-        team: rocket
-        topic: managementcluster
-    - alert: ManagementClusterAPIServerAdmissionWebhookErrorsCloud
+    - alert: ManagementClusterAPIServerAdmissionWebhookErrors
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"aws|azure|google"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
       for: 5m
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
-    - alert: ManagementClusterAPIServerAdmissionWebhookErrorsOnprem
-      annotations:
-        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
-        opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"kvm|openstack|vsphere"}[5m]) > 0
-      for: 5m
-      labels:
-        area: kaas
-        severity: notify
-        team: rocket
-        topic: managementcluster
-    - alert: ManagementClusterWebhookDurationExceedsTimeoutCloud
+    - alert: ManagementClusterWebhookDurationExceedsTimeout
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"aws|azure|google"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"aws|azure|google"}[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas
         severity: page
-        team: phoenix
-        topic: managementcluster
-    - alert: ManagementClusterWebhookDurationExceedsTimeoutOnprem
-      annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
-        opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"kvm|openstack|vsphere"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"kvm|openstack|vsphere"}[5m]) > 8
-      for: 15m
-      labels:
-        area: kaas
-        severity: page
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
@@ -14,11 +14,11 @@ spec:
     # expr produces 95th percentile latency for requests to the api server, by request verb.
     # verb WATCH is excluded because it produces a flat line and is not relevant.
     # apiserver_request_latencies_bucket are expressed in microseconds, dividing by 1e+06 bring this to seconds.
-    - alert: ManagementClusterAPIServerLatencyTooHigh
+    - alert: ManagementClusterAPIServerLatencyTooHighCloud
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
         opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_latencies_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT"}[1h])) by (verb, le)) / 1e+06 > 1
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"aws|azure|google"}[1h])) by (verb, le)) > 1
       for: 1h
       labels:
         area: kaas
@@ -29,25 +29,62 @@ spec:
         severity: notify
         team: phoenix
         topic: managementcluster
-    - alert: ManagementClusterAPIServerAdmissionWebhookErrors
+    - alert: ManagementClusterAPIServerLatencyTooHighOnprem
+      annotations:
+        description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
+        opsrecipe: apiserver-overloaded/
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"kvm|openstack|vsphere"}[1h])) by (verb, le)) > 1
+      for: 1h
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_with_notready_nodepools: "true"
+        severity: notify
+        team: rocket
+        topic: managementcluster
+    - alert: ManagementClusterAPIServerAdmissionWebhookErrorsCloud
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"aws|azure|google"}[5m]) > 0
       for: 5m
       labels:
         area: kaas
         severity: notify
         team: phoenix
         topic: managementcluster
-    - alert: ManagementClusterWebhookDurationExceedsTimeout
+    - alert: ManagementClusterAPIServerAdmissionWebhookErrorsOnprem
+      annotations:
+        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"kvm|openstack|vsphere"}[5m]) > 0
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: rocket
+        topic: managementcluster
+    - alert: ManagementClusterWebhookDurationExceedsTimeoutCloud
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"aws|azure|google"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"aws|azure|google"}[5m]) > 8
       for: 15m
       labels:
         area: kaas
         severity: page
         team: phoenix
+        topic: managementcluster
+    - alert: ManagementClusterWebhookDurationExceedsTimeoutOnprem
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"kvm|openstack|vsphere"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"kvm|openstack|vsphere"}[5m]) > 8
+      for: 15m
+      labels:
+        area: kaas
+        severity: page
+        team: rocket
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -13,11 +13,11 @@ spec:
     rules:
     # expr produces 95th percentile latency for requests to the api server, by request verb.
     # verb WATCH is excluded because it produces a flat line and is not relevant.
-    - alert: WorkloadClusterAPIServerLatencyTooHighCloud
+    - alert: WorkloadClusterAPIServerLatencyTooHigh
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
         opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"aws|azure|google"}[1h])) by (verb, le)) > 1
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT"}[1h])) by (verb, le)) > 1
       for: 1h
       labels:
         area: kaas
@@ -26,64 +26,27 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
-    - alert: WorkloadClusterAPIServerLatencyTooHighOnprem
-      annotations:
-        description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
-        opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"kvm|openstack|vsphere"}[1h])) by (verb, le)) > 1
-      for: 1h
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_cluster_with_notready_nodepools: "true"
-        severity: notify
-        team: rocket
-        topic: kubernetes
-    - alert: WorkloadClusterAPIServerAdmissionWebhookErrorsCloud
+    - alert: WorkloadClusterAPIServerAdmissionWebhookErrors
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"aws|azure|google"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
       for: 5m
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
-    - alert: WorkloadClusterAPIServerAdmissionWebhookErrorsOnprem
-      annotations:
-        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
-        opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"kvm|openstack|vsphere"}[5m]) > 0
-      for: 5m
-      labels:
-        area: kaas
-        severity: notify
-        team: rocket
-        topic: kubernetes
-    - alert: WorkloadClusterWebhookDurationExceedsTimeoutCloud
+    - alert: WorkloadClusterWebhookDurationExceedsTimeout
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"aws|azure|google"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"aws|azure|google"}[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas
         severity: page
-        team: phoenix
-        topic: kubernetes
-    - alert: WorkloadClusterWebhookDurationExceedsTimeoutOnprem
-      annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
-        opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"kvm|openstack|vsphere"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"kvm|openstack|vsphere"}[5m]) > 8
-      for: 15m
-      labels:
-        area: kaas
-        severity: page
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -13,12 +13,11 @@ spec:
     rules:
     # expr produces 95th percentile latency for requests to the api server, by request verb.
     # verb WATCH is excluded because it produces a flat line and is not relevant.
-    # apiserver_request_latencies_bucket are expressed in microseconds, dividing by 1e+06 bring this to seconds.
-    - alert: WorkloadClusterAPIServerLatencyTooHigh
+    - alert: WorkloadClusterAPIServerLatencyTooHighCloud
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
         opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_latencies_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT"}[1h])) by (verb, le)) / 1e+06 > 1
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"aws|azure|google"}[1h])) by (verb, le)) > 1
       for: 1h
       labels:
         area: kaas
@@ -29,25 +28,62 @@ spec:
         severity: notify
         team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterAPIServerAdmissionWebhookErrors
+    - alert: WorkloadClusterAPIServerLatencyTooHighOnprem
+      annotations:
+        description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
+        opsrecipe: apiserver-overloaded/
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT", provider=~"kvm|openstack|vsphere"}[1h])) by (verb, le)) > 1
+      for: 1h
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_with_notready_nodepools: "true"
+        severity: notify
+        team: rocket
+        topic: kubernetes
+    - alert: WorkloadClusterAPIServerAdmissionWebhookErrorsCloud
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"aws|azure|google"}[5m]) > 0
       for: 5m
       labels:
         area: kaas
         severity: notify
         team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterWebhookDurationExceedsTimeout
+    - alert: WorkloadClusterAPIServerAdmissionWebhookErrorsOnprem
+      annotations:
+        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_rejection_count{error_type=~"calling_webhook_error|apiserver_internal_error", provider=~"kvm|openstack|vsphere"}[5m]) > 0
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: rocket
+        topic: kubernetes
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutCloud
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"aws|azure|google"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"aws|azure|google"}[5m]) > 8
       for: 15m
       labels:
         area: kaas
         severity: page
         team: phoenix
+        topic: kubernetes
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutOnprem
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum{provider=~"kvm|openstack|vsphere"}[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count{provider=~"kvm|openstack|vsphere"}[5m]) > 8
+      for: 15m
+      labels:
+        area: kaas
+        severity: page
+        team: rocket
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
@@ -39,7 +39,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd
     - alert: NoHealthyJumphost
       annotations:

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -82,8 +82,8 @@ spec:
       record: aggregation:kubelet:version
     - expr: sum(apiserver_request_total) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:apiserver_request_count
-    - expr: sum(apiserver_request_latencies_bucket) by (le, cluster_type, cluster_id)
-      record: aggregation:kubernetes:apiserver_request_latencies_bucket
+    - expr: sum(apiserver_request_duration_seconds_bucket) by (le, cluster_type, cluster_id)
+      record: aggregation:kubernetes:apiserver_request_duration_seconds_bucket
     - expr: sum(apiserver_audit_event_total) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:audit_event_total
     - expr: count(kube_configmap_created) by (cluster_type, cluster_id)


### PR DESCRIPTION
fixed the deprecated latency metric along the way


This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.