### PR TITLE
add recording rule for k8s-authenticator requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `aggregation:dex_k8s_authenticator_requests` recording rule.
+
 ### Changed
 
 - Change `NodeHasConstantOOMKills` to consider only pods managed by us.

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -219,6 +219,9 @@ spec:
       record: aggregation:dex_requests_status_ok
     - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_email, user_name)
       record: aggregation:grafana_analytics_sessions_total
+    # Requests to the deprecated k8s authenticator. TODO: Get rid of this recording rule when the component is no longer used.
+    - expr: nginx_ingress_controller_requests{ingress="dex-k8s-authenticator"}
+      record: aggregation:dex_k8s_authenticator_requests
     # Falco event counts
     - expr: sum(falco_events{priority=~"0|1|2|3|4|5|6|7"}) by (cluster_type, cluster_id, priority, rule)
       record: aggregation:falco_events


### PR DESCRIPTION
This PR:

- adds a recording rule for dex k8s authenticator requests. 
Towards https://github.com/giantswarm/roadmap/issues/1228
We want to be able to see where the component is still used so we can talk to customers and replace it.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
