### PR TITLE
aws-servicequotas-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Push aws-servicequotas-operator errors to Cortex.
 - Alerts for Loki
 - Add support for VCD provider.
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -236,3 +236,10 @@ spec:
     # IAM roles for Service Accounts metrics
     - expr: sum(irsa_operator_cluster_errors) by (account_id,cluster_id,cluster_namespace,installation)
       record: aggregation:giantswarm:irsa_operator_cluster_errors
+    # AWS service quotas metrics
+    - expr: sum(aws_servicequotas_operator_quota_increase_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
+      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_increase_errors
+    - expr: sum(aws_servicequotas_operator_quota_history_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
+      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_history_errors
+    - expr: sum(aws_servicequotas_operator_quota_applied_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
+      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_applied_errors

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -238,8 +238,8 @@ spec:
       record: aggregation:giantswarm:irsa_operator_cluster_errors
     # AWS service quotas metrics
     - expr: sum(aws_servicequotas_operator_quota_increase_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_increase_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_increase_errors
     - expr: sum(aws_servicequotas_operator_quota_history_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_history_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_history_errors
     - expr: sum(aws_servicequotas_operator_quota_applied_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_cluster_quota_applied_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_applied_errors

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -238,8 +238,8 @@ spec:
       record: aggregation:giantswarm:irsa_operator_cluster_errors
     # AWS service quotas metrics
     - expr: sum(aws_servicequotas_operator_quota_increase_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_quota_increase_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_increase_request_errors
     - expr: sum(aws_servicequotas_operator_quota_history_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_quota_history_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_history_request_errors
     - expr: sum(aws_servicequotas_operator_quota_applied_request_errors) by (cluster_id,cluster_namespace,service_name,quota_description,quota_code,quota_value)
-      record: aggregation:giantswarm:aws_servicequotas_operator_quota_applied_errors
+      record: aggregation:giantswarm:aws_servicequotas_operator_quota_applied_request_errors


### PR DESCRIPTION
This adds errors for AWS service quotas operator to Cortex

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.