### PR TITLE
send operatorkit errors to provider teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split `OperatorkitErrorRateTooHighRocket` out to provider teams.
+
 ## [1.5.1] - 2022-02-25
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -119,7 +119,7 @@ spec:
 
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.
-    - alert: OperatorkitErrorRateTooHighRocket
+    - alert: OperatorkitErrorRateTooHighKaas
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
@@ -128,7 +128,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: qa
     # It might happen that CRs get orphaned or deletion gets kind of stuck during
     # the cleanup process. Then we want to get notified and figure out what went


### PR DESCRIPTION
This PR:

- splits `OperatorkitErrorRateTooHigh` out to provider teams.

(Rocket receives alerts for cert-operator on gauss, for example)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
