### PR TITLE
add openstack lb alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce Kubernetes API down alert on openstack.
+
 ## [2.25.0] - 2022-05-26
 
 ### Fixed
@@ -171,7 +175,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed `ManagementClusterPodPendingFor15Min` and `ManagementClusterPodPending`.
-
 
 ## [1.7.1] - 2022-03-22
 
@@ -437,7 +440,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.40.2] - 2021-12-03
 
-
 ### Fixed
 
 - Consolidate alerts that covered the same issues.
@@ -503,7 +505,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `WorkloadClusterEtcdCommitDurationTooHigh` severity to paging.
-
 
 ## [0.31.3] - 2021-11-09
 
@@ -865,7 +866,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add existing rules from https://github.com/giantswarm/prometheus-meta-operator/pull/637/commits/bc6a26759eb955de92b41ed5eb33fa37980660f2
+- Add existing rules from <https://github.com/giantswarm/prometheus-meta-operator/pull/637/commits/bc6a26759eb955de92b41ed5eb33fa37980660f2>
 
 [Unreleased]: https://github.com/giantswarm/prometheus-rules/compare/v2.25.0...HEAD
 [2.25.0]: https://github.com/giantswarm/prometheus-rules/compare/v2.24.0...v2.25.0

--- a/helm/prometheus-rules/templates/alerting-rules/openstack.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/openstack.workload-cluster.rules.yml
@@ -1,0 +1,29 @@
+{{- if eq .Values.managementCluster.provider.kind "openstack" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "workload_cluster"
+  name: openstack.workload-cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: openstack
+    rules:
+    - alert: WorkloadClusterKubernetesAPINotReachable
+      annotations:
+        description: '{{`Kubernetes API in {{ $labels.installation }}/{{ $labels.cluster_id }} is down.`}}'
+        opsrecipe: openstack-k8s-api-unreachable/
+      expr: up{app="kubernetes"} == 0
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: rocket
+        topic: kubernetes
+{{- end }}


### PR DESCRIPTION
This PR:

- adds kubernetes API down alert on openstack

Ops-recipe: https://github.com/giantswarm/giantswarm/pull/22258

Fixes: https://github.com/giantswarm/giantswarm/issues/22251

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
