### PR TITLE
Relax regex for managed deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add kong to `WorkloadClusterManagedDeploymentNotSatisfied` alert.
+- Relax external-dns and cert-manager managed app names in `WorkloadClusterManagedDeploymentNotSatisfied` alert.
+
 ## [2.20.0] - 2022-05-13
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager|external-dns"} > 0
+      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*|external-dns.*|kong.*"} > 0
       for: 30m
       labels:
         area: managedservices


### PR DESCRIPTION
This PR:

- Add kong to `WorkloadClusterManagedDeploymentNotSatisfied` alert.
- Relax external-dns and cert-manager managed app names in `WorkloadClusterManagedDeploymentNotSatisfied` alert.

@giantswarm/team-honeybadger this is the alert where routing depends on the team label right?

### Checklist

- [x] Update changelog in CHANGELOG.md.

