### PR TITLE
Fix ManagementClusterContainerIsRestartingTooFrequentlyGCP expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ManagementClusterContainerIsRestartingTooFrequentlyGCP expression.
+
 ## [2.45.0] - 2022-08-18
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{container=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*"|dns-operator-gcp.*|.*workload-identity-operator-gcp.*}[1h]) > 6
+      expr: increase(kube_pod_container_status_restarts_total{container=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|cilium.*|csi-gce-pd-node.*|dns-operator-gcp.*|.*workload-identity-operator-gcp.*"}[1h]) > 6
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
This PR:

- Fixes ManagementClusterContainerIsRestartingTooFrequentlyGCP expression.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
