### PR TITLE
CadvisorDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Inhibit CadvisorDown with InhibitionKubeletDown
-- Extend delay CadvisorDown to 1h
+- Inhibit CadvisorDown with InhibitionKubeletDown.
+- Extend delay CadvisorDown to 1h.
+- CadvisorDown only triggered during working hours.
 
 ## [2.41.0] - 2022-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Add InhibitionKubeletDown to bring back kubelet down inhibition.
+
+## Changed
+
+- Inhibit CadvisorDown with InhibitionKubeletDown
+- Extend delay CadvisorDown to 1h
+
 ## [2.41.0] - 2022-08-02
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -27,7 +27,7 @@ spec:
         area: kaas
         topic: kubernetes
       annotations:
-        description: Kubelet ({{ $labels.ip }}) is down.
+        description: '{{`Kubelet ({{ $labels.instance }}) is down.`}}'
     - alert: InhibitionKubeStateMetricsDown
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -20,6 +20,14 @@ spec:
         outside_working_hours: "true"
         team: phoenix
         topic: monitoring
+    - alert: InhibitionKubeletDown
+      expr: up{app="kubelet"} == 0
+      labels:
+        kubelet_down: true
+        area: kaas
+        topic: kubernetes
+      annotations:
+        description: Kubelet ({{ $labels.ip }}) is down.
     - alert: InhibitionKubeStateMetricsDown
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -32,7 +32,6 @@ spec:
       annotations:
         description: '{{`Cadvisor ({{ $labels.ip }}) is down.`}}'
       expr: up{app="cadvisor"} == 0
-      for: 15m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -32,6 +32,7 @@ spec:
       annotations:
         description: '{{`Cadvisor ({{ $labels.ip }}) is down.`}}'
       expr: up{app="cadvisor"} == 0
+      for: 1h
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -39,7 +39,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_kubelet_down: "true"
         cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23029

This PR add an inhibition when kubelet are down and use this to silence CadvisorDown when needed. Also extend delay to 1h, and make it page only during working hours.

* extend CadvisorDown delay to 1h
* bring back KubeletDown inhibition
* CadvisorDown only page during working hours