### PR TITLE
fix `cluster_id` in `InhibitionClusterStatus*` inhibition alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GrafanaDown page again
 
+### Fixed
+
+- Fix `cluster_id` in `InhibitionClusterStatus*` inhibition alerts.
+
 ## [2.42.2] - 2022-08-04
 
 ## Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: InhibitionClusterStatusCreating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Creating''.`}}'
-      expr: max_over_time(statusresource_cluster_status{status="Creating"}[30m]) == 1 or max_over_time(cluster_operator_cluster_status{status="Creating"}[30m]) == 1
+      expr: label_replace(max_over_time(statusresource_cluster_status{status="Creating"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Creating"}[30m]) == 1
       labels:
         area: kaas
         cluster_status_creating: "true"
@@ -23,7 +23,7 @@ spec:
     - alert: InhibitionClusterStatusCreated
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Created''.`}}'
-      expr: statusresource_cluster_status{status="Created"} == 1 or cluster_operator_cluster_status{status="Created"} == 1
+      expr: label_replace(statusresource_cluster_status{status="Created"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Created"} == 1
       labels:
         area: kaas
         cluster_status_created: "true"
@@ -32,7 +32,7 @@ spec:
     - alert: InhibitionClusterStatusUpdating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updating''.`}}'
-      expr: statusresource_cluster_status{status="Updating"} == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or changes(statusresource_cluster_status{status="Updating"}[10m]) == 1 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) == 1
+      expr: label_replace(statusresource_cluster_status{status="Updating"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or label_replace(changes(statusresource_cluster_status{status="Updating"}[10m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) == 1
       labels:
         area: kaas
         cluster_status_updating: "true"
@@ -41,7 +41,7 @@ spec:
     - alert: InhibitionClusterStatusUpdated
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updated''.`}}'
-      expr: statusresource_cluster_status{status="Updated"} == 1 or cluster_operator_cluster_status{status="Updated"} == 1
+      expr: label_replace(statusresource_cluster_status{status="Updated"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updated"} == 1
       labels:
         area: kaas
         cluster_status_updated: "true"
@@ -50,7 +50,7 @@ spec:
     - alert: InhibitionClusterStatusDeleting
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Deleting''.`}}'
-      expr: max_over_time(statusresource_cluster_status{status="Deleting"}[30m]) == 1 or max_over_time(cluster_operator_cluster_status{status="Deleting"}[30m]) == 1
+      expr: label_replace(max_over_time(statusresource_cluster_status{status="Deleting"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Deleting"}[30m]) == 1
       labels:
         area: kaas
         cluster_status_deleting: "true"


### PR DESCRIPTION
Today I got paged with [gollum / g3k7i - MatchingNumberOfPrometheusAndCluster](https://giantswarm.app.opsgenie.com/alert/detail/e6ecfc51-a72c-45a1-b99a-01c4ff2dd10e-1660560008294/logs) at 12:40 UTC+2

This alert is set to [page after 10mn](https://github.com/giantswarm/prometheus-rules/blob/b2483b48f5b87ab52510d3162c23723347ccb76d/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml#L24-L41), which is basically what happened

![image](https://user-images.githubusercontent.com/6536819/184632472-6afb7454-a49b-4663-9f8b-c0e140c95ee9.png)

even though this alert is supposed to be silenced when cluster are creating via the `cancel_if_cluster_status_creating` label

Checking closer the `InhibitionClusterStatusCreating` alert I found out that the `cluster_id` label was missing

![image](https://user-images.githubusercontent.com/6536819/184632960-d7e90121-6670-41ca-a4ea-8b54b6739e83.png)

but the correct value is in `exported_cluster_id` label.

So this PR adds add the correct `cluster_id` label in all Inhibition relying on the `statusresource_cluster_status` metric. 