### PR TITLE
Adds aggregations for kong metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add aggregations for kong metrics
+
 ## [2.8.0] - 2022-03-24
 
 ## [1.9.1] - 2022-03-24

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -225,3 +225,8 @@ spec:
     # Starboard unique vulnerability counts by severity
     - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)
       record: aggregation:starboard_unique_vulnerability_count
+    # Kong metrics
+    - expr: kong_nginx_http_current_connections
+      record: aggregation:kong:nginx_http_current_connections
+    - expr: container_memory_usage_bytes{namespace=~"kong.*", container=~"proxy|ingress-controller"}
+      record: aggregation:kong:memory_usage_bytes


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21426

This PR:

- adds aggregation recording rules for Kong metrics

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
