### PR TITLE
Add namespace monitoring to heartbeat alerts

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -18,6 +18,7 @@ spec:
         team: "atlas"
         topic: "observability"
         type: "heartbeat"
+        namespace: "monitoring" # Needed due to https://github.com/prometheus-operator/prometheus-operator/issues/3737
       annotations:
         description: This alert is used to ensure the entire alerting pipeline is functional.
     - alert: "MatchingNumberOfPrometheusAndCluster"


### PR DESCRIPTION
This PR Add namespace monitoring to heartbeat alerts to be supported by the primetheus operator


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
