### PR TITLE
NodeExporterCollectorFailed does not page anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- NodeExporterCollectorFailed does not page anymore
 - GrafanaDown does not page anymore
 
 ## [2.39.1] - 2022-07-27

--- a/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
@@ -18,7 +18,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: atlas
         topic: observability
     - alert: NodeExporterDeviceError


### PR DESCRIPTION
This PR:

- NodeExporterCollectorFailed does not page anymore. 
Related to https://github.com/giantswarm/giantswarm/issues/23002 - we can set it back to paging once the issue is fixed.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
