### PR TITLE
Check if there is a meaningful number of DNS queries before firing `CoreDNSLoadUnbalanced`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Check if there is a meaningful number of DNS queries before firing `CoreDNSLoadUnbalanced`.
+
 ## [1.5.4] - 2022-03-04
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -81,8 +81,9 @@ spec:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled to its maximum replica count for too long.`}}'
     # This alert checks the percentage of the dns requests that are handled by a single pod. The result of the query should always be 0 (that means load is spread evenly between all coredns pods).
     # If it's > 20 for 10 minutes there is something weird happening in the cluster.
+    # This is only relevant if there is a meaningful number of DNS requests happening
     - alert: CoreDNSLoadUnbalanced
-      expr: (sum by(cluster_id,pod) (rate(coredns_dns_requests_total[10m])) / ignoring(pod) group_left sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) * 100) - ignoring(pod) group_left 100 / sum by (cluster_id) (kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
+      expr: sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) > 10 AND (sum by(cluster_id,pod) (rate(coredns_dns_requests_total[10m])) / ignoring(pod) group_left sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) * 100) - ignoring(pod) group_left 100 / sum by (cluster_id) (kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/828

When enabling node local dns cache on a cluster, the load towards classic coredns pods is so low that it makes the Unbalanced alert fire. But in this scenario is not a problem at all, so with this PR we require at least a few requests to be made otherwise we don't fire the alert.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
