### PR TITLE
Add more context about alerting and routing in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,70 @@ This repository contains Giant Swarm alerting and recording rules
 
 
 
+### Alerting
+
+The alerting rules are located in `helm/prometheus-rules/templates/alerting-rules`
+
+#### How alerts are structured
+
+At Giant Swarm we follow some best practices to organize our alerts:
+
+here is an example:
+
+```yaml
+  groups:
+  - name: app
+    rules:
+    - alert: ManagementClusterAppFailedAtlas
+        annotations:
+            description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
+            opsrecipe: app-failed/
+        expr: app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog=~"control-plane-.*",team="atlas"}
+        for: 30m
+        labels:
+            area: managedservices
+            cancel_if_cluster_status_creating: "true"
+            cancel_if_cluster_status_deleting: "true"
+            cancel_if_cluster_status_updating: "true"
+            cancel_if_outside_working_hours: "true"
+            severity: page
+            sig: none
+            team: atlas
+```
+
+Any Alert includes:
+
+* A description
+* An [opsrecipe](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/) 
+* Mandatory labels:
+   - `area`
+   - `team`
+   - `severity`
+
+* Optional labels:
+   - `sig`
+   - `cancel_if_.*`
+
+
+#### Routing
+
+Alertmanager does the routing based on the labels menitoned above.
+
+* `severity=page` is sent to opsgenie
+
+##### Opsgenie routing
+
+Opsgenie routing is defined in the `Teams` section.
+
+Opsgenie route alerts based on the `team` label.
+
+
+
+
+### Recording rules
+
+The recording rules are located `helm/prometheus-rules/templates/recording-rules`
+
 
 ### Mixin
 


### PR DESCRIPTION
This PR:

- Add more context about alerting and routing in the Readme

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
