### PR TITLE
Lowered ManagedLoggingElasticsearchDataNodesNotSatisfied alert sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lowered `ManagedLoggingElasticsearchDataNodesNotSatisfied` alert sensitivity - now triggers after 15min to avoid triggering on pod restarts.
+
 ## [2.47.1] - 2022-09-06
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
@@ -16,7 +16,7 @@ spec:
         description: '{{`Number of data nodes of Elastic Search on {{ $labels.cluster_id }} is not satified.`}}'
         opsrecipe: managed-logging-create/
       expr: sum(elasticsearch_cluster_health_number_of_data_nodes) by (cluster_id) < 3
-      for: 5m
+      for: 15m
       labels:
         area: managedservices
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION

This PR:
- Lowers `ManagedLoggingElasticsearchDataNodesNotSatisfied` alert sensitivity - now triggers after 15min to avoid triggering on pod restarts
- 
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
