### PR TITLE
Fix service level rule failing for prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Service Level alert for prometheus.
+
 ## [2.16.1] - 2022-05-04
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -247,7 +247,7 @@ spec:
       record: raw_slo_requests
       # -- 99% availability
       # -- this expression collects all the services from the area managed apps and assigns the same slo target to all of them
-    - expr: sum by (service, area) (raw_slo_errors{area="managed-apps"} - raw_slo_errors{area="managed-apps"}) + 1-0.99
+    - expr: sum by (service, area, class) (raw_slo_errors{area="managed-apps"} - raw_slo_errors{area="managed-apps"}) + 1-0.99
       record: slo_target
 
     # core k8s components internal API requests
@@ -322,12 +322,6 @@ spec:
         class: MEDIUM
         service: managed-prometheus
       record: raw_slo_errors
-    - expr: "vector((1 - 0.999))"
-      labels:
-        area: managed-apps
-        class: MEDIUM
-        service: managed-prometheus
-      record: slo_target
 
       # -- generic stuff
       # -- standard burnrates based on https://sre.google/workbook/alerting-on-slos/#6-multiwindow-multi-burn-rate-alerts


### PR DESCRIPTION
This PR:

fixes prometheus rule failing due to 2 slo target for managed prometheus as the slo target is also created by  

- expr: sum by (service, area) (raw_slo_errors{area="managed-apps"} - raw_slo_errors{area="managed-apps"}) + 1-0.99
  record: slo_target

![image](https://user-images.githubusercontent.com/2787548/167104874-35f3976e-2bd2-4e91-8cfc-f10928cf2794.png)
![image](https://user-images.githubusercontent.com/2787548/167105057-8bc1647d-a707-4481-bfa0-a43742cf8de0.png)


### Checklist

- [x] Update changelog in CHANGELOG.md.
