### PR TITLE
grafana cronjob alerts: add an alert based on kube job status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- alert "GrafanaFolderPermissionsCronjobFails"n
+
 ## [2.38.0] - 2022-07-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -52,9 +52,13 @@ spec:
       # We have a cronjob (grafana-permissions) that runs every 20 minutes.
       # Here we check the kubernetes job status
       annotations:
-        description: '{{`Grafana Folder updates cronjob failed for ({{ $labels.instance }}).`}}'
+        description: '{{`Grafana permissions updates cronjob failed for ({{ $labels.job_name }}).`}}'
         opsrecipe: grafana-perms/
-      expr: kube_job_status_failed{job_name=~"grafana-permissions.*"} >0
+      # expression explanation:
+      # - we create cronjob label from cron name (label_replace)
+      # - we sum number of failed to have one global value
+      # - we avg_over_time to avoid 0 value when a cron was skipped for whatever reason
+      expr: sum(label_replace(avg_over_time(kube_job_status_failed{job_name=~"grafana-permissions.*"}[60m]), "cronjob", "(", "job_name", "(grafana-permissions)-.*")) by (cronjob)")")) > 0
       for: 6h
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -47,3 +47,23 @@ spec:
         severity: notify
         team: atlas
         topic: observability
+    - alert: GrafanaFolderPermissionsCronjobFails
+      # Monitors that folder permissions job has run successfully.
+      # We have a cronjob (grafana-permissions) that runs every 20 minutes.
+      # Here we check the kubernetes job status
+      annotations:
+        description: '{{`Grafana Folder updates cronjob failed for ({{ $labels.instance }}).`}}'
+        opsrecipe: grafana-perms/
+      expr: kube_job_status_failed{job_name=~"grafana-permissions.*"} >0
+      for: 6h
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
+        topic: observability


### PR DESCRIPTION
This PR:

- adds a new alert for grafana permssions cronjob, for better coverage.
- 
Towards https://github.com/giantswarm/giantswarm/issues/22923

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
