### PR TITLE
Enable api-server SLO alert during upgrades of HA masters clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't monitor bastions on gcp.
 - Don't monitor vault on gcp.
 - Don't monitor cluster-service on gcp.
+- Enable api-server SLO alert during upgrades of HA masters clusters.
 
 ## [2.36.0] - 2022-07-20
 

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -17,14 +17,18 @@ spec:
         service: api-server
       record: raw_slo_requests
     # The first statement ensures that an api-server error is counted if the kubernetes api is not up for a specific cluster.
-    # The next statement returns 1 for a cluster with "updated", "created" or unknown (absent) status.
-    # It returns 0 for clusters in "updating", "creating" and "deleting" status. 
-    # By multiplying with this statement we ensure that errors for transitioning clusters are not counted.
+    # The next statement returns 1 in 3 cases:
+    # - for a cluster with "updated", "created" status
+    # - for a cluster with unknown (absent) status.
+    # - for an HA master cluster
+    # It returns 0 otherwise.
+    # We use the second statement to avoid paging for clusters that have one master only which will obviously be down during upgrades.
     - expr: sum((up{app='kubernetes'} * -1) + 1) by (cluster_id, cluster_type) * 
             ignoring (cluster_type) group_left (cluster_id) 
             (
               max(cluster_operator_cluster_status{status=~"Updated|Created"}) by (cluster_id) 
               or absent(cluster_operator_cluster_status)
+              or (count(up{app="kubernetes"}) by (cluster_id)) > 1
             )
       labels:
         class: HIGH


### PR DESCRIPTION
SLO alerts for api-server are inhibited during HA master cluster upgrades.
We want to enabled them, but keeping them disabled for single master clusters.

This PR does just that.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
