### PR TITLE
Remove ChartOrphanSecret rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `ChartOrphanSecret` rule that is no longer required.
+
 ## [0.57.1] - 2022-02-01
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/chart.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/chart.rules.yml
@@ -21,14 +21,3 @@ spec:
         severity: notify
         team: honeybadger
         topic: releng
-    - alert: ChartOrphanSecret
-      annotations:
-        description: '{{`Chart secrets have not been deleted.`}}'
-        opsrecipe: chart-orphan-resources/
-      expr: chart_operator_secret_orphan > 0
-      for: 10m
-      labels:
-        area: managedservices
-        severity: notify
-        team: honeybadger
-        topic: releng


### PR DESCRIPTION
This PR:

- Remove ChartOrphanSecret rule that is no longer required.

The alert is notify so we're not paying attention to it. This lets us remove this [silence](https://github.com/giantswarm/silences/blob/da166ccf94f66dc1a6cf2421209f1a845df59640/all-orphan-secrets.yaml).

We can't remove the silence because app-operator's older than 4.X create a secret so chart-operator can call a status webhook in app-operator with basic auth.

As of app-operator 4.X the chart CR watcher replaces this.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
