### PR TITLE
Use plain kube-state-metrics metrics for IngressControllerDeploymentNotSatisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Avoid alerting if `nvme` collector in node exporter is down on Azure.
+- Use plain kube-state-metrics metrics for `IngressControllerDeploymentNotSatisfied` until [kube-state-metrics-app v1.9.0](https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.9.0) is available in all WCs.
 
 ## [2.10.0] - 2022-03-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -14,7 +14,10 @@ spec:
       annotations:
         description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: ingress-controller-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_available{managed_app="nginx-ingress-controller"} / (managed_app_deployment_status_replicas_available{managed_app="nginx-ingress-controller"} + managed_app_deployment_status_replicas_unavailable{managed_app="nginx-ingress-controller"}) * 100 < 51
+      # Not using the gs-managed-app-deployments.recording rules because we're missing required labels until
+      # kube-state-metrics-app 1.9.0 is rolled out into WCs
+      # check git-blame to find the correct expression
+      expr: kube_deployment_status_replicas_available{deployment=~".*nginx-ingress-controller-app.*"} / (kube_deployment_status_replicas_available{deployment=~".*nginx-ingress-controller-app.*"} + kube_deployment_status_replicas_unavailable{deployment=~".*nginx-ingress-controller-app.*"}) * 100 < 51
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: gs-managed-app-deployment-status.recording.rules
-  namespace: {{ .Values.namespace  }}
+  namespace: {{ .Values.namespace }}
 spec:
   groups:
   - name: gs-managed-app-deployments.recording


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21615

Use the plain old kube_deployment_... metrics for `IngressControllerDeploymentNotSatisfied`. Some update of kube-state-metrics removed required labels so we have to wait for rollout into new platform releases.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).

