### PR TITLE
fix `kube_node_status_capacity_pods` metrics

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -50,7 +50,7 @@ spec:
     - alert: WorkloadClusterPodLimitAlmostReachedAzure
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
-      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity{resource="pods"}) by (cluster_id)) > 0.8
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -60,7 +60,7 @@ spec:
     - alert: ManagementClusterPodLimitAlmostReachedKVM
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
-      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity{resource="pods"}) by (cluster_id)) > 0.8
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -38,7 +38,7 @@ spec:
     - alert: WorkloadClusterPodLimitAlmostReachedKVM
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
-      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity{resource="pods"}) by (cluster_id)) > 0.8
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -82,7 +82,7 @@ spec:
     - alert: ManagementClusterPodLimitAlmostReached
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
-      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity{resource="pods"}) by (cluster_id)) > 0.8
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/flexshopper/issues/28

Fixing broken metrics from [kube-state-metrics 2.x upgrade](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-alpha)