### PR TITLE
Add DeploymentNotSatisfiedFlux alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add managed prometheus to `ServiceLevelBurnRateTooHigh` alert.
+- Add `DeploymentNotSatisfiedFlux` alert.
 
 ## [1.1.0] - 2022-02-07
 

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -10,6 +10,20 @@ spec:
   groups:
   - name: fluxcd
     rules:
+    - alert: DeploymentNotSatisfiedFlux
+      annotations:
+        description: '{{`Flux deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"flux-.*"} > 0
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: honeybadger
+        topic: managementcluster
     - alert: FluxHelmReleaseFailed
       annotations:
         description: |-


### PR DESCRIPTION
This PR:

- adds `DeploymentNotSatisfiedFlux` alert, which covers Flux deployments in `flux-giantswarm` and `flux-system` namespaces.

Towards https://github.com/giantswarm/giantswarm/issues/19967

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
