### PR TITLE
Inhibit WorkloadClusterAppFailedPhoenix if cluster has no workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Inhibit `WorkloadClusterAppFailedPhoenix` if cluster has no worker nodes
+
 ## [1.7.0] - 2022-03-22
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -185,6 +185,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         sig: none
         team: phoenix


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

- inhibits the `WorkloadClusterAppFailedPhoenix` alert if the cluster has no worker nodes

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
