### PR TITLE
Nodepool SLO alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new SLO metric for nodepool-specific node health.
+
 ### Changed
 
 - Remove exception from `InhibitionOutsideWorkingHours` for ascension day 2022.

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -77,7 +77,7 @@ spec:
         area: kaas
       record: slo_target
 
-      # -- kubelet
+      # -- kubelet whole cluster
     - expr: "kube_node_status_condition{condition='Ready',status='true'}"
       labels:
         class: MEDIUM
@@ -99,6 +99,33 @@ spec:
       record: raw_slo_errors
       # -- 99% availability
     - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+        service: kubelet
+      record: slo_target
+
+    # kubelet - single nodepool
+    - expr: label_replace(kube_node_labels{nodepool=~".+"}, "service", "kubelet nodepool $1", "nodepool", "(.+)")
+      labels:
+        area: kaas
+        class: MEDIUM
+      record: raw_slo_requests
+
+    - expr: |
+        (
+          label_replace((kube_node_status_condition{condition="Ready", status!="true"} + on (node) group_left(nodepool) kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.*)")
+          and
+          on (node) kube_node_spec_unschedulable == 0
+        )
+        and
+        on (node) time() - kube_node_created > 10 * 60
+      labels:
+        area: kaas
+        class: MEDIUM
+        record: raw_slo_errors
+
+    - expr: |
+        label_replace(count by (nodepool) (kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.+)") * (1 - 0.99)
       labels:
         area: kaas
         service: kubelet

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -122,7 +122,7 @@ spec:
       labels:
         area: kaas
         class: MEDIUM
-        record: raw_slo_errors
+      record: raw_slo_errors
 
     - expr: |
         label_replace(count by (nodepool) (kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.+)") * (1 - 0.99)

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -113,7 +113,7 @@ spec:
 
     - expr: |
         (
-          label_replace((kube_node_status_condition{condition="Ready", status!="true"} + on (node) group_left(nodepool) kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.*)")
+          label_replace((kube_node_status_condition{condition="Ready", status!="true"} * on (node) group_left(nodepool) kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.*)")
           and
           on (node) kube_node_spec_unschedulable == 0
         )

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -125,7 +125,7 @@ spec:
       record: raw_slo_errors
 
     - expr: |
-        label_replace(count by (nodepool) (kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.+)") * (1 - 0.99)
+        label_replace(max by (nodepool) (kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.+)") * (1 - 0.99)
       labels:
         area: kaas
       record: slo_target

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -128,7 +128,6 @@ spec:
         label_replace(count by (nodepool) (kube_node_labels{nodepool=~".+"}), "service", "kubelet nodepool $1", "nodepool", "(.+)") * (1 - 0.99)
       labels:
         area: kaas
-        service: kubelet
       record: slo_target
 
       # -- node-exporter


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21428

The current SLO alert for the `kubelet` service takes into account all nodes as a whole, not considering single node pools.
Sometimes this might be not ideal, because one node being down in a 10 nodes node pool as a different impact than a node being down in a 2 nodes node pool.

Starting from kube-state-metrics-app version 1.10.0, we now have the `nodepool` label available so we can split node health metrics by node pool.

This PR leverages this new available info and exposes SLO metrics by node pool.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
