### PR TITLE
add PrometheusTargetMissing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `PrometheusTargetMissing` alert.
+
 ## [2.11.0] - 2022-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -51,3 +51,15 @@ spec:
         team: atlas
         topic: observability
         cancel_if_outside_working_hours: "true"
+    - alert: PrometheusTargetMissing
+      annotations:
+        description: {{`No targets were found for the job {{$labels.scrape_job}} in prometheus {{$labels.installation}}/{{$labels.cluster_id}}.`}}
+        summary: Targets are missing
+      expr: prometheus_target_metadata_cache_entries == 0
+      for: 1h
+      labels:
+        area: empowerment
+        severity: page
+        team: atlas
+        topic: observability
+        cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21156

Add `PrometheusTargetMissing` alert, so we are alerted when a job has 0 targets.

This needs to be tested everywhere first, because I have the feeling many targets are missing.