### PR TITLE
cert manager cert requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CertManagerTooManyCertificateRequests (Team Cabbage).
+
 ## [2.45.1] - 2022-08-23
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -46,7 +46,7 @@ spec:
       expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
       for: 15m
       labels:
-        area: managedapps
+        area: managedservices
         cancel_if_outside_working_hours: "true"
         severity: notify
         team: cabbage

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -39,3 +39,15 @@ spec:
         severity: page
         team: cabbage
         topic: cert-manager
+    - alert: CertManagerTooManyCertificateRequests
+      annotations:
+        description: '{{`There are too many CertificateRequests in cluster {{ $labels.cluster_id }}.`}}'
+        opsrecipe: cert-requests-too-many/
+      expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 5000
+      for: 15m
+      labels:
+        area: managedapps
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: cabbage
+        topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`There are too many CertificateRequests in cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: cert-requests-too-many/
-      expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 5000
+      expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
       for: 15m
       labels:
         area: managedapps


### PR DESCRIPTION
This PR:

Add CertManagerTooManyCertificateRequests alert to identify early possible control plane overloading.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [x] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
