### PR TITLE
Fixed query for `CoreDNSLoadUnbalanced` to make it work across all cl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed query for `CoreDNSLoadUnbalanced` to make it work across all clusters in a MC.
+
 ## [1.5.0] - 2022-02-25
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -82,7 +82,7 @@ spec:
     # This alert checks the percentage of the dns requests that are handled by a single pod. The result of the query should always be 0 (that means load is spread evenly between all coredns pods).
     # If it's > 20 for 10 minutes there is something weird happening in the cluster.
     - alert: CoreDNSLoadUnbalanced
-      expr: (sum by (pod) (rate(coredns_dns_requests_total[10m])) / ignoring (pod) group_left sum(rate(coredns_dns_requests_total[10m])) * 100) - ignoring (pod) group_left 100 / sum(kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
+      expr: (sum by(cluster_id,pod) (rate(coredns_dns_requests_total[10m])) / ignoring(pod) group_left sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) * 100) - ignoring(pod) group_left 100 / sum by (cluster_id) (kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
…usters in a MC.

Towards: https://github.com/giantswarm/roadmap/issues/849

this fixed the query for a newly created alert in order to work also when run across promxy

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
