### PR TITLE
Removed `ManagementClusterPodPendingFor15Min` and `ManagementClusterPodPending`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `ManagementClusterPodPendingFor15Min` and `ManagementClusterPodPending`.
+
 ## [1.6.1] - 2022-03-17
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -12,28 +12,6 @@ spec:
   - name: management-cluster
     rules:
     {{- if or (eq .Values.managementCluster.provider.kind "aws") (eq .Values.managementCluster.provider.kind "azure") }}
-    - alert: ManagementClusterPodPendingFor15Min
-      annotations:
-        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
-      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending",pod!~"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
-      for: 15m
-      labels:
-        area: kaas
-        severity: notify
-        team: phoenix
-        topic: managementcluster
-    - alert: ManagementClusterPodPending
-      annotations:
-        description: '{{`Pod {{ $labels.pod }} is stuck in Pending.`}}'
-        opsrecipe: management-cluster-pod-pending/
-      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending", pod!~"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
-      for: 1h
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: phoenix
-        topic: managementcluster
     - alert: ManagementClusterHasLessThanThreeNodes
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} has less than 3 nodes.`}}'


### PR DESCRIPTION
The `ManagementClusterPodPendingFor15Min` and `ManagementClusterPodPending` make no sense at all.
They page phoenix/cloud kaas area for any pod being pending EXCEPT the actual pods that belong to phoenix + prometheus.
Phoenix has specific alerts for pods they care about not being running properly, so this alerts are useless to us.
Every team should have similar alerts for all pods they need to be running in management clusters.

For this reason we decided to ditch those alerts.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
