### PR TITLE
Raise timeout before alerting for alerts that have `cancel_if_kube_state_metrics_down`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise timeout before alerting for alerts that have `cancel_if_kube_state_metrics_down`.
+
 ## [1.2.1] - 2022-02-15
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -28,7 +28,7 @@ spec:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
-      for: 5m
+      for: 25m
       labels:
         area: kaas
         cancel_if_kube_state_metrics_down: "true"
@@ -40,7 +40,7 @@ spec:
         description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-      for: 5m
+      for: 25m
       labels:
         area: kaas
         cancel_if_kube_state_metrics_down: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -108,7 +108,7 @@ spec:
         description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-      for: 5m
+      for: 25m
       labels:
         area: kaas
         cancel_if_kube_state_metrics_down: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20888

This PR:

Raises alert timeout for alerts that have cancel_if_kube_state_metrics_down = true.
This is because when a customer deletes all node pools from a cluster, kube_state_metrics goes down almost immediately but the inhibition might take a while before is in place. Increasing the timeout should help with false positives.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
