### PR TITLE
Make `ClusterAutoscalerFailedScaling` less sensitive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Split Giant Swarm and customer Flux alerts.
 - Switch `severity` of customer's Flux alerts to `notify`.
+- Make `ClusterAutoscalerFailedScaling` less sensitive.
 
 ## [2.33.0] - 2022-07-18
 

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has failed scaling up.`}}'
         opsrecipe: cluster-autoscaler-scaling/
-      expr: increase(cluster_autoscaler_failed_scale_ups_total[1h]) > 0
+      expr: increase(cluster_autoscaler_failed_scale_ups_total[5m]) > 1
       for: 15m
       labels:
         area: managedservices


### PR DESCRIPTION
Make cluster-autoscaler not page in case of some random errors by looking at a higher threshold over a shorter period of time.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
