### PR TITLE
Extend `InhibitionOutsideWorkingHours` to also fire during ascension day 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extend `InhibitionOutsideWorkingHours` to also fire during ascension day 2022.
+
 ## [2.11.0] - 2022-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: InhibitionOutsideWorkingHours
       annotations:
         description: '{{`Fires outside working hours.`}}'
-      expr: (hour() <= 7 or hour() >= 16) or (day_of_week() > 5 or day_of_week() < 1)
+      expr: (hour() <= 7 or hour() >= 16) or (day_of_week() > 5 or day_of_week() < 1) or (day_of_month() == 18 and month() == 4 and year() == 2022)
       labels:
         area: empowerment
         nodes_down: "true"


### PR DESCRIPTION
See: https://gigantic.slack.com/archives/C99HAM8DS/p1649403138243179

This PR:

- Extend `InhibitionOutsideWorkingHours` to also fire during ascension day 2022.

This is needed in order not to fire for business hours alerts during a bank holiday.
Just a dirty hack before we find a better way of handling this.

cc @calvix 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
