### PR TITLE
Ship failing Kyverno policy numbers to Cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push failing Kyverno policy information to Cortex.
+
 ## [2.11.0] - 2022-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -222,6 +222,9 @@ spec:
     # Falco event counts
     - expr: sum(falco_events{priority=~"0|1|2|3|4|5|6|7"}) by (cluster_type, cluster_id, priority, rule)
       record: aggregation:falco_events
+    # Kyverno failing policies
+    - expr: sum(kyverno_policy_results_total{rule_result="fail"}) by (policy_type, policy_name)
+      record: aggregation:kyverno_policy_failures
     # Starboard unique vulnerability counts by severity
     - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)
       record: aggregation:starboard_unique_vulnerability_count


### PR DESCRIPTION
This PR:

- sends the number of failures for a given kyverno policy to cortex

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
