### PR TITLE
Fix azure cluster releases query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `aggregation:giantswarm:cluster_release_version` query for Azure cluster.
+
 ## [2.48.0] - 2022-09-08
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -54,7 +54,7 @@ spec:
       record: aggregation:giantswarm:app_upgrade_available
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)
       record: aggregation:giantswarm:cluster_certificate_not_after_seconds
-    - expr: sum(azure_operator_cluster_release{release_version!=""}) by (release_version, cluster_id) or sum(cluster_service_cluster_info) by (release_version, cluster_id) / 2 or sum(cluster_operator_cluster_status{release_version!=""}) by (release_version, cluster_id)
+    - expr: sum(label_replace(azure_operator_cluster_release{release_version!=""}, "cluster_id", "$1", "exported_cluster_id", "(.*)")) by (release_version, cluster_id) or sum(cluster_service_cluster_info) by (release_version, cluster_id) / 2 or sum(cluster_operator_cluster_status{release_version!=""}) by (release_version, cluster_id)
       record: aggregation:giantswarm:cluster_release_version
     - expr: avg_over_time(cluster_operator_cluster_create_transition[1w]) or avg_over_time(azure_operator_cluster_create_transition[1w])
       record: aggregation:giantswarm:cluster_transition_create


### PR DESCRIPTION
The azure cluster release query used to ship data to cortex exports the installation name in place of the WC name:

![wrong](https://user-images.githubusercontent.com/868430/189165760-374cc6ee-ddeb-4bf3-ad6c-1c632692612c.png)

This PR fixes that.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
