### PR TITLE
fix GrafanaFolderPermissionsCronjobFails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### fixed
+
+- GrafanaFolderPermissionsCronjobFails alert
+
 ## [2.39.0] - 2022-07-27
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -58,7 +58,7 @@ spec:
       # - we create cronjob label from cron name (label_replace)
       # - we sum number of failed to have one global value
       # - we avg_over_time to avoid 0 value when a cron was skipped for whatever reason
-      expr: sum(label_replace(avg_over_time(kube_job_status_failed{job_name=~"grafana-permissions.*"}[60m]), "cronjob", "$1", "job_name", "(grafana-permissions)-.*")) by (cronjob) > 0
+      expr: sum(label_replace(avg_over_time(kube_job_status_failed{job_name=~"grafana-permissions.*", reason!="BackoffLimitExceeded"}[60m]), "cronjob", "$1", "job_name", "(grafana-permissions)-.*")) by (cronjob) > 0
       for: 6h
       labels:
         area: managedservices


### PR DESCRIPTION
This PR:

- Fixes GrafanaFolderPermissionsCronjobFails alert. For whatever reason, `reason="BackoffLimitExceeded"` always return 1, so we should filter them out.



### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
