### PR TITLE
Restrict `WorkloadClusterEtcdDown` query in order to avoid false alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Print `PrometheusRuleFailures` decimals.
+- Restrict `WorkloadClusterEtcdDown` query in order to avoid false alerts.
 
 ## [1.6.0] - 2022-03-07
 

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) on workload cluster {{ $labels.cluster_id }} is down.`}}'
         opsrecipe: etcd-down/
-      expr: up{cluster_type="workload_cluster", app=~"etcd.*"} == 0
+      expr: up{cluster_type="workload_cluster", app="etcd"} == 0
       for: 20m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/882

The WorkloadClusterEtcdDown query was using `app=~"etcd.*"` but this might pick up too much stuff.

![app](https://user-images.githubusercontent.com/868430/158837142-fedae1fe-80e3-4a61-9553-993d60b5605f.png)

the value of the `app` label for the `up` metric for etcd is exactly "etcd" so I restricted the query to avoid false alerts

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
