### PR TITLE
CadvisorDown description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fix description and add opsrecipe for CadvisorDown.
+
 ## [2.42.0] - 2022-08-03
 
 ## Added

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -32,7 +32,6 @@ spec:
       annotations:
         description: '{{`Cadvisor ({{ $labels.ip }}) is down.`}}'
       expr: up{app="cadvisor"} == 0
-      for: 1h
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -31,6 +31,7 @@ spec:
     - alert: CadvisorDown
       annotations:
         description: '{{`Cadvisor ({{ $labels.instance }}) is down.`}}'
+        opsrecipe: kubelet-is-down/
       expr: up{app="cadvisor"} == 0
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -30,7 +30,7 @@ spec:
         topic: releng
     - alert: CadvisorDown
       annotations:
-        description: '{{`Cadvisor ({{ $labels.ip }}) is down.`}}'
+        description: '{{`Cadvisor ({{ $labels.instance }}) is down.`}}'
       expr: up{app="cadvisor"} == 0
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23029

- add opsrecipe: [kubelet-is-down/](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/kubelet-is-down/)
- fix CadvisorDown description

![image](https://user-images.githubusercontent.com/6536819/182634225-fdede65b-ebd2-45d4-9801-23409a9432da.png)
