### PR TITLE
Increase timeout for `VaultIsDown` to 15 minutes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extending time period for AWS cluster updates.
 - Add `$labels.name` to team `WorkloadClusterWebhookDurationExceedsTimeout` alerts.
+- Increase timeout for `VaultIsDown` to 15 minutes.
 
 ## [2.44.0] - 2022-08-12
 

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Vault is down.`}}'
         opsrecipe: vault-is-down/
       expr: vault_up == 0
-      for: 5m
+      for: 15m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}


### PR DESCRIPTION
This PR:

- When rolling vault to renew certificates, vault service might be down for more than 5 minutes. This PR raises the alert timeout to avoid unneeded alerts


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
