### PR TITLE
Disable vault and cluster-service rules for CAPO and CAPV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `cluster-service` and `vault` rules for CAPO and CAPV.
+
 ## [2.12.0] - 2022-04-11
 
 ### Added

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -42,3 +42,19 @@ phoenix
 "false"
 {{- end -}}
 {{- end -}}
+
+{{- define "isClusterServiceInstalled" -}}
+{{- if has .Values.managementCluster.provider.kind (list "openstack" "vsphere") -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "isVaultBeingMonitored" -}}
+{{- if has .Values.managementCluster.provider.kind (list "openstack" "vsphere") -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "isClusterServiceInstalled" .) "true" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -32,3 +33,4 @@ spec:
       labels:
         severity: notify
     {{- end }}
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "isVaultBeingMonitored" .) "true" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -83,3 +84,4 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: vault
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/640

We don't install `cluster-service` into CAPO and CAPV clusters. We don't have `vault` machine as well. We deploy vault into MC now. Vault monitoring will be supported soon but we need to disable those now.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
