### PR TITLE
Make WC pod restart alert filter by namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `NodeHasConstantOOMKills` to consider only pods managed by us.
+
 ## [2.49.0] - 2022-09-20
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -64,7 +64,7 @@ spec:
     - alert: NodeHasConstantOOMKills
       annotations:
         description: '{{`Node {{ $labels.ip }} has constant OOM kills.`}}'
-      expr: kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 1h >= 1 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{reason='OOMKilled'} > 0
+      expr: kube_pod_container_status_restarts_total{namespace=~"(giantswarm|kube-system)"} - kube_pod_container_status_restarts_total offset 1h >= 1 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{reason='OOMKilled'} > 0
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -62,6 +62,8 @@ spec:
         team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: NodeHasConstantOOMKills
+      # Check if a core component is restarted because memory reasons
+      # in the last hour.
       annotations:
         description: '{{`Node {{ $labels.ip }} has constant OOM kills.`}}'
       expr: kube_pod_container_status_restarts_total{namespace=~"(giantswarm|kube-system)"} - kube_pod_container_status_restarts_total offset 1h >= 1 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{reason='OOMKilled'} > 0


### PR DESCRIPTION
This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
