### PR TITLE
Fix Division By Zero error in `WorkloadClusterWebhookDurationExceedsTimeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Division By Zero error in `WorkloadClusterWebhookDurationExceedsTimeout`.
+
 ## [1.5.2] - 2022-02-25
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20251

added a `> 0` check to avoid a division by zero that could trigger false alerts.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
