### PR TITLE
Updated many team ownership to be provider dependant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated team ownership to be provider dependant
+
 ## [1.0.0] - 2022-02-03
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/alertmanager-dashboard.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/alertmanager-dashboard.rules.yml
@@ -24,6 +24,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: atlas
         topic: monitoring
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
@@ -21,7 +21,7 @@ spec:
       labels:
         area: storage
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
     {{- if eq .Values.managementCluster.pipeline "testing" }}
     - alert: TestClusterTooOld

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -18,7 +18,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: observability
     - alert: CoreDNSLatencyTooHigh
       # There are two sub-queries here that need to be true for the alert to fire.
@@ -52,7 +52,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: dns
     - alert: CoreDNSDeploymentNotSatisfied
       annotations:
@@ -66,7 +66,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: dns
     - alert: CoreDNSMaxHPAReplicasReached
       expr: kube_hpa_status_current_replicas{hpa="coredns"} == kube_hpa_spec_max_replicas{hpa="coredns"} AND kube_hpa_spec_min_replicas{hpa="coredns"} != kube_hpa_spec_max_replicas{hpa="coredns"}

--- a/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -32,7 +32,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -44,7 +44,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -56,7 +56,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: PersistentVolumeSpaceTooLow
       annotations:
@@ -68,7 +68,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -80,7 +80,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: storage
     - alert: PrometheusPersistentVolumeSpaceTooLow
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
@@ -21,5 +21,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -20,7 +20,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdDBSizeTooLarge
       annotations:
@@ -31,7 +31,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
@@ -40,7 +40,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdHasNoLeader
       annotations:
@@ -51,5 +51,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd
     - alert: LatestETCDBackup1DayOld
       annotations:
@@ -36,7 +36,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd-backup
     - alert: LatestETCDBackup2DaysOld
       annotations:
@@ -51,7 +51,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd-backup
     - alert: ManagementClusterNotBackedUp24h
       annotations:
@@ -66,5 +66,5 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: etcd-backup

--- a/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
@@ -22,5 +22,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
@@ -22,5 +22,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: atlas
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/job.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/job.rules.yml
@@ -19,7 +19,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: JobHasNotBeenScheduledForTooLong

--- a/helm/prometheus-rules/templates/alerting-rules/kubelet.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kubelet.management-cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_instance_state_not_running: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
     - alert: KubeletDockerOperationsErrorsTooHigh
       annotations:
@@ -38,7 +38,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
@@ -52,7 +52,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
@@ -66,5 +66,5 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/net-exporter.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/net-exporter.management-cluster.rules.yml
@@ -19,5 +19,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/net-exporter.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/net-exporter.workload-cluster.rules.yml
@@ -19,5 +19,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/network.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.management-cluster.rules.yml
@@ -19,7 +19,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: network
     - alert: Network95thPercentileLatencyTooHigh
       annotations:
@@ -29,7 +29,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: network
     - alert: SYNRetransmissionRateTooHigh
       annotations:
@@ -39,5 +39,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: network

--- a/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules .yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules .yml
@@ -31,7 +31,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: NodeHasConstantOOMKills
       annotations:
@@ -44,7 +44,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
@@ -55,7 +55,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: MachineEntropyTooLow
       annotations:
@@ -66,7 +66,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure
     - alert: MachineAllocatedFileDescriptorsTooHigh
       annotations:
@@ -77,7 +77,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure
     # Alert if load average is 2 times the number of CPUs.
     - alert: MachineLoadTooHigh
@@ -88,7 +88,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure
     - alert: MachineMemoryUsageTooHigh
       annotations:
@@ -98,5 +98,5 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
@@ -20,7 +20,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure
     - alert: ManagementClusterDisabledSystemdUnitActive
       annotations:
@@ -31,5 +31,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -20,7 +20,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault
     - alert: VaultIsSealed
       annotations:
@@ -31,7 +31,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault
     - alert: ClusterServiceVaultTokenAlmostExpired
       annotations:
@@ -43,7 +43,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault
     - alert: ClusterServiceVaultTokenAlmostExpiredMissing
       annotations:
@@ -54,7 +54,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault
     - alert: CertOperatorVaultTokenAlmostExpired
       annotations:
@@ -66,7 +66,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault
     - alert: CertOperatorVaultTokenAlmostExpiredMissing
       annotations:
@@ -77,5 +77,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: vault


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

Sets the team ownership of several alerts based on the associated provider

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
