### PR TITLE
update severity for grafana alerts to page

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -41,7 +41,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsCronjobFails
@@ -58,6 +58,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -28,9 +28,6 @@ spec:
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsDown
-      # Monitors that folder permissions have been updated.
-      # We have a cronjob (grafana-permissions) that runs every 20 minutes.
-      # When successfully run, folders permissions successful updates counter increases.  
       annotations:
         description: '{{`Grafana Folder not updated for ({{ $labels.instance }}).`}}'
         opsrecipe: grafana-perms/
@@ -48,16 +45,9 @@ spec:
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsCronjobFails
-      # Monitors that folder permissions job has run successfully.
-      # We have a cronjob (grafana-permissions) that runs every 20 minutes.
-      # Here we check the kubernetes job status
       annotations:
         description: '{{`Grafana permissions updates cronjob failed for ({{ $labels.job_name }}).`}}'
         opsrecipe: grafana-perms/
-      # expression explanation:
-      # - we create cronjob label from cron name (label_replace)
-      # - we sum number of failed to have one global value
-      # - we avg_over_time to avoid 0 value when a cron was skipped for whatever reason
       expr: sum(label_replace(avg_over_time(kube_job_status_failed{job_name=~"grafana-permissions.*"}[60m]), "cronjob", "(", "job_name", "(grafana-permissions)-.*")) by (cronjob)")")) > 0
       for: 6h
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -44,7 +44,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsCronjobFails
@@ -68,6 +68,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
This PR:

- update severity for grafana alerts to page

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
