### PR TITLE
Adding Flux alert for stuck image automation controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `FluxImageAutomationControllerStuck` alert for stuck Flux Image Automation Controller.
+
 ## [2.45.1] - 2022-08-23
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -130,6 +130,20 @@ spec:
         severity: page
         team: honeybadger
         topic: releng
+    - alert: FluxImageAutomationControllerStuck
+      annotations:
+        description: |-
+          {{`Flux Image Automation Controller on {{ $labels.installation }} seems stuck.`}}
+        opsrecipe: flux-image-automation-stuck/
+      expr: |
+        sum(irate(workqueue_unfinished_work_seconds{name="imageupdateautomation",cluster_type="management_cluster",namespace="flux-system"}[15m])) > 0
+      for: 30m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: honeybadger
+        topic: releng
   # Customer's Alerts
   - name: fluxcd-customer
     rules:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23428

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
