### PR TITLE
Add `CoreDNSLoadUnbalanced` alert to check when DNS traffic is served…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `CoreDNSLoadUnbalanced` alert to check when DNS traffic is served by a subset of the coredns pods.
+
 ## [1.4.1] - 2022-02-23
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -79,3 +79,16 @@ spec:
         topic: dns
       annotations:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled to its maximum replica count for too long.`}}'
+    # This alert checks the percentage of the dns requests that are handled by a single pod. The result of the query should always be 0 (that means load is spread evenly between all coredns pods).
+    # If it's > 20 for 10 minutes there is something weird happening in the cluster.
+    - alert: CoreDNSLoadUnbalanced
+      expr: (sum by (pod) (rate(coredns_dns_requests_total[10m])) / ignoring (pod) group_left sum(rate(coredns_dns_requests_total[10m])) * 100) - ignoring (pod) group_left 100 / sum(kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
+      for: 10m
+      labels:
+        area: kaas
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: dns
+      annotations:
+        description: '{{`CoreDNS Load has been unbalanced for more than 10m.`}}'
+        opsrecipe: core-dns-unbalanced/


### PR DESCRIPTION
… by a subset of the coredns pods.

Towards: https://github.com/giantswarm/roadmap/issues/849

This PR:

- adds a new alert for when a subset of coredns pods is handling all DNS traffic.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
