### PR TITLE
Don't page on unused node exporter collectors

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: NodeExporterCollectorFailed
       annotations:
         description: '{{`NodeExporter Collector {{ $labels.collector }} on {{ $labels.instance }} is failed.`}}'
-      expr: node_scrape_collector_success{collector!~"bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd"} == 0
+      expr: node_scrape_collector_success{collector!~"bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|"} == 0
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
[This alert is firing](https://prometheus.g8s.gorilla.eu-central-1.aws.gigantic.io/rfjh2/graph?g0.expr=ALERTS%7Balertname%3D%22NodeExporterCollectorFailed%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0.g0.range_input=1h.) on AWS installations but we don't really care about those collectors