### PR TITLE
Webhook alert split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split `WorkloadClusterWebhookDurationExceedsTimeout` by team owning the component.
+
 ## [2.22.0] - 2022-05-20
 
 ## Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -44,17 +44,17 @@ spec:
 
     # Webhooks that are not explicitely owner by any team (customer owned ones).
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutSolutionEngineers
-        annotations:
-          description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
-          opsrecipe: apiserver-admission-webhook-errors/
-        expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name!~".*(prometheus|vpa.k8s.io|linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io|kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
-        for: 15m
-        labels:
-          area: kaas
-          cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-          severity: page
-          team: se
-          topic: kubernetes
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name!~".*(prometheus|vpa.k8s.io|linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io|kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: se
+        topic: kubernetes
 
       # Webhooks owned by Honeybadger
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutHoneybadger

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -41,15 +41,42 @@ spec:
         severity: notify
         team: {{ include "providerTeam" . }}
         topic: kubernetes
-    - alert: WorkloadClusterWebhookDurationExceedsTimeout
+
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutHoneybadger
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*kyverno|app-admission-controller.*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: honeybadger
+        topic: kubernetes
+
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutCabbage
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*(linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: cabbage
+        topic: kubernetes
+
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutAtlas
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        opsrecipe: apiserver-admission-webhook-errors/
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*(prometheus|vpa.k8s.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: atlas
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -42,11 +42,26 @@ spec:
         team: {{ include "providerTeam" . }}
         topic: kubernetes
 
+    # Webhooks that are not explicitely owner by any team (customer owned ones).
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutSolutionEngineers
+        annotations:
+          description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+          opsrecipe: apiserver-admission-webhook-errors/
+        expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name!~".*(prometheus|vpa.k8s.io|linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io|kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+        for: 15m
+        labels:
+          area: kaas
+          cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+          severity: page
+          team: se
+          topic: kubernetes
+
+      # Webhooks owned by Honeybadger
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutHoneybadger
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*kyverno|app-admission-controller.*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas
@@ -55,11 +70,12 @@ spec:
         team: honeybadger
         topic: kubernetes
 
+      # Webhooks owned by Cabbage
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutCabbage
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*(linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas
@@ -68,11 +84,12 @@ spec:
         team: cabbage
         topic: kubernetes
 
+      # Webhooks owned by Atlas
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutAtlas
       annotations:
         description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{name=~".*(prometheus|vpa.k8s.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
+      expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(prometheus|vpa.k8s.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Currently, phoenix and rocket get paged by all webhooks in workload clusters, when they are responding too slowly.
This includes webhooks belonging to apps owned by other teams, as well as webhooks belonging to the customer.

This in practice means we get paged by `kong` for example, an app we have zero clue about.

We believe this is wrong, so this PR aims at fixing this problem.

This PR:

- ships internal webhook alerts to the team owning the app (cabbage, honeybadger or atlas)
- ships all other webhooks, should be customer webhooks only, to the `se` team.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
