### PR TITLE
Improve `CoreDNSDeploymentNotSatisfied` query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve `CoreDNSDeploymentNotSatisfied` query.
+
 ## [2.34.0] - 2022-07-20
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: core-dns-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_available{deployment="coredns"} / (kube_deployment_status_replicas_available{deployment="coredns"} + kube_deployment_status_replicas_unavailable{deployment="coredns"}) * 100 < 51
+      expr: sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) / (sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) + sum(kube_deployment_status_replicas_unavailable{deployment=~"coredns.*"}))* 100 < 51
       for: 10m
       labels:
         area: managedservices


### PR DESCRIPTION
in recent releases Coredns is deployed in 2 different deployments, but the old alerting rule was only considering one of the two, leading to false alerts.

This PR attempts at fixing this issue.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
