### PR TITLE
alerting rules Atlas: alerts that did not page now do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - alert "GrafanaFolderPermissionsCronjobFails"n
 
+### Changed
+
+- Atlas alerts that did not page now do, at least during workhours
+
 ## [2.38.0] - 2022-07-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/daemonset.management-cluster.rules.yml
@@ -18,8 +18,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: managementcluster
     # We split up the alerts for unsatisfied daemon sets because of network
@@ -32,7 +32,7 @@ spec:
       for: 3h
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/elasticsearch.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/elasticsearch.rules.yml
@@ -82,7 +82,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: logging

--- a/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
@@ -19,13 +19,13 @@ spec:
       for: 10m
       labels:
         area: empowerment
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         cancel_if_apiserver_down: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: FluentbitDown
@@ -36,12 +36,12 @@ spec:
       for: 15m
       labels:
         area: empowerment
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         cancel_if_apiserver_down: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentd.rules.yml
@@ -21,7 +21,7 @@ spec:
       for: 5m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsDown
@@ -44,7 +44,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsCronjobFails
@@ -68,6 +68,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
@@ -18,8 +18,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeDaemonSetCreatedMetricMissing
@@ -30,8 +30,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeDeploymentCreatedMetricMissing
@@ -42,8 +42,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeEndpointCreatedMetricMissing
@@ -54,8 +54,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeNamespaceCreatedMetricMissing
@@ -66,8 +66,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeNodeCreatedMetricMissing
@@ -78,8 +78,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubePodCreatedMetricMissing
@@ -90,8 +90,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeReplicaSetCreatedMetricMissing
@@ -102,8 +102,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeSecretCreatedMetricMissing
@@ -114,8 +114,8 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes
     - alert: KubeServiceCreatedMetricMissing
@@ -126,7 +126,7 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -28,7 +28,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: LokiRequestPanics
@@ -45,6 +45,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
@@ -19,8 +19,8 @@ spec:
       for: 5m
       labels:
         area: managedservices
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: logging
     - alert: ManagedLoggingElasticsearchClusterDown
@@ -31,7 +31,7 @@ spec:
       for: 5m
       labels:
         area: managedservices
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: logging

--- a/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
@@ -17,8 +17,8 @@ spec:
       for: 5m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: observability
     - alert: NodeExporterDeviceError
@@ -28,7 +28,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -36,7 +36,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorWatchErrors
@@ -47,7 +47,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorSyncFailed
@@ -58,7 +58,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorReconcileErrors
@@ -69,7 +69,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorNodeLookupErrors
@@ -80,7 +80,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorNotReady
@@ -91,7 +91,7 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
     - alert: PrometheusOperatorRejectedResources
@@ -102,6 +102,6 @@ spec:
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -39,8 +39,8 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_kubelet_down: "true"
         cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: atlas
         topic: observability
     - alert: KubeStateMetricsDown

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -39,7 +39,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_kubelet_down: "true"
         cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
This PR changes Atlas alerts from "severity: notify" to "severity: page".

Related to:
* https://github.com/giantswarm/giantswarm/issues/22923
* https://github.com/giantswarm/giantswarm/issues/22944
* https://github.com/giantswarm/giantswarm/issues/22920

We had a few tickets where we detected problems without alerts.
The alerting rules were existing, but not paging.

According to alertmanager config, it seems `severity: notify` alerts are sent to Slack, but at Atlas we don't look much at it.
On top of that, the recent alerts I created were supposed to page, but I did not understand the severity setting and misused it.

So I propose to set all the Atlas alerts to `severity: page`, but in order to avoid an increase of area oncall alerts during the night, I also set most of them to only page during workhours.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
