### PR TITLE
Add `FlowcontrolRejectedRequests` to alert when k8s API Server's fairness is rejecting API calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `FlowcontrolRejectedRequests` to alert when k8s API Server's fairness is rejecting API calls.
+
 ### Changed
 
 - Lowered `ManagedLoggingElasticsearchDataNodesNotSatisfied` alert sensitivity - now triggers after 15min to avoid triggering on pod restarts.

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -1,7 +1,6 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: fairness.rules

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: fairness.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: fairness
+    rules:
+    - alert: FlowcontrolRejectedRequests
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} .`}}'
+        opsrecipe: flowcontrol-rejected-requests/
+      expr: (increase(apiserver_flowcontrol_rejected_requests_total[1m]) > 0)
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{include "providerTeam" .}}
+        topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: FlowcontrolRejectedRequests
       annotations:
-        description: '{{`Cluster {{ $labels.cluster_id }} .`}}'
+        description: '{{`Cluster {{ $labels.installation }}/{{ $labels.cluster_id }}: k8s API fairness is rejecting calls in flow schema {{ $labels.flow_schema }}.`}}'
         opsrecipe: flowcontrol-rejected-requests/
       expr: (increase(apiserver_flowcontrol_rejected_requests_total[1m]) > 0)
       for: 5m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1360

This PR adds a new alert that fires if the API server's fairness subsystem is rejecting at least one API call for 5 minutes straight.
This should help us detect underprovisioned master nodes in both MCs and WCs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [x] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
