### PR TITLE
Enable alerts for dex in workload clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable alerts for dex in workload clusters with "highest" service priority.
+
 ### Added
 
 - Add CertManagerTooManyCertificateRequests (Team Cabbage).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enable alerts for dex in workload clusters with "highest" service priority.
+- Enable alerts for dex in workload clusters.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CertManagerTooManyCertificateRequests (Team Cabbage).
+
 ## [2.46.0] - 2022-08-26
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -39,3 +39,15 @@ spec:
         severity: page
         team: cabbage
         topic: cert-manager
+    - alert: CertManagerTooManyCertificateRequests
+      annotations:
+        description: '{{`There are too many CertificateRequests in cluster {{ $labels.cluster_id }}.`}}'
+        opsrecipe: cert-requests-too-many/
+      expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
+      for: 15m
+      labels:
+        area: managedservices
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: cabbage
+        topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "management_cluster"
   name: dex.rules
   namespace: {{ .Values.namespace  }}
 spec:
@@ -15,7 +14,7 @@ spec:
       annotations:
         description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
         opsrecipe: dex-error-rate-high/
-      expr: sum(increase(http_requests_total{service="dex", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
+      expr: sum(increase(http_requests_total{app="dex", code=~"^[4]..$|[5]..$", service_priority="highest"}[5m])) by (cluster_id) > 10
       for: 30m
       labels:
         area: managedapps

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
         opsrecipe: dex-error-rate-high/
-      expr: sum(increase(http_requests_total{app="dex", code=~"^[4]..$|[5]..$", service_priority="highest"}[5m])) by (cluster_id) > 10
+      expr: sum(increase(http_requests_total{app="dex", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
       for: 30m
       labels:
         area: managedapps


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1359

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
