### PR TITLE
Enable api-server SLO alert during upgrades of HA masters clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable api-server SLO alert during upgrades of HA masters clusters.
+
 ## [2.38.0] - 2022-07-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -17,14 +17,17 @@ spec:
         service: api-server
       record: raw_slo_requests
     # The first statement ensures that an api-server error is counted if the kubernetes api is not up for a specific cluster.
-    # The next statement returns 1 for a cluster with "updated", "created" or unknown (absent) status.
-    # It returns 0 for clusters in "updating", "creating" and "deleting" status. 
-    # By multiplying with this statement we ensure that errors for transitioning clusters are not counted.
+    # The next statement returns 1 in 2 cases:
+    # - for a cluster with "updated", "created" status (so that is not upgrading)
+    # - for an HA master cluster
+    # It returns 0 otherwise.
+    # We use the second statement to avoid paging for clusters that have one master only which will obviously be down during upgrades.
     - expr: sum((up{app='kubernetes'} * -1) + 1) by (cluster_id, cluster_type) * 
             ignoring (cluster_type) group_left (cluster_id) 
             (
               max(cluster_operator_cluster_status{status=~"Updated|Created"}) by (cluster_id) 
               or absent(cluster_operator_cluster_status)
+              or sgn(count(up{app='kubernetes'}) by (cluster_id) - 1)
             )
       labels:
         class: HIGH


### PR DESCRIPTION
Fix api-server slo alert and make it page for HA master clusters even during upgrades

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
