### PR TITLE
Change `*EtcdDBSizeTooLarge`'s `for` to `7h` to catch when automated defrag is not happening.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `*EtcdDBSizeTooLarge`'s `for` to `7h` to catch when automated defrag is not happening.
+
 ## [2.19.0] - 2022-05-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -28,7 +28,7 @@ spec:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
       expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) > 200000000
-      for: 10m
+      for: 7h
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -44,7 +44,7 @@ spec:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
       expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) > 200000000
-      for: 35m
+      for: 7h
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
Automated defrag happens every 6 hours (by etcd backup operator).
It might be that this alert fires for up to 6h because simply defrag didn't happen yet.
This PR changes the `for` to 7h to make the alert only fire when there is actually a problem.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
