### PR TITLE
Add GCP alerts for Team Hydra business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add ops-recipe for prometheus rule failures.
+- Add ManagementClusterAppFailedHydra (Team Hydra alert for GCP). 
+- Add WorkloadClusterAppFailedHydra (Team Hydra alert for GCP). 
+- Add ManagementClusterPodPendingGCP (Team Hydra alert for GCP). 
+- Add ManagementClusterContainerIsRestartingTooFrequentlyGCP (Team Hydra alert for GCP). 
+- Add ManagementClusterDeploymentMissingGCP (Team Hydra alert for GCP).
+- Add WorkloadClusterContainerIsRestartingTooFrequentlyGCP (Team Hydra alert for GCP).
+- Add WorkloadClusterCriticalPodNotRunningGCP (Team Hydra alert for GCP).
+- Add WorkloadClusterPodPendingGCP (Team Hydra alert for GCP).
+- Enable CAPI alerts (MachineUnhealthyPhase, MachineDeploymentReplicasMismatch, KubeadmControlPlaneReplicasMismatch, ClusterUnhealthyPhase) for GCP.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -30,6 +30,8 @@ giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- define "providerTeam" -}}
 {{- if has .Values.managementCluster.provider.kind (list "kvm" "openstack" "cloud-director" "vsphere") -}}
 rocket
+{{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa" "capz") -}}
+hydra
 {{- else -}}
 phoenix
 {{- end -}}

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -75,6 +75,22 @@ spec:
         sig: none
         team: phoenix
         topic: releng
+    - alert: ManagementClusterAppFailedHydra
+      annotations:
+        description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
+        opsrecipe: app-failed/
+      expr: app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog=~"control-plane-.*",team=~"hydra"}
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        sig: none
+        team: hydra
+        topic: releng
     - alert: ManagementClusterAppFailedRainbow
       annotations:
         description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
@@ -129,7 +145,7 @@ spec:
       annotations:
         description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog!~"control-plane-.*", team!~"(?i:(atlas|cabbage|phoenix|rocket))"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog!~"control-plane-.*", team!~"(?i:(atlas|cabbage|phoenix|hydra|rocket))"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 30m
       labels:
         area: managedservices
@@ -189,6 +205,23 @@ spec:
         severity: page
         sig: none
         team: phoenix
+        topic: releng
+    - alert: WorkloadClusterAppFailedHydra
+      annotations:
+        description: '{{`Workload Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
+        opsrecipe: app-failed/
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog!~"control-plane-.*", team="hydra"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        severity: page
+        sig: none
+        team: hydra
         topic: releng
     - alert: WorkloadClusterAppFailedRocket
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.managementCluster.provider.kind "openstack") }}
+{{- if or (eq .Values.managementCluster.provider.kind "openstack") (eq .Values.managementCluster.provider.kind "gcp") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
@@ -1,0 +1,61 @@
+{{- if eq .Values.managementCluster.provider.kind "gcp" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+      {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: gcp.management-cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: gcp
+    rules:
+    - alert: ManagementClusterPodPendingGCP
+      annotations:
+        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
+        opsrecipe: pod-stuck-in-pending/
+      expr: kube_pod_status_phase{namespace="giantswarm|kube-system",pod=~"(capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*)",phase="Pending"} == 1
+      for: 25m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        severity: page
+        team: hydra
+        topic: managementcluster
+    - alert: ManagementClusterContainerIsRestartingTooFrequentlyGCP
+      annotations:
+        description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
+        opsrecipe: container-is-restarting-too-often/
+      expr: increase(kube_pod_container_status_restarts_total{container=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*"}[1h]) > 6
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: hydra
+        topic: kubernetes
+    - alert: ManagementClusterDeploymentMissingGCP
+      annotations:
+        description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
+        opsrecipe: management-cluster-deployment-is-missing/
+      expr: absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", deployment~="capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*"})
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: hydra
+        topic: kubernetes
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
-      expr: kube_pod_status_phase{namespace="giantswarm|kube-system",pod=~"(capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*)",phase="Pending"} == 1
+      expr: kube_pod_status_phase{namespace=~"giantswarm|kube-system",pod=~"(capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*|dns-operator-gcp.*|.*workload-identity-operator-gcp.*)",phase="Pending"} == 1
       for: 25m
       labels:
         area: kaas
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{container=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*"}[1h]) > 6
+      expr: increase(kube_pod_container_status_restarts_total{container=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*"|dns-operator-gcp.*|.*workload-identity-operator-gcp.*}[1h]) > 6
       for: 5m
       labels:
         area: kaas
@@ -47,7 +47,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/
-      expr: absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", deployment~="capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*"})
+      expr: absent(kube_deployment_status_condition{namespace=~"giantswarm|kube-system", condition="Available", deployment=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|dns-operator-gcp.*|.*workload-identity-operator-gcp.*"})
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
@@ -1,0 +1,63 @@
+{{- if eq .Values.managementCluster.provider.kind "gcp" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "workload_cluster"
+  name: gcp.workload-cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: gcp
+    rules:
+    - alert: WorkloadClusterContainerIsRestartingTooFrequentlyGCP
+      annotations:
+        description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
+        opsrecipe: container-is-restarting-too-often/
+      expr: increase(kube_pod_container_status_restarts_total{container=~"cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*"}[1h]) > 10
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        severity: page
+        team: hydra
+        topic: kubernetes
+    - alert: WorkloadClusterCriticalPodNotRunningGCP
+      annotations:
+        description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: kube_pod_container_status_running{container=~"(kube-apiserver|kube-controller-manager|kube-scheduler)"} != 1 or label_replace(absent(kube_pod_container_status_running{container="kube-apiserver"}), "pod", "$1", "container", "(.+)") == 1 or label_replace(absent(kube_pod_container_status_running{container="kube-controller-manager"}), "pod", "$1", "container", "(.+)") == 1 or label_replace(absent(kube_pod_container_status_running{container="kube-scheduler"}), "pod", "$1", "container", "(.+)") == 1
+      for: 1h
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: hydra
+        topic: kubernetes
+    - alert: WorkloadClusterPodPendingGCP
+      annotations:
+        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
+        opsrecipe: pod-stuck-in-pending/
+      expr: kube_pod_status_phase{namespace="kube-system",pod=~"(cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*)",phase="Pending"} == 1
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        severity: page
+        team: hydra
+        topic: kubernetes
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{container=~"cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*"}[1h]) > 10
+      expr: increase(kube_pod_container_status_restarts_total{container=~"cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*|.*workload-identity-operator-gcp.*"}[1h]) > 10
       for: 10m
       labels:
         area: kaas
@@ -47,7 +47,7 @@ spec:
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: pod-stuck-in-pending/
-      expr: kube_pod_status_phase{namespace="kube-system",pod=~"(cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*)",phase="Pending"} == 1
+      expr: kube_pod_status_phase{namespace=~"giantswarm|kube-system",pod=~"(cilium.*|csi-gce-pd-controller.*|csi-gce-pd-node.*|.*workload-identity-operator-gcp.*)",phase="Pending"} == 1
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
This PR adds GCP-equivalents of alerts that we already have for AWS and Azure.

- Add ManagementClusterAppFailedHydra (Team Hydra alert for GCP). 
- Add WorkloadClusterAppFailedHydra (Team Hydra alert for GCP). 
- Add ManagementClusterPodPendingGCP (Team Hydra alert for GCP). 
- Add ManagementClusterContainerIsRestartingTooFrequentlyGCP (Team Hydra alert for GCP). 
- Add ManagementClusterDeploymentMissingGCP (Team Hydra alert for GCP).
- Add WorkloadClusterContainerIsRestartingTooFrequentlyGCP (Team Hydra alert for GCP).
- Add WorkloadClusterCriticalPodNotRunningGCP (Team Hydra alert for GCP).
- Add WorkloadClusterPodPendingGCP (Team Hydra alert for GCP).
- Enable CAPI alerts (MachineUnhealthyPhase, MachineDeploymentReplicasMismatch, KubeadmControlPlaneReplicasMismatch, ClusterUnhealthyPhase) for GCP.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
