### PR TITLE
Fix opsrecipe link for KiamSTSIssuingErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Opsrecipie link for `KiamSTSIssuingErrors`
+
 ## [2.14.0] - 2022-04-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
@@ -30,7 +30,7 @@ spec:
     - alert: KiamSTSIssuingErrors
       annotations:
         description: '{{`Kiam pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has increased STS issuing errors.`}}'
-        opsrecipe: kiam_sts_issuing_errors_total/
+        opsrecipe: kiam-sts-issue-errors/
       expr: rate(kiam_sts_issuing_errors_total[15m]) > 0.10
       for: 15m
       labels:


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

- fixes the opsrecipe link for `KiamSTSIssuingErrors`

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
