### PR TITLE
Fix recording query to gather total number of Pods and Containers in a cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.9.0] - 2022-03-24
+### Fixed
 
+- Fix recording query to gather total number of Pods and Containers in a cluster.
+
+## [1.9.0] - 2022-03-24
 
 ### Added
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -74,9 +74,9 @@ spec:
       record: aggregation:giantswarm:passage_requests
     - expr: sum(rate(nginx_ingress_controller_nginx_process_requests_total[5m])) by (cluster_type, cluster_id)
       record: aggregation:ingress:requests_total
-    - expr: sum(kubelet_running_container_count) by (cluster_type, cluster_id)
+    - expr: sum(kubelet_running_container_count or kubelet_running_containers{container_state="running"}) by (cluster_type, cluster_id)
       record: aggregation:kubelet:running_container_total
-    - expr: sum(kubelet_running_pod_count) by (cluster_type, cluster_id)
+    - expr: sum(kubelet_running_pod_count or kubelet_running_pods) by (cluster_type, cluster_id)
       record: aggregation:kubelet:running_pod_total
     - expr: sum by(cluster_type, git_version, cluster_id) (label_replace(kubernetes_build_info{app="kubelet"}, "git_version", "$1", "gitVersion", "(.+)"))
       record: aggregation:kubelet:version


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20487

The `Pods` and  `Containers` charts were based on the `kubelet_running_pod_count` and `kubelet_running_container_count` metrics that are renamed to `kubelet_running_pods` and `kubelet_running_containers` in newer k8s versions

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
