### PR TITLE
fix prometheus-meta-operator reconcile errors alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prometheus-meta-operator reconcile errors alert are now limited to prometheus-meta-operator
+
 ## [2.43.0] - 2022-08-11
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -53,7 +53,7 @@ spec:
         description: '{{`prometheus-meta-operator controller {{ $labels.controller }} too many reconcile errors.`}}'
         opsrecipe: "pmo-reconcile-errors/"
       expr: |
-        avg_over_time(operatorkit_controller_errors_total[20m]) > 0
+        avg_over_time(operatorkit_controller_errors_total{app="prometheus-meta-operator"}[20m]) > 0
       for: 1h
       labels:
         area: "empowerment"


### PR DESCRIPTION

This PR:

- fixes prometheus-meta-operator reconcile errors alerts: they are now only checking prometheus-meta-operator.
Towards https://github.com/giantswarm/roadmap/issues/1175

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
