### PR TITLE
Remove exception from `InhibitionOutsideWorkingHours` for ascension day 2022.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove exception from `InhibitionOutsideWorkingHours` for ascension day 2022.
+
 ### Fixed
 
 - Fixed query for kubelet SLO requests.

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: InhibitionOutsideWorkingHours
       annotations:
         description: '{{`Fires outside working hours.`}}'
-      expr: (hour() <= 7 or hour() >= 16) or (day_of_week() > 5 or day_of_week() < 1) or (day_of_month() == 18 and month() == 4 and year() == 2022)
+      expr: (hour() <= 7 or hour() >= 16) or (day_of_week() > 5 or day_of_week() < 1)
       labels:
         area: empowerment
         nodes_down: "true"


### PR DESCRIPTION
This PR:

- removed exception for 2022 ascension day from business hours inhibition

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
