### PR TITLE
Fix query for `WorkloadClusterCertificateWillExpireMetricMissing` ale…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix query for `WorkloadClusterCertificateWillExpireMetricMissing` alert and rename to `ClusterCertificateWillExpireMetricMissing`.
+
 ## [2.15.0] - 2022-04-20
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -42,6 +42,10 @@ spec:
       for: 30m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
         team: {{ include "providerTeam" . }}
         topic: security

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -35,10 +35,10 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: security
-    - alert: WorkloadClusterCertificateWillExpireMetricMissing
+    - alert: ClusterCertificateWillExpireMetricMissing
       annotations:
         description: '{{`Certificate metrics are missing for cluster {{ $labels.cluster_id }}.`}}'
-      expr: count(up{app="cert-exporter",cluster_type="workload_cluster"} == 1) by (cluster_id) unless count(cert_exporter_not_after{cluster_type="workload_cluster"}) by (cluster_id)
+      expr: max(up{cluster_id!=""}) by (cluster_id) unless on (cluster_id) count (cert_exporter_not_after) by (cluster_id) > 0
       for: 30m
       labels:
         area: kaas


### PR DESCRIPTION
…rt and rename to `ClusterCertificateWillExpireMetricMissing`.

Towards: https://github.com/giantswarm/giantswarm/issues/21951

cert-exporter was down for weeks on one WC and we didn't notice.
This PR fixes the query that should page when 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
