### PR TITLE
Improve '*EtcdDBSizeTooLarge' alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve '*EtcdDBSizeTooLarge' alerts.
+
 ## [2.18.0] - 2022-05-11
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} > 500 * 1024 * 1024
+      expr:(etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) > 200000000
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} > 500 * 1024 * 1024
+      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) > 200000000
       for: 35m
       labels:
         area: kaas


### PR DESCRIPTION
What defines an etcd as "too large"? I reckon not the absolute size because a 100 nodes cluster will definitely have a bigger etcd database compared to a 10 nodes one.
In my opinion, this alert should fire then the total size on disk of etcd DB is bigger than the used size as reported by etcd metrics.
That means that the database needs a defragmentation to free disk space (and that's what the ops recipe wants to do).

This PR changes the query, in order for the alert not to page when the absolute size is > 500M, but to page when the difference between disk and used space differ by more than 200M.

WDYT?

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
