### PR TITLE
Suspend alert for GS Flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `GSFluxSuspendedForTooLong` alert.
+
 ## [1.3.0] - 2022-02-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `GSFluxSuspendedForTooLong` alert.
+- Add `FluxSuspendedForTooLong` alert.
 
 ## [1.3.0] - 2022-02-16
 

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -114,3 +114,15 @@ spec:
         severity: page
         team: honeybadger
         topic: releng
+    - alert: GSFluxSuspendedForTooLong
+      annotations:
+        description: |-
+          {{`The {{ $labels.name }} {{ $labels.kind }} resource on {{ $labels.installation }} has been suspended for 24h.`}}
+      expr: gotk_suspend_status{namespace="flux-giantswarm"} > 0
+      for: 24h
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: honeybadger
+        topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -117,7 +117,7 @@ spec:
     - alert: FluxSuspendedForTooLong
       annotations:
         description: |-
-          {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns giantswarm on {{ $labels.installation }} has been suspended for 24h.`}}
+          {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }} has been suspended for 24h.`}}
       expr: gotk_suspend_status{namespace="flux-giantswarm"} > 0
       for: 24h
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -114,7 +114,7 @@ spec:
         severity: page
         team: honeybadger
         topic: releng
-    - alert: GSFluxSuspendedForTooLong
+    - alert: FluxSuspendedForTooLong
       annotations:
         description: |-
           {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns giantswarm on {{ $labels.installation }} has been suspended for 24h.`}}
@@ -123,6 +123,6 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -117,7 +117,7 @@ spec:
     - alert: GSFluxSuspendedForTooLong
       annotations:
         description: |-
-          {{`The {{ $labels.name }} {{ $labels.kind }} resource on {{ $labels.installation }} has been suspended for 24h.`}}
+          {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns giantswarm on {{ $labels.installation }} has been suspended for 24h.`}}
       expr: gotk_suspend_status{namespace="flux-giantswarm"} > 0
       for: 24h
       labels:


### PR DESCRIPTION
### Description

The `GSFluxSuspendedForTooLong` checks for suspended resources in the `giantswarm` namespace. Towards: https://github.com/giantswarm/giantswarm/issues/20984

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
