### PR TITLE
Rename alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Rename `ClusterCertificateWillExpireMetricMissing` alert to `ClusterCertificateExpirationMetricsMissing` to avoid being paged for test installations.
+
 ## [2.16.0] - 2022-05-04
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -36,7 +36,7 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: security
-    - alert: ClusterCertificateWillExpireMetricMissing
+    - alert: ClusterCertificateExpirationMetricsMissing
       annotations:
         description: '{{`Certificate metrics are missing for cluster {{ $labels.cluster_id }}.`}}'
       expr: max(up{cluster_id!=""}) by (cluster_id) unless on (cluster_id) count (cert_exporter_not_after) by (cluster_id) > 0


### PR DESCRIPTION
Rename `ClusterCertificateWillExpireMetricMissing` alert to `ClusterCertificateExpirationMetricsMissing` to avoid being paged for test installations.

After turning ClusterCertificateWillExpireMetricMissing from a Notify to a Page alert, it started paging for all clusters, including testing ones.
The reason is that, in the notification policy, we page for test clusters if alerts contain the word `CertificateWillExpire` in the `message`:

![test](https://user-images.githubusercontent.com/868430/166691110-541429a9-5a49-4b91-a380-403af13eadec.png)

This PR renames the alert in order not to contain that word in the message.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
