### PR TITLE
Disable bastion alerts for CAPO/CAPV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `NoHealthyJumphost` for CAPO and CAPV.
+
 ## [2.13.0] - 2022-04-11
 
 ### Changed

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -58,3 +58,11 @@ false
 true
 {{- end -}}
 {{- end -}}
+
+{{- define "isBastionBeingMonitored" -}}
+{{- if has .Values.managementCluster.provider.kind (list "openstack" "vsphere") -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}

--- a/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
@@ -43,6 +43,7 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd
+    {{- if eq (include "isBastionBeingMonitored" .) "true" }}
     - alert: NoHealthyJumphost
       annotations:
         description: '{{`There are no healthy jumphosts available.`}}'
@@ -55,3 +56,4 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: managementcluster
+    {{- end }}


### PR DESCRIPTION
We have some `NoHealthyJumphost` alerts for different clusters now since bastion monitoring is not enabled yet.  It will be added in the scope of https://github.com/giantswarm/roadmap/issues/1030

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
