### PR TITLE
GranafaDown: set severity to notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- GrafanaDown does not page anymore
+
 ## [2.39.1] - 2022-07-27
 
 ### fixed

--- a/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/grafana.management-cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: page
+        severity: notify
         team: atlas
         topic: observability
     - alert: GrafanaFolderPermissionsDown


### PR DESCRIPTION
This PR:

- Sets `GrafanaDown` alert to stop paging.
- Related to https://github.com/giantswarm/giantswarm/issues/22922 - once this issue is fixed, we should set it back to paging.


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
