### PR TITLE
Route Certificate Expiration alerts to SE team.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alerts for Loki
 - Add support for VCD provider.
 
+### Changed
+
+- Route Certificate Expiration alerts to SE team.
+
 ## [2.26.0] - 2022-06-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than one month.`}}'
         opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="aws", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="aws", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 4 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: kaas
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than one month.`}}'
         opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="azure", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="azure", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 4 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
@@ -23,9 +23,9 @@ spec:
         severity: page
         team: rocket
         topic: security
-    - alert: ManagementClusterAWSCertificateWillExpireInLessThanTwoWeeks
+    - alert: ManagementClusterAWSCertificateWillExpireInLessThanOneMonth
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than one month.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="aws", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
@@ -33,11 +33,11 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: se
         topic: security
-    - alert: ManagementClusterAzureCertificateWillExpireInLessThanTwoWeeks
+    - alert: ManagementClusterAzureCertificateWillExpireInLessThanOneMonth
       annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than one month.`}}'
         opsrecipe: renew-certificates/
       expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="azure", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
@@ -45,5 +45,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: se
         topic: security

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -21,20 +21,8 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: notify
-        team: {{ include "providerTeam" . }}
-        topic: security
-    - alert: WorkloadClusterCertificateWillExpireInLessThanAWeek
-      annotations:
-        description: '{{`Certificate {{ $labels.path }} on {{ $labels.node }} will expire in less than a week.`}}'
-        opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="workload_cluster", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 7 * 24 * 60 * 60
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: se
         topic: security
     - alert: ClusterCertificateExpirationMetricsMissing
       annotations:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22583

Ship certificates expiration alerts to SE team rather than provider team

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
