### PR TITLE
Increase cert expiration alert to a month for KVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increase the cert expiration alert to page before a month in KVM installations.
 - Remove exception from `InhibitionOutsideWorkingHours` for ascension day 2022.
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
@@ -11,11 +11,11 @@ spec:
   groups:
   - name: certificate
     rules:
-    - alert: ManagementClusterKVMCertificateWillExpireInLessThanTwoWeeks
+    - alert: ManagementClusterKVMCertificateWillExpireInLessThanOneMonth
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than a month.`}}'
         opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="kvm", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="kvm", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 4 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
This PR:

- Give us more bandwidth to deal with the situation, important in KVM since the customer can have multiple WCs

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
