### PR TITLE
Make InhibitionClusterStatusCreating last longer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make InhibitionClusterStatusCreating last longer.
 
 ## [2.40.0] - 2022-08-01
 

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: InhibitionClusterStatusCreating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Creating''.`}}'
-      expr: statusresource_cluster_status{status="Creating"} == 1 or cluster_operator_cluster_status{status="Creating"} == 1
+      expr: max_over_time(statusresource_cluster_status{status="Creating"}[30m]) == 1 or max_over_time(cluster_operator_cluster_status{status="Creating"}[30m]) == 1
       labels:
         area: kaas
         cluster_status_creating: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22719

This PR:

- makes the `InhibitionClusterStatusCreating` inhibition last at least 30m after the creating condition is flipped to avoid useless pages for new clusters.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
