### PR TITLE
Add Opsrecipe for prometheus rule failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ops-recipe for prometheus rule failures.
+
 ## [2.42.2] - 2022-08-04
 
 ## Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -43,6 +43,7 @@ spec:
       annotations:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.2f" $value }} time(s).`}}
         summary: Prometheus is failing rule evaluations.
+        opsrecipe: prometheus-rule-failures/
       expr: rate(prometheus_rule_evaluation_failures_total[30m]) > 0
       for: 1h
       labels:


### PR DESCRIPTION
To merge after https://github.com/giantswarm/giantswarm/pull/23113/files

This PR:

- Add Opsrecipe for prometheus rule failure

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
