### PR TITLE
Improve `OperatorkitErrorRateTooHighPhoenix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve `OperatorkitErrorRateTooHighPhoenix` to page only if a meaningful numer of errors is happening.
+
 ## [2.9.0] - 2022-03-29
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/operatorkit.rules.yml
@@ -36,8 +36,8 @@ spec:
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
-      expr: operatorkit_controller_error_total{app=~"azure-operator.*"} > 5
-      for: 1m
+      expr: rate(operatorkit_controller_error_total{app=~"azure-.*|aws-.*"}[5m]) > 1
+      for: 10m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
Improve the OperatorKitErrorRateTooHighPhoenix alert to page according to rate of errors rather than to absolute number in order to make it less sensitive during MC rollouts.
Also include aws-operator in the alert.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
