### PR TITLE
Fixed query for kubelet SLO requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed query for kubelet SLO requests.
+
 ## [2.14.1] - 2022-04-12
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -78,7 +78,7 @@ spec:
       record: slo_target
 
       # -- kubelet
-    - expr: "kube_node_status_condition{condition='Ready'}"
+    - expr: "kube_node_status_condition{condition='Ready',status='true'}"
       labels:
         class: MEDIUM
         area: kaas


### PR DESCRIPTION
The `raw_slo_requests` query for `kubelet` used to have this query:

```
kube_node_status_condition{condition='Ready'}
```

This is wrong, because it returns the same node twice:

```
kube_node_status_condition{..., node="ip-10-5-0-123.ec2.internal", ..., status="false"} | 0
-- | --
kube_node_status_condition{..., node="ip-10-5-0-123.ec2.internal", ... , status="true"}
```

This makes the SLO calculation wrong, as it thinks the size of the cluster is double what it actually is.

This PR fixes this problem

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
