### PR TITLE
Fix Promtheus recording rules for grafana mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixing mixins prometheus recording rules
+
 ## [2.24.0] - 2022-05-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,13 +19,22 @@ To Update `kubernetes-mixin` recording rules:
 
 * Copy the content of `prometheus_rules.yaml` and overwrite `helm/prometheus-rules/recording-rules/kubernetes-mixins.rules.yml` (Make sure to overwrite the groups and not the whole file)
 
-* Go back and Adjust labels
+* Adjust labels
 
 ```
-job="kube-scheduler" => app="kube-scheduler"
+(cluster)                  =>  (cluster_id)
 
-job="node-exporter"  => app="node-exporter"
+job="apiserver"            =>  component="apiserver"
 
-job="kubelet"  => app="kubelet"
+job="cadvisor"             =>  app="cadvisor"
 
+job="kube-state-metrics"   =>  app="kube-state-metrics"
+
+job="kube-scheduler"       =>  app="kube-scheduler"
+
+job="node-exporter"        =>  app="node-exporter"
+
+job="kubelet"              =>  app="kubelet"
 ```
+
+* make sure to update [grafana dashboards](https://github.com/giantswarm/dashboards/tree/master/helm/dashboards/dashboards/mixin)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,26 @@
 
 This repository contains Giant Swarm alerting and recording rules
 
+
+
+
+### Mixin
+
+To Update `kubernetes-mixin` recording rules:
+
+* Check for a suitable release in the [upstream](https://github.com/kubernetes-monitoring/kubernetes-mixin#releases)
+
+* Clone the repo (use the release branch) and follow those [instructions](https://github.com/kubernetes-monitoring/kubernetes-mixin#generate-config-files)
+
+* Copy the content of `prometheus_rules.yaml` and overwrite `helm/prometheus-rules/recording-rules/kubernetes-mixins.rules.yml` (Make sure to overwrite the groups and not the whole file)
+
+* Go back and Adjust labels
+
+```
+job="kube-scheduler" => app="kube-scheduler"
+
+job="node-exporter"  => app="node-exporter"
+
+job="kubelet"  => app="kubelet"
+
+```

--- a/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
@@ -578,32 +578,32 @@ spec:
   - name: k8s.recording.rules
     rules:
     - expr: |-
-        sum by (cluster, namespace, pod, container) (
-          rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}[5m])
-        ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
-          1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+        sum by (cluster_id, namespace, pod, container) (
+            rate(container_cpu_usage_seconds_total{app="cadvisor", image!="", container!="POD"}[5m])
+        ) * on (cluster_id, namespace, pod) group_left(node) topk by (cluster_id, namespace, pod) (
+            1, max by(cluster_id, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
     - expr: |-
-        container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_working_set_bytes{app="cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info{node!=""})
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_working_set_bytes
     - expr: |-
-        container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_rss{app="cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
           max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_rss
     - expr: |-
-        container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_cache{app="cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
           max by(namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_cache
     - expr: |-
-        container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+        container_memory_swap{app="cadvisor", image!=""}
         * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
           max by(namespace, pod, node) (kube_pod_info{node!=""})
         )

--- a/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
@@ -7,86 +7,6 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: node.recording.rules
-    rules:
-    - expr: |-
-        topk by(namespace, pod) (1,
-          max by (node, namespace, pod) (
-            label_replace(kube_pod_info{node!=""}, "pod", "$1", "pod", "(.*)")
-        ))
-      record: 'node_namespace_pod:kube_pod_info:'
-    - expr: |-
-        count by (cluster, node) (sum by (node, cpu) (
-          node_cpu_seconds_total{}
-        * on (namespace, pod) group_left(node)
-          node_namespace_pod:kube_pod_info:
-        ))
-      record: node:node_num_cpu:sum
-    - expr: |-
-        sum(
-          node_memory_MemAvailable_bytes{} or
-          (
-            node_memory_Buffers_bytes{} +
-            node_memory_Cached_bytes{} +
-            node_memory_MemFree_bytes{} +
-            node_memory_Slab_bytes{}
-          )
-        ) by (cluster)
-      record: :node_memory_MemAvailable_bytes:sum
-  - name: node-exporter.recording.rules
-    rules:
-    - expr: |-
-        count without (cpu) (
-          count without (mode) (
-            node_cpu_seconds_total{}
-          )
-        )
-      record: instance:node_num_cpu:sum
-    - expr: |-
-        1 - avg without (cpu, mode) (
-          rate(node_cpu_seconds_total{ mode="idle"}[1m])
-        )
-      record: instance:node_cpu_utilisation:rate1m
-    - expr: |-
-        (
-          node_load1{}
-        /
-          instance:node_num_cpu:sum{}
-        )
-      record: instance:node_load1_per_cpu:ratio
-    - expr: |-
-        1 - (
-          node_memory_MemAvailable_bytes{}
-        /
-          node_memory_MemTotal_bytes{}
-        )
-      record: instance:node_memory_utilisation:ratio
-    - expr: rate(node_vmstat_pgmajfault{}[1m])
-      record: instance:node_vmstat_pgmajfault:rate1m
-    - expr: rate(node_disk_io_time_seconds_total{ device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
-      record: instance_device:node_disk_io_time_seconds:rate1m
-    - expr: rate(node_disk_io_time_weighted_seconds_total{ device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
-      record: instance_device:node_disk_io_time_weighted_seconds:rate1m
-    - expr: |-
-        sum without (device) (
-          rate(node_network_receive_bytes_total{ device!="lo"}[1m])
-        )
-      record: instance:node_network_receive_bytes_excluding_lo:rate1m
-    - expr: |-
-        sum without (device) (
-          rate(node_network_transmit_bytes_total{ device!="lo"}[1m])
-        )
-      record: instance:node_network_transmit_bytes_excluding_lo:rate1m
-    - expr: |-
-        sum without (device) (
-          rate(node_network_receive_drop_total{ device!="lo"}[1m])
-        )
-      record: instance:node_network_receive_drop_excluding_lo:rate1m
-    - expr: |-
-        sum without (device) (
-          rate(node_network_transmit_drop_total{ device!="lo"}[1m])
-        )
-      record: instance:node_network_transmit_drop_excluding_lo:rate1m
   - name: kube-prometheus-node.recording.rules
     rules:
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m])) BY (instance)
@@ -107,565 +27,811 @@ spec:
       record: count:up1
     - expr: count without(instance, pod, node) (up == 0)
       record: count:up0
-  - name: kube-apiserver.recording.rules
+
+  - name: kube-apiserver-burnrate.rules
     rules:
-    - expr: |-
-        (
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[1d]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1d]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1d]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1d]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1d]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1d]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1d]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate1d
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate1d'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[1h]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1h]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1h]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1h]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1h]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1h]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1h]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate1h
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate1h'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[2h]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[2h]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[2h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[2h]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[2h]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[2h]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[2h]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[2h]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate2h
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate2h'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30m]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30m]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[30m]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[30m]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[30m]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30m]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30m]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[30m]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate30m
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate30m'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[3d]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[3d]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[3d]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[3d]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[3d]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[3d]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[3d]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[3d]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate3d
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate3d'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[5m]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[5m]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[5m]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[5m]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[5m]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[5m]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[5m]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate5m
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate5m'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[6h]))
-            -
             (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+              -
               (
-                sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[6h]))
-                or
-                vector(0)
+                (
+                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[6h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[6h]))
+                +
+                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[6h]))
               )
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[6h]))
-              +
-              sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[6h]))
             )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
           )
-          +
-          # errors
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[6h]))
-      labels:
-        verb: read
-      record: apiserver_request:burnrate6h
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+        labels:
+          verb: read
+        record: 'apiserver_request:burnrate6h'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate1d
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate1d'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate1h
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate1h'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate2h
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate2h'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate30m
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate30m'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate3d
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate3d'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate5m
-    - expr: |-
-        (
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate5m'
+      - expr: >
           (
-            # too slow
-            sum(rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
-            -
-            sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+              -
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
           )
-          +
-          sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
-        )
-        /
-        sum(rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
-      labels:
-        verb: write
-      record: apiserver_request:burnrate6h
-    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
-      labels:
-        verb: read
-      record: code_resource:apiserver_request_total:rate5m
-    - expr: sum by (code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
-      labels:
-        verb: write
-      record: code_resource:apiserver_request_total:rate5m
-    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET"}[5m]))) > 0
-      labels:
-        quantile: '0.99'
-        verb: read
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
-      labels:
-        quantile: '0.99'
-        verb: write
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.99'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.9'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
-      labels:
-        quantile: '0.5'
-      record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+
+          /
+
+          sum by (cluster)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+        labels:
+          verb: write
+        record: 'apiserver_request:burnrate6h'
+  - name: kube-apiserver-histogram.rules
+    rules:
+      - expr: >
+          histogram_quantile(0.99, sum by (cluster, le, resource)
+          (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET"}[5m])))
+          > 0
+        labels:
+          quantile: '0.99'
+          verb: read
+        record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.99, sum by (cluster, le, resource)
+          (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m])))
+          > 0
+        labels:
+          quantile: '0.99'
+          verb: write
+        record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.99,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.99'
+        record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.9,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.9'
+        record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.5,
+          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.5'
+        record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
   - interval: 3m
-    name: kube-apiserver-availability.recording.rules
+    name: kube-apiserver-availability.rules
     rules:
-    - expr: |-
-        1 - (
-          (
-            # write too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
-            -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
-          ) +
-          (
-            # read too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
+      - expr: >
+          avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24
+          * 30
+        record: 'code_verb:apiserver_request_total:increase30d'
+      - expr: >
+          sum by (cluster, code)
+          (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+        labels:
+          verb: read
+        record: 'code:apiserver_request_total:increase30d'
+      - expr: >
+          sum by (cluster, code)
+          (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+        labels:
+          verb: write
+        record: 'code:apiserver_request_total:increase30d'
+      - expr: >
+          sum by (cluster, verb, scope)
+          (increase(apiserver_request_duration_seconds_count[1h]))
+        record: 'cluster_verb_scope:apiserver_request_duration_seconds_count:increase1h'
+      - expr: >
+          sum by (cluster, verb, scope)
+          (avg_over_time(cluster_verb_scope:apiserver_request_duration_seconds_count:increase1h[30d])
+          * 24 * 30)
+        record: >-
+          cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d
+      - expr: >
+          sum by (cluster, verb, scope, le)
+          (increase(apiserver_request_duration_seconds_bucket[1h]))
+        record: >-
+          cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase1h
+      - expr: >
+          sum by (cluster, verb, scope, le)
+          (avg_over_time(cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase1h[30d])
+          * 24 * 30)
+        record: >-
+          cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d
+      - expr: |
+          1 - (
+            (
+              # write too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              -
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
+            ) +
+            (
+              # read too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
+              -
+              (
+                (
+                  sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
+                +
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
+              )
+            ) +
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+          )
+          /
+          sum by (cluster) (code:apiserver_request_total:increase30d)
+        labels:
+          verb: all
+        record: 'apiserver_request:availability30d'
+      - expr: >
+          1 - (
+            sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
             -
             (
+              # too slow
               (
-                sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
                 or
                 vector(0)
               )
               +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
               +
-              sum(increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
             )
-          ) +
-          # errors
-          sum(code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
-        )
-        /
-        sum(code:apiserver_request_total:increase30d)
-      labels:
-        verb: all
-      record: apiserver_request:availability30d
-    - expr: |-
-        1 - (
-          sum(increase(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[30d]))
-          -
-          (
-            # too slow
+            +
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+          )
+
+          /
+
+          sum by (cluster)
+          (code:apiserver_request_total:increase30d{verb="read"})
+        labels:
+          verb: read
+        record: 'apiserver_request:availability30d'
+      - expr: >
+          1 - (
             (
-              sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
-              or
-              vector(0)
+              # too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              -
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
             )
             +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
-            +
-            sum(increase(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
           )
-          +
-          # errors
-          sum(code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
-        )
-        /
-        sum(code:apiserver_request_total:increase30d{verb="read"})
-      labels:
-        verb: read
-      record: apiserver_request:availability30d
-    - expr: |-
-        1 - (
-          (
-            # too slow
-            sum(increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
-            -
-            sum(increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
-          )
-          +
-          # errors
-          sum(code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
-        )
-        /
-        sum(code:apiserver_request_total:increase30d{verb="write"})
-      labels:
-        verb: write
-      record: apiserver_request:availability30d
-    - expr: avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30
-      record: code_verb:apiserver_request_total:increase30d
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="LIST",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="GET",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="POST",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PUT",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="PATCH",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code, verb) (increase(apiserver_request_total{job="apiserver",verb="DELETE",code=~"5.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-    - expr: sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
-      labels:
-        verb: read
-      record: code:apiserver_request_total:increase30d
-    - expr: sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
-      labels:
-        verb: write
-      record: code:apiserver_request_total:increase30d
-  - name: k8s.recording.rules
+
+          /
+
+          sum by (cluster)
+          (code:apiserver_request_total:increase30d{verb="write"})
+        labels:
+          verb: write
+        record: 'apiserver_request:availability30d'
+      - expr: >
+          sum by (cluster,code,resource)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+        labels:
+          verb: read
+        record: 'code_resource:apiserver_request_total:rate5m'
+      - expr: >
+          sum by (cluster,code,resource)
+          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+        labels:
+          verb: write
+        record: 'code_resource:apiserver_request_total:rate5m'
+      - expr: >
+          sum by (cluster, code, verb)
+          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
+        record: 'code_verb:apiserver_request_total:increase1h'
+      - expr: >
+          sum by (cluster, code, verb)
+          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
+        record: 'code_verb:apiserver_request_total:increase1h'
+      - expr: >
+          sum by (cluster, code, verb)
+          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
+        record: 'code_verb:apiserver_request_total:increase1h'
+      - expr: >
+          sum by (cluster, code, verb)
+          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+        record: 'code_verb:apiserver_request_total:increase1h'
+  - name: k8s.rules
     rules:
-    - expr: |-
-        sum by (cluster_id, namespace, pod, container) (
-            rate(container_cpu_usage_seconds_total{app="cadvisor", image!="", container!="POD"}[5m])
-        ) * on (cluster_id, namespace, pod) group_left(node) topk by (cluster_id, namespace, pod) (
-            1, max by(cluster_id, namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
-    - expr: |-
-        container_memory_working_set_bytes{app="cadvisor", image!=""}
-        * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+      - expr: >
+          sum by (cluster, namespace, pod, container) (
+            irate(container_cpu_usage_seconds_total{job="cadvisor", image!=""}[5m])
+          ) * on (cluster, namespace, pod) group_left(node) topk by (cluster,
+          namespace, pod) (
+            1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: >-
+          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+      - expr: |
+          container_memory_working_set_bytes{job="cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
             max by(namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_working_set_bytes
-    - expr: |-
-        container_memory_rss{app="cadvisor", image!=""}
-        * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_rss
-    - expr: |-
-        container_memory_cache{app="cadvisor", image!=""}
-        * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_cache
-    - expr: |-
-        container_memory_swap{app="cadvisor", image!=""}
-        * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
-          max by(namespace, pod, node) (kube_pod_info{node!=""})
-        )
-      record: node_namespace_pod_container:container_memory_swap
-    - expr: |-
-        sum by (namespace) (
-            sum by (namespace, pod) (
-                max by (namespace, pod, container) (
-                    kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
-                ) * on(namespace, pod) group_left() max by (namespace, pod) (
+          )
+        record: 'node_namespace_pod_container:container_memory_working_set_bytes'
+      - expr: |
+          container_memory_rss{job="cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: 'node_namespace_pod_container:container_memory_rss'
+      - expr: |
+          container_memory_cache{job="cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: 'node_namespace_pod_container:container_memory_cache'
+      - expr: |
+          container_memory_swap{job="cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: 'node_namespace_pod_container:container_memory_swap'
+      - expr: >
+          kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"} 
+          * on (namespace, pod, cluster)
+
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+          )
+        record: >-
+          cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
-                )
-            )
-        )
-      record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
-    - expr: |-
-        sum by (namespace) (
-            sum by (namespace, pod) (
-                max by (namespace, pod, container) (
-                    kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
-                ) * on(namespace, pod) group_left() max by (namespace, pod) (
-                  kube_pod_status_phase{phase=~"Pending|Running"} == 1
-                )
-            )
-        )
-      record: namespace:kube_pod_container_resource_requests_cpu_cores:sum
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            label_replace(
-              kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
-              "replicaset", "$1", "owner_name", "(.*)"
-            ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
-              1, max by (replicaset, namespace, owner_name) (
-                kube_replicaset_owner{job="kube-state-metrics"}
+                  )
               )
-            ),
-            "workload", "$1", "owner_name", "(.*)"
           )
-        )
-      labels:
-        workload_type: deployment
-      record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
-            "workload", "$1", "owner_name", "(.*)"
+        record: 'namespace_memory:kube_pod_container_resource_requests:sum'
+      - expr: >
+          kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"} 
+          * on (namespace, pod, cluster)
+
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
           )
-        )
-      labels:
-        workload_type: daemonset
-      record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: |-
-        max by (cluster, namespace, workload, pod) (
-          label_replace(
-            kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
-            "workload", "$1", "owner_name", "(.*)"
+        record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests'
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
           )
-        )
-      labels:
-        workload_type: statefulset
-      record: namespace_workload_pod:kube_pod_owner:relabel
-  
- 
+        record: 'namespace_cpu:kube_pod_container_resource_requests:sum'
+      - expr: >
+          kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"} 
+          * on (namespace, pod, cluster)
+
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+          )
+        record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits'
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: 'namespace_memory:kube_pod_container_resource_limits:sum'
+      - expr: >
+          kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"} 
+          * on (namespace, pod, cluster)
+
+          group_left() max by (namespace, pod, cluster) (
+           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+           )
+        record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits'
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: 'namespace_cpu:kube_pod_container_resource_limits:sum'
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              label_replace(
+                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+                "replicaset", "$1", "owner_name", "(.*)"
+              ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
+                1, max by (replicaset, namespace, owner_name) (
+                  kube_replicaset_owner{job="kube-state-metrics"}
+                )
+              ),
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: deployment
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: daemonset
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: statefulset
+        record: 'namespace_workload_pod:kube_pod_owner:relabel'
+  - name: kube-scheduler.rules
+    rules:
+      - expr: >
+          histogram_quantile(0.99,
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.99'
+        record: >-
+          cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.99,
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.99'
+        record: >-
+          cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.99,
+          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.99'
+        record: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.9,
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.9'
+        record: >-
+          cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.9,
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.9'
+        record: >-
+          cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.9,
+          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.9'
+        record: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.5,
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.5'
+        record: >-
+          cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.5,
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.5'
+        record: >-
+          cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: >
+          histogram_quantile(0.5,
+          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          without(instance, pod))
+        labels:
+          quantile: '0.5'
+        record: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile'
+  - name: node.rules
+    rules:
+      - expr: |
+          topk by(namespace, pod) (1,
+            max by (node, namespace, pod) (
+              label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
+          ))
+        record: 'node_namespace_pod:kube_pod_info:'
+      - expr: |
+          count by (cluster, node) (sum by (node, cpu) (
+            node_cpu_seconds_total{job="node-exporter"}
+          * on (namespace, pod) group_left(node)
+            topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
+          ))
+        record: 'node:node_num_cpu:sum'
+      - expr: |
+          sum(
+            node_memory_MemAvailable_bytes{job="node-exporter"} or
+            (
+              node_memory_Buffers_bytes{job="node-exporter"} +
+              node_memory_Cached_bytes{job="node-exporter"} +
+              node_memory_MemFree_bytes{job="node-exporter"} +
+              node_memory_Slab_bytes{job="node-exporter"}
+            )
+          ) by (cluster)
+        record: ':node_memory_MemAvailable_bytes:sum'
+  - name: kubelet.rules
+    rules:
+      - expr: >
+          histogram_quantile(0.99,
+          sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
+          (instance, le) * on(instance) group_left(node)
+          kubelet_node_name{job="kubelet"})
+        labels:
+          quantile: '0.99'
+        record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.9,
+          sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
+          (instance, le) * on(instance) group_left(node)
+          kubelet_node_name{job="kubelet"})
+        labels:
+          quantile: '0.9'
+        record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'
+      - expr: >
+          histogram_quantile(0.5,
+          sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
+          (instance, le) * on(instance) group_left(node)
+          kubelet_node_name{job="kubelet"})
+        labels:
+          quantile: '0.5'
+        record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'
+
+
+

--- a/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml
@@ -34,29 +34,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[1d]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1d]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1d]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1d]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1d]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1d]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1d]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[1d]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate1d'
@@ -64,29 +64,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[1h]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1h]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[1h]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[1h]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[1h]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[1h]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate1h'
@@ -94,29 +94,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[2h]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[2h]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[2h]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[2h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[2h]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[2h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[2h]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[2h]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate2h'
@@ -124,29 +124,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[30m]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[30m]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[30m]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[30m]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[30m]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[30m]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[30m]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[30m]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate30m'
@@ -154,29 +154,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[3d]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[3d]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[3d]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[3d]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[3d]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[3d]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[3d]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[3d]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate3d'
@@ -184,29 +184,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[5m]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[5m]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[5m]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[5m]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[5m]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[5m]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[5m]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[5m]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate5m'
@@ -214,29 +214,29 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"LIST|GET"}[6h]))
               -
               (
                 (
-                  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[6h]))
+                  sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope=~"resource|",le="1"}[6h]))
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[6h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="namespace",le="5"}[6h]))
                 +
-                sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[6h]))
+                sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET",scope="cluster",le="30"}[6h]))
               )
             )
             +
             # errors
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[6h]))
         labels:
           verb: read
         record: 'apiserver_request:burnrate6h'
@@ -244,18 +244,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate1d'
@@ -263,18 +263,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate1h'
@@ -282,18 +282,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate2h'
@@ -301,18 +301,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate30m'
@@ -320,18 +320,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate3d'
@@ -339,18 +339,18 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate5m'
@@ -358,34 +358,34 @@ spec:
           (
             (
               # too slow
-              sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_count{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
               -
-              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
+              sum by (cluster_id) (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
             )
             +
-            sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
+            sum by (cluster_id) (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
           )
 
           /
 
-          sum by (cluster)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+          sum by (cluster_id)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
         labels:
           verb: write
         record: 'apiserver_request:burnrate6h'
   - name: kube-apiserver-histogram.rules
     rules:
       - expr: >
-          histogram_quantile(0.99, sum by (cluster, le, resource)
-          (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET"}[5m])))
+          histogram_quantile(0.99, sum by (cluster_id, le, resource)
+          (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"LIST|GET"}[5m])))
           > 0
         labels:
           quantile: '0.99'
           verb: read
         record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
       - expr: >
-          histogram_quantile(0.99, sum by (cluster, le, resource)
-          (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m])))
+          histogram_quantile(0.99, sum by (cluster_id, le, resource)
+          (rate(apiserver_request_duration_seconds_bucket{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m])))
           > 0
         labels:
           quantile: '0.99'
@@ -393,21 +393,21 @@ spec:
         record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
       - expr: >
           histogram_quantile(0.99,
-          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          sum(rate(apiserver_request_duration_seconds_bucket{component="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.99'
         record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
       - expr: >
           histogram_quantile(0.9,
-          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          sum(rate(apiserver_request_duration_seconds_bucket{component="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.9'
         record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile'
       - expr: >
           histogram_quantile(0.5,
-          sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+          sum(rate(apiserver_request_duration_seconds_bucket{component="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.5'
@@ -420,34 +420,34 @@ spec:
           * 30
         record: 'code_verb:apiserver_request_total:increase30d'
       - expr: >
-          sum by (cluster, code)
+          sum by (cluster_id, code)
           (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
         labels:
           verb: read
         record: 'code:apiserver_request_total:increase30d'
       - expr: >
-          sum by (cluster, code)
+          sum by (cluster_id, code)
           (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
         labels:
           verb: write
         record: 'code:apiserver_request_total:increase30d'
       - expr: >
-          sum by (cluster, verb, scope)
+          sum by (cluster_id, verb, scope)
           (increase(apiserver_request_duration_seconds_count[1h]))
         record: 'cluster_verb_scope:apiserver_request_duration_seconds_count:increase1h'
       - expr: >
-          sum by (cluster, verb, scope)
+          sum by (cluster_id, verb, scope)
           (avg_over_time(cluster_verb_scope:apiserver_request_duration_seconds_count:increase1h[30d])
           * 24 * 30)
         record: >-
           cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d
       - expr: >
-          sum by (cluster, verb, scope, le)
+          sum by (cluster_id, verb, scope, le)
           (increase(apiserver_request_duration_seconds_bucket[1h]))
         record: >-
           cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase1h
       - expr: >
-          sum by (cluster, verb, scope, le)
+          sum by (cluster_id, verb, scope, le)
           (avg_over_time(cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase1h[30d])
           * 24 * 30)
         record: >-
@@ -456,58 +456,58 @@ spec:
           1 - (
             (
               # write too slow
-              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              sum by (cluster_id) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
               -
-              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
+              sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
             ) +
             (
               # read too slow
-              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
+              sum by (cluster_id) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
               -
               (
                 (
-                  sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
+                  sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
                   or
                   vector(0)
                 )
                 +
-                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
+                sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
                 +
-                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
+                sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
               )
             ) +
             # errors
-            sum by (cluster) (code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+            sum by (cluster_id) (code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
           )
           /
-          sum by (cluster) (code:apiserver_request_total:increase30d)
+          sum by (cluster_id) (code:apiserver_request_total:increase30d)
         labels:
           verb: all
         record: 'apiserver_request:availability30d'
       - expr: >
           1 - (
-            sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
+            sum by (cluster_id) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"LIST|GET"})
             -
             (
               # too slow
               (
-                sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
+                sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
                 or
                 vector(0)
               )
               +
-              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
+              sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
               +
-              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
+              sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
             )
             +
             # errors
-            sum by (cluster) (code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+            sum by (cluster_id) (code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
           )
 
           /
 
-          sum by (cluster)
+          sum by (cluster_id)
           (code:apiserver_request_total:increase30d{verb="read"})
         labels:
           verb: read
@@ -516,87 +516,87 @@ spec:
           1 - (
             (
               # too slow
-              sum by (cluster) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              sum by (cluster_id) (cluster_verb_scope:apiserver_request_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
               -
-              sum by (cluster) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
+              sum by (cluster_id) (cluster_verb_scope_le:apiserver_request_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
             )
             +
             # errors
-            sum by (cluster) (code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
+            sum by (cluster_id) (code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
           )
 
           /
 
-          sum by (cluster)
+          sum by (cluster_id)
           (code:apiserver_request_total:increase30d{verb="write"})
         labels:
           verb: write
         record: 'apiserver_request:availability30d'
       - expr: >
-          sum by (cluster,code,resource)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+          sum by (cluster_id,code,resource)
+          (rate(apiserver_request_total{component="apiserver",verb=~"LIST|GET"}[5m]))
         labels:
           verb: read
         record: 'code_resource:apiserver_request_total:rate5m'
       - expr: >
-          sum by (cluster,code,resource)
-          (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+          sum by (cluster_id,code,resource)
+          (rate(apiserver_request_total{component="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
         labels:
           verb: write
         record: 'code_resource:apiserver_request_total:rate5m'
       - expr: >
-          sum by (cluster, code, verb)
-          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
+          sum by (cluster_id, code, verb)
+          (increase(apiserver_request_total{component="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
         record: 'code_verb:apiserver_request_total:increase1h'
       - expr: >
-          sum by (cluster, code, verb)
-          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
+          sum by (cluster_id, code, verb)
+          (increase(apiserver_request_total{component="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
         record: 'code_verb:apiserver_request_total:increase1h'
       - expr: >
-          sum by (cluster, code, verb)
-          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
+          sum by (cluster_id, code, verb)
+          (increase(apiserver_request_total{component="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
         record: 'code_verb:apiserver_request_total:increase1h'
       - expr: >
-          sum by (cluster, code, verb)
-          (increase(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+          sum by (cluster_id, code, verb)
+          (increase(apiserver_request_total{component="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
         record: 'code_verb:apiserver_request_total:increase1h'
   - name: k8s.rules
     rules:
       - expr: >
-          sum by (cluster, namespace, pod, container) (
-            irate(container_cpu_usage_seconds_total{job="cadvisor", image!=""}[5m])
-          ) * on (cluster, namespace, pod) group_left(node) topk by (cluster,
+          sum by (cluster_id, namespace, pod, container) (
+            irate(container_cpu_usage_seconds_total{app="cadvisor", image!=""}[5m])
+          ) * on (cluster_id, namespace, pod) group_left(node) topk by (cluster_id,
           namespace, pod) (
-            1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+            1, max by(cluster_id, namespace, pod, node) (kube_pod_info{node!=""})
           )
         record: >-
           node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
       - expr: |
-          container_memory_working_set_bytes{job="cadvisor", image!=""}
+          container_memory_working_set_bytes{app="cadvisor", image!=""}
           * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
             max by(namespace, pod, node) (kube_pod_info{node!=""})
           )
         record: 'node_namespace_pod_container:container_memory_working_set_bytes'
       - expr: |
-          container_memory_rss{job="cadvisor", image!=""}
+          container_memory_rss{app="cadvisor", image!=""}
           * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
             max by(namespace, pod, node) (kube_pod_info{node!=""})
           )
         record: 'node_namespace_pod_container:container_memory_rss'
       - expr: |
-          container_memory_cache{job="cadvisor", image!=""}
+          container_memory_cache{app="cadvisor", image!=""}
           * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
             max by(namespace, pod, node) (kube_pod_info{node!=""})
           )
         record: 'node_namespace_pod_container:container_memory_cache'
       - expr: |
-          container_memory_swap{job="cadvisor", image!=""}
+          container_memory_swap{app="cadvisor", image!=""}
           * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
             max by(namespace, pod, node) (kube_pod_info{node!=""})
           )
         record: 'node_namespace_pod_container:container_memory_swap'
       - expr: >
-          kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"} 
+          kube_pod_container_resource_requests{resource="memory",app="kube-state-metrics"} 
           * on (namespace, pod, cluster)
 
           group_left() max by (namespace, pod, cluster) (
@@ -605,82 +605,82 @@ spec:
         record: >-
           cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
       - expr: |
-          sum by (namespace, cluster) (
-              sum by (namespace, pod, cluster) (
-                  max by (namespace, pod, container, cluster) (
-                    kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}
-                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+          sum by (namespace, cluster_id) (
+              sum by (namespace, pod, cluster_id) (
+                  max by (namespace, pod, container, cluster_id) (
+                    kube_pod_container_resource_requests{resource="memory",app="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster_id) group_left() max by (namespace, pod, cluster_id) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
                   )
               )
           )
         record: 'namespace_memory:kube_pod_container_resource_requests:sum'
       - expr: >
-          kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"} 
-          * on (namespace, pod, cluster)
+          kube_pod_container_resource_requests{resource="cpu",app="kube-state-metrics"} 
+          * on (namespace, pod, cluster_id)
 
-          group_left() max by (namespace, pod, cluster) (
+          group_left() max by (namespace, pod, cluster_id) (
             (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
           )
         record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests'
       - expr: |
-          sum by (namespace, cluster) (
-              sum by (namespace, pod, cluster) (
-                  max by (namespace, pod, container, cluster) (
-                    kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}
-                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+          sum by (namespace, cluster_id) (
+              sum by (namespace, pod, cluster_id) (
+                  max by (namespace, pod, container, cluster_id) (
+                    kube_pod_container_resource_requests{resource="cpu",app="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster_id) group_left() max by (namespace, pod, cluster_id) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
                   )
               )
           )
         record: 'namespace_cpu:kube_pod_container_resource_requests:sum'
       - expr: >
-          kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"} 
-          * on (namespace, pod, cluster)
+          kube_pod_container_resource_limits{resource="memory",app="kube-state-metrics"} 
+          * on (namespace, pod, cluster_id)
 
-          group_left() max by (namespace, pod, cluster) (
+          group_left() max by (namespace, pod, cluster_id) (
             (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
           )
         record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits'
       - expr: |
-          sum by (namespace, cluster) (
-              sum by (namespace, pod, cluster) (
-                  max by (namespace, pod, container, cluster) (
-                    kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}
-                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+          sum by (namespace, cluster_id) (
+              sum by (namespace, pod, cluster_id) (
+                  max by (namespace, pod, container, cluster_id) (
+                    kube_pod_container_resource_limits{resource="memory",app="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster_id) group_left() max by (namespace, pod, cluster_id) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
                   )
               )
           )
         record: 'namespace_memory:kube_pod_container_resource_limits:sum'
       - expr: >
-          kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"} 
-          * on (namespace, pod, cluster)
+          kube_pod_container_resource_limits{resource="cpu",app="kube-state-metrics"} 
+          * on (namespace, pod, cluster_id)
 
-          group_left() max by (namespace, pod, cluster) (
+          group_left() max by (namespace, pod, cluster_id) (
            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
            )
         record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits'
       - expr: |
-          sum by (namespace, cluster) (
-              sum by (namespace, pod, cluster) (
-                  max by (namespace, pod, container, cluster) (
-                    kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}
-                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+          sum by (namespace, cluster_id) (
+              sum by (namespace, pod, cluster_id) (
+                  max by (namespace, pod, container, cluster_id) (
+                    kube_pod_container_resource_limits{resource="cpu",app="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster_id) group_left() max by (namespace, pod, cluster_id) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
                   )
               )
           )
         record: 'namespace_cpu:kube_pod_container_resource_limits:sum'
       - expr: |
-          max by (cluster, namespace, workload, pod) (
+          max by (cluster_id, namespace, workload, pod) (
             label_replace(
               label_replace(
-                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+                kube_pod_owner{app="kube-state-metrics", owner_kind="ReplicaSet"},
                 "replicaset", "$1", "owner_name", "(.*)"
               ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
                 1, max by (replicaset, namespace, owner_name) (
-                  kube_replicaset_owner{job="kube-state-metrics"}
+                  kube_replicaset_owner{app="kube-state-metrics"}
                 )
               ),
               "workload", "$1", "owner_name", "(.*)"
@@ -690,9 +690,9 @@ spec:
           workload_type: deployment
         record: 'namespace_workload_pod:kube_pod_owner:relabel'
       - expr: |
-          max by (cluster, namespace, workload, pod) (
+          max by (cluster_id, namespace, workload, pod) (
             label_replace(
-              kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+              kube_pod_owner{app="kube-state-metrics", owner_kind="DaemonSet"},
               "workload", "$1", "owner_name", "(.*)"
             )
           )
@@ -700,9 +700,9 @@ spec:
           workload_type: daemonset
         record: 'namespace_workload_pod:kube_pod_owner:relabel'
       - expr: |
-          max by (cluster, namespace, workload, pod) (
+          max by (cluster_id, namespace, workload, pod) (
             label_replace(
-              kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+              kube_pod_owner{app="kube-state-metrics", owner_kind="StatefulSet"},
               "workload", "$1", "owner_name", "(.*)"
             )
           )
@@ -713,7 +713,7 @@ spec:
     rules:
       - expr: >
           histogram_quantile(0.99,
-          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.99'
@@ -721,7 +721,7 @@ spec:
           cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.99,
-          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.99'
@@ -729,14 +729,14 @@ spec:
           cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.99,
-          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_binding_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.99'
         record: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile'
       - expr: >
           histogram_quantile(0.9,
-          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.9'
@@ -744,7 +744,7 @@ spec:
           cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.9,
-          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.9'
@@ -752,14 +752,14 @@ spec:
           cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.9,
-          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_binding_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.9'
         record: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile'
       - expr: >
           histogram_quantile(0.5,
-          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.5'
@@ -767,7 +767,7 @@ spec:
           cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.5,
-          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.5'
@@ -775,7 +775,7 @@ spec:
           cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
       - expr: >
           histogram_quantile(0.5,
-          sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+          sum(rate(scheduler_binding_duration_seconds_bucket{app="kube-scheduler"}[5m]))
           without(instance, pod))
         labels:
           quantile: '0.5'
@@ -785,26 +785,26 @@ spec:
       - expr: |
           topk by(namespace, pod) (1,
             max by (node, namespace, pod) (
-              label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
+              label_replace(kube_pod_info{app="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
           ))
         record: 'node_namespace_pod:kube_pod_info:'
       - expr: |
-          count by (cluster, node) (sum by (node, cpu) (
-            node_cpu_seconds_total{job="node-exporter"}
+          count by (cluster_id, node) (sum by (node, cpu) (
+            node_cpu_seconds_total{app="node-exporter"}
           * on (namespace, pod) group_left(node)
             topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
           ))
         record: 'node:node_num_cpu:sum'
       - expr: |
           sum(
-            node_memory_MemAvailable_bytes{job="node-exporter"} or
+            node_memory_MemAvailable_bytes{app="node-exporter"} or
             (
-              node_memory_Buffers_bytes{job="node-exporter"} +
-              node_memory_Cached_bytes{job="node-exporter"} +
-              node_memory_MemFree_bytes{job="node-exporter"} +
-              node_memory_Slab_bytes{job="node-exporter"}
+              node_memory_Buffers_bytes{app="node-exporter"} +
+              node_memory_Cached_bytes{app="node-exporter"} +
+              node_memory_MemFree_bytes{app="node-exporter"} +
+              node_memory_Slab_bytes{app="node-exporter"}
             )
-          ) by (cluster)
+          ) by (cluster_id)
         record: ':node_memory_MemAvailable_bytes:sum'
   - name: kubelet.rules
     rules:
@@ -812,7 +812,7 @@ spec:
           histogram_quantile(0.99,
           sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
           (instance, le) * on(instance) group_left(node)
-          kubelet_node_name{job="kubelet"})
+          kubelet_node_name{app="kubelet"})
         labels:
           quantile: '0.99'
         record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'
@@ -820,7 +820,7 @@ spec:
           histogram_quantile(0.9,
           sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
           (instance, le) * on(instance) group_left(node)
-          kubelet_node_name{job="kubelet"})
+          kubelet_node_name{app="kubelet"})
         labels:
           quantile: '0.9'
         record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'
@@ -828,7 +828,7 @@ spec:
           histogram_quantile(0.5,
           sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by
           (instance, le) * on(instance) group_left(node)
-          kubelet_node_name{job="kubelet"})
+          kubelet_node_name{app="kubelet"})
         labels:
           quantile: '0.5'
         record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile'


### PR DESCRIPTION
Ref https://github.com/giantswarm/giantswarm/issues/19855

This PR:

- updated `kubernetes-mixins.rules.yml` recording rules to the latest  from [upstream](https://github.com/kubernetes-monitoring/kubernetes-mixin)

<!--
Changelog must always be updated.
-->

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [X] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [X] Alerting rules must have a comment documenting why it needs to exist.
- [X] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
