### PR TITLE
Include $labels.name in team WorkloadClusterWebhookDurationExceedsTim…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `$labels.name` to team `WorkloadClusterWebhookDurationExceedsTimeout` alerts.
+
 ## [2.44.0] - 2022-08-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -44,7 +44,7 @@ spec:
     # Webhooks that are not explicitely owner by any team (customer owned ones).
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutSolutionEngineers
       annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
       expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name!~".*(prometheus|vpa.k8s.io|linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io|kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
@@ -58,7 +58,7 @@ spec:
       # Webhooks owned by Honeybadger
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutHoneybadger
       annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
       expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(kyverno|app-admission-controller).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
@@ -72,7 +72,7 @@ spec:
       # Webhooks owned by Cabbage
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutCabbage
       annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
       expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(linkerd|validate.nginx.ingress.kubernetes.io|kong.konghq.com|cert-manager.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m
@@ -86,7 +86,7 @@ spec:
       # Webhooks owned by Atlas
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutAtlas
       annotations:
-        description: '{{`Kubernetes API Server admission webhook for {{ $labels.cluster_id }} is timing out.`}}'
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} for {{ $labels.cluster_id }} is timing out.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
       expr: rate(apiserver_admission_webhook_admission_duration_seconds_count{cluster_type="workload_cluster",name=~".*(prometheus|vpa.k8s.io).*"}[5m]) > 0 AND rate(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) / rate(apiserver_admission_webhook_admission_duration_seconds_count[5m]) > 8
       for: 15m


### PR DESCRIPTION
…eout alerts

This PR:

- Adds $labels.name to team WorkloadClusterWebhookDurationExceedsTimeout alerts

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
