### PR TITLE
[MC] Add new alert for when `Kyverno` scraping fails for 5m.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert for when `Kyverno` scraping fails for 5m.
+
 ## [1.7.1] - 2022-03-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kyverno.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kyverno.rules.yml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: kyverno.management_cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+    - name: kyverno
+      rules:
+        - alert: NoKyvernoPodRunning
+          annotations:
+            description: '{{`Scraping of all kyverno pods failed for 5 minutes.`}}'
+            opsrecipe: kyverno-is-not-running/
+          expr: (count(up{service="kyverno-svc-metrics"}) or vector(0)) == 0
+          for: 5m
+          labels:
+            area: kaas
+            severity: page
+            team: honeybadger
+            topic: managementcluster
+            cancel_if_cluster_status_creating: "true"
+            cancel_if_cluster_status_deleting: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/kyverno.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kyverno.rules.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     cluster_type: "management_cluster"
-  name: kyverno.management_cluster.rules
+  name: kyverno.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/903

@giantswarm/team-honeybadger what do you think about this?
If anything happens to a management cluster and it turns down all replicas of kyverno, the cluster stops working until kyverno runs again.
As owners of kyverno, reliability is your responsibility as much as reliability of the cluster nodes health is Phoenix's.

We therefore believe that if such thing happens both us and you should be paged.