### PR TITLE
Adapt rules and alerting to gcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Inhibit gcp alerts out of business hours.
+- Don't monitor bastions on gcp.
+- Don't monitor vault on gcp.
+- Don't monitor cluster-service on gcp.
+
 ## [2.36.0] - 2022-07-20
 
 ### Added

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -36,7 +36,7 @@ phoenix
 {{- end -}}
 
 {{- define "workingHoursOnly" -}}
-{{- if has .Values.managementCluster.provider.kind (list "openstack") -}}
+{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack") -}}
 "true"
 {{- else -}}
 "false"
@@ -52,7 +52,7 @@ true
 {{- end -}}
 
 {{- define "isClusterServiceInstalled" -}}
-{{- if has .Values.managementCluster.provider.kind (list "openstack" "cloud-director" "vsphere") -}}
+{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere") -}}
 false
 {{- else -}}
 true
@@ -60,7 +60,7 @@ true
 {{- end -}}
 
 {{- define "isVaultBeingMonitored" -}}
-{{- if has .Values.managementCluster.provider.kind (list "openstack" "cloud-director" "vsphere") -}}
+{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere") -}}
 false
 {{- else -}}
 true
@@ -68,7 +68,7 @@ true
 {{- end -}}
 
 {{- define "isBastionBeingMonitored" -}}
-{{- if has .Values.managementCluster.provider.kind (list "openstack" "cloud-director" "vsphere") -}}
+{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere") -}}
 false
 {{- else -}}
 true


### PR DESCRIPTION
This PR:

- Inhibit gcp alerts out of business hours.
- Don't monitor bastions on gcp.
- Don't monitor vault on gcp.
- Don't monitor cluster-service on gcp.

