### PR TITLE
Route `ServiceLevelBurnRateTooHigh` alert using `application.giantswarm.io/team` label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Route ServiceLevelBurnRateTooHigh alert using giantswarm.io/monitoring_team label.
+
 ## [2.26.0] - 2022-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Route ServiceLevelBurnRateTooHigh alert using giantswarm.io/monitoring_team label.
+- Route ServiceLevelBurnRateTooHigh alert using application.giantswarm.io/team label.
 
 ## [2.26.0] - 2022-06-08
 

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -34,4 +34,4 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: '{{`{{ $labels.label_giantswarm_io_monitoring_team }}`}}'
+        team: '{{`{{ $labels.label_application_giantswarm_io_team }}`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -34,3 +34,4 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
+        team: "{{ $labels.label_giantswarm_io_monitoring_team }}"

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -34,4 +34,4 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: "{{ $labels.label_giantswarm_io_monitoring_team }}"
+        team: '{{`{{ $labels.label_giantswarm_io_monitoring_team }}`}}'

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -353,19 +353,19 @@ spec:
       record: slo_requests
     - expr: sum(raw_slo_errors) by (service, cluster_type, cluster_id, area)
       record: slo_errors
-    - expr: sum(sum_over_time(raw_slo_errors[5m])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[5m])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[5m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[5m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate5m
-    - expr: sum(sum_over_time(raw_slo_errors[30m])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[30m])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[30m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[30m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate30m
-    - expr: sum(sum_over_time(raw_slo_errors[1h])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[1h])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[1h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[1h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate1h
-    - expr: sum(sum_over_time(raw_slo_errors[6h])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[6h])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[6h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[6h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate6h
-    - expr: sum(sum_over_time(raw_slo_errors[2h])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[2h])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[2h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[2h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate2h
-    - expr: sum(sum_over_time(raw_slo_errors[24h])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[24h])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[24h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[24h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate24h
-    - expr: sum(sum_over_time(raw_slo_errors[3d])) by (cluster_type, cluster_id, service, class, area) / sum(sum_over_time(raw_slo_requests[3d])) by (cluster_type, cluster_id, service, class, area)
+    - expr: sum(sum_over_time(raw_slo_errors[3d])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[3d])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
       record: slo_errors_per_request:ratio_rate3d
       # -- We use the `min` function here because we have `slo_burnrate_high` for each installation and cluster_id, even though the metric value is always the same.
     - expr: slo_target*scalar(min(slo_burnrate_high))

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -183,11 +183,13 @@ spec:
     # -- error recording rules
     # record when pods of a daemonset with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        label_replace(
-          kube_daemonset_status_number_unavailable
-          and on(daemonset,cluster_id,cluster_type,namespace,workload_name)
-          kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_daemonset_labels * on (daemonset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_daemonset_status_number_unavailable
+            and on(daemonset,cluster_id,cluster_type,namespace,workload_name)
+            kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps
@@ -207,22 +209,26 @@ spec:
       record: raw_slo_errors
     # record when pods of a statefulset with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        label_replace(
-          kube_statefulset_status_replicas - kube_statefulset_status_replicas_current
-          and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
-          kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_statefulset_labels * on (statefulset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_statefulset_status_replicas - kube_statefulset_status_replicas_current
+            and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
+            kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps
       record: raw_slo_errors
     # -- present pods recording rules
     - expr: |
-        label_replace(
-          kube_daemonset_status_desired_number_scheduled
-          and on(daemonset,cluster_id,cluster_type,namespace, workload_name)
-          kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_daemonset_labels * on (daemonset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_daemonset_status_desired_number_scheduled
+            and on(daemonset,cluster_id,cluster_type,namespace, workload_name)
+            kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps
@@ -240,11 +246,13 @@ spec:
         area: managed-apps
       record: raw_slo_requests
     - expr: |
-        label_replace(
-          kube_statefulset_status_replicas
-          and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
-          kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_statefulset_labels * on (statefulset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_statefulset_status_replicas
+            and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
+            kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -194,11 +194,13 @@ spec:
       record: raw_slo_errors
     # record when pods of a deployment with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        label_replace(
-          kube_deployment_status_replicas_unavailable
-          and on(deployment,cluster_id,cluster_type,namespace, workload_name)
-          kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_deployment_labels * on (deployment, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_deployment_status_replicas_unavailable
+            and on(deployment,cluster_id,cluster_type,namespace, workload_name)
+            kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps
@@ -226,11 +228,13 @@ spec:
         area: managed-apps
       record: raw_slo_requests
     - expr: |
-        label_replace(
-          kube_deployment_status_replicas
-          and on(deployment,cluster_id,cluster_type,namespace, workload_name)
-          kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-        "service", "$1", "workload_name", "(.*)" )
+        kube_deployment_labels * on (deployment, namespace) group_right(label_giantswarm_io_monitoring_team) (
+          label_replace(
+            kube_deployment_status_replicas
+            and on(deployment,cluster_id,cluster_type,namespace, workload_name)
+            kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
+          "service", "$1", "workload_name", "(.*)" )
+        )
       labels:
         class: MEDIUM
         area: managed-apps

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -183,7 +183,7 @@ spec:
     # -- error recording rules
     # record when pods of a daemonset with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        kube_daemonset_labels * on (daemonset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_daemonset_labels * on (daemonset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_daemonset_status_number_unavailable
             and on(daemonset,cluster_id,cluster_type,namespace,workload_name)
@@ -196,7 +196,7 @@ spec:
       record: raw_slo_errors
     # record when pods of a deployment with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        kube_deployment_labels * on (deployment, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_deployment_labels * on (deployment, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_deployment_status_replicas_unavailable
             and on(deployment,cluster_id,cluster_type,namespace, workload_name)
@@ -209,7 +209,7 @@ spec:
       record: raw_slo_errors
     # record when pods of a statefulset with label "label_giantswarm_io_monitoring_basic_sli" are down
     - expr: |
-        kube_statefulset_labels * on (statefulset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_statefulset_labels * on (statefulset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_statefulset_status_replicas - kube_statefulset_status_replicas_current
             and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
@@ -222,7 +222,7 @@ spec:
       record: raw_slo_errors
     # -- present pods recording rules
     - expr: |
-        kube_daemonset_labels * on (daemonset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_daemonset_labels * on (daemonset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_daemonset_status_desired_number_scheduled
             and on(daemonset,cluster_id,cluster_type,namespace, workload_name)
@@ -234,7 +234,7 @@ spec:
         area: managed-apps
       record: raw_slo_requests
     - expr: |
-        kube_deployment_labels * on (deployment, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_deployment_labels * on (deployment, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_deployment_status_replicas
             and on(deployment,cluster_id,cluster_type,namespace, workload_name)
@@ -246,7 +246,7 @@ spec:
         area: managed-apps
       record: raw_slo_requests
     - expr: |
-        kube_statefulset_labels * on (statefulset, namespace) group_right(label_giantswarm_io_monitoring_team) (
+        kube_statefulset_labels * on (statefulset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_statefulset_status_replicas
             and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
@@ -361,19 +361,19 @@ spec:
       record: slo_requests
     - expr: sum(raw_slo_errors) by (service, cluster_type, cluster_id, area)
       record: slo_errors
-    - expr: sum(sum_over_time(raw_slo_errors[5m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[5m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[5m])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[5m])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate5m
-    - expr: sum(sum_over_time(raw_slo_errors[30m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[30m])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[30m])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[30m])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate30m
-    - expr: sum(sum_over_time(raw_slo_errors[1h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[1h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[1h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[1h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate1h
-    - expr: sum(sum_over_time(raw_slo_errors[6h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[6h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[6h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[6h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate6h
-    - expr: sum(sum_over_time(raw_slo_errors[2h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[2h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[2h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[2h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate2h
-    - expr: sum(sum_over_time(raw_slo_errors[24h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[24h])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[24h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[24h])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate24h
-    - expr: sum(sum_over_time(raw_slo_errors[3d])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team) / sum(sum_over_time(raw_slo_requests[3d])) by (cluster_type, cluster_id, service, class, area, label_giantswarm_io_monitoring_team)
+    - expr: sum(sum_over_time(raw_slo_errors[3d])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[3d])) by (cluster_type, cluster_id, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate3d
       # -- We use the `min` function here because we have `slo_burnrate_high` for each installation and cluster_id, even though the metric value is always the same.
     - expr: slo_target*scalar(min(slo_burnrate_high))


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22290

This PR aims at using dynamic routing for `ServiceLevelBurnRateTooHigh`. (see [article](https://tech.loveholidays.com/dynamic-alert-routing-with-prometheus-and-alertmanager-f6a919edb5f8))

The idea basically to be able to route alert based on labels given to k8s resources. To achieve this we need:

1. Label our app with team name ([PR](https://github.com/giantswarm/prometheus-operator-app/pull/191/files#diff-e27896bc0794dd5a2ff25c437b60bb597c4b52f02e224d83e61d1bacb7d1f6f3R12))
2. Have this label in prometheus (thanks to kube-state-metrics, see [PR](https://github.com/giantswarm/kube-state-metrics-app/pull/138))
3. Add this label into our alert (this PR)
4. Route to different team based on tag/label (already done in [OpsGenie](https://giantswarm.app.opsgenie.com/teams/dashboard/bbbc9d91-93fa-4882-8b07-84bebea41508/main))

There are 3 main changes in this PR:

1. I added the `application.giantswarm.io/team` label to every managed-app slo rules. This was achieved by wrapping the current expression with
```
kube_daemonset_labels * on (daemonset, namespace) group_right(label_application_giantswarm_io_team) (
  current_expression
)
```
2. Adding the `label_application_giantswarm_io_team` to every `slo_errors*` recording rules
3. Adding the `label_application_giantswarm_io_team` as `team` label into `ServiceLevelBurnRateTooHigh` alert