### PR TITLE
Improve EtcdDBSizeTooLarge alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve EtcdDBSizeTooLarge alerts.
+
 ## [2.23.0] - 2022-05-23
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -27,8 +27,8 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) > 200000000
-      for: 7h
+      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"} > 0.5
+      for: 24h
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -43,8 +43,8 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) > 200000000
-      for: 7h
+      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"} > 0.5
+      for: 24h
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
Increased the alert timeout to 24h because we have one defrag a day.
Also made the query respect the database size rather than having an hardcoded threshold as suggested in sig monitoring.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
