### PR TITLE
added rules for Loki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alerts for Loki
+
 ## [2.26.0] - 2022-06-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -1,0 +1,50 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: grafana.all.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: loki
+    rules:
+    # Rules inspired from loki-mixins - https://github.com/grafana/loki/blob/main/production/loki-mixin-compiled/alerts.yaml
+    - alert: LokiRequestErrors
+      annotations:
+        description: This alert checks that we have less than 10% errors on Loki requests.
+        opsrecipe: loki
+      expr: |
+        100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[1m])) by (namespace, job, route)
+          /
+        sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
+          > 10
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: notify
+        team: atlas
+        topic: observability
+    - alert: LokiRequestPanics
+      annotations:
+        description: This alert checks that we have no panic errors on Loki.
+        opsrecipe: loki
+      expr: |
+        sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: notify
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -19,7 +19,7 @@ spec:
           /
         sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
           > 10
-      for: 15m
+      for: 120m
       labels:
         area: managedservices
         cancel_if_apiserver_down: "true"


### PR DESCRIPTION
This PR adds alerts for Loki

Ops-recipes: https://github.com/giantswarm/giantswarm/pull/22375
Towards https://github.com/giantswarm/roadmap/issues/718

No dashboards created yet. I hope to use loki-mixins in the future, but we should have some working loki instances first!

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
