### PR TITLE
fix opsrecipe links

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: DockerMemoryUsageTooHigh
       annotations:
         description: '{{`Docker memory usage on {{ $labels.instance }} is too high.`}}'
-        opsrecipe: docker-memory-usage-high
+        opsrecipe: docker-memory-usage-high/
       expr: process_resident_memory_bytes{app="docker", cluster_type="management_cluster"} > (5 * 1024 * 1024 * 1024)
       for: 15m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: DockerMemoryUsageTooHigh
       annotations:
         description: '{{`Docker memory usage on {{ $labels.instance }} is too high.`}}'
-        opsrecipe: docker-memory-usage-high
+        opsrecipe: docker-memory-usage-high/
       expr: process_resident_memory_bytes{app="docker", cluster_type="workload_cluster"} > (5 * 1024 * 1024 * 1024)
       for: 15m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: ManagementClusterEtcdCommitDurationTooHigh
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'
-        opsrecipe: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/etcd-high-commit-duration/
+        opsrecipe: etcd-high-commit-duration/
       expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster"}[5m])) > 1.0
       for: 15m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -29,7 +29,7 @@ spec:
     - alert: WorkloadClusterEtcdCommitDurationTooHigh
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'
-        opsrecipe: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/etcd-high-commit-duration/
+        opsrecipe: etcd-high-commit-duration/
       expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster"}[5m])) > 1.0
       for: 15m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -54,7 +54,7 @@ spec:
     - alert: IngressControllerServiceHasNoEndpoints
       annotations:
         description: '{{`Ingress Controller has no live endpoints.`}}'
-        opsrecipe: ingress-controller-no-live-endpoints.md
+        opsrecipe: ingress-controller-no-live-endpoints/
       expr: count by (cluster_id) (kube_endpoint_address_available{endpoint="nginx-ingress-controller"}) == 0
       for: 2m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: LokiRequestErrors
       annotations:
         description: This alert checks that we have less than 10% errors on Loki requests.
-        opsrecipe: loki
+        opsrecipe: loki/
       expr: |
         100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[1m])) by (namespace, job, route)
           /
@@ -34,7 +34,7 @@ spec:
     - alert: LokiRequestPanics
       annotations:
         description: This alert checks that we have no panic errors on Loki.
-        opsrecipe: loki
+        opsrecipe: loki/
       expr: |
         sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
       labels:


### PR DESCRIPTION
This PR:

- fixes ops-recipe names so we generate working links


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
