### PR TITLE
ensure rocket aren't alerted for gcp and aws clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `NodeHasConstantOOMKills` to consider only pods managed by us.
+- Stop Rocket being alerted for AWS and GCP clusters.
 
 ## [2.49.0] - 2022-09-20
 

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -102,7 +102,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="prometheus.*|promxy.*|.*-admission-controller.*|aws-*|route53-manager.*"}[1h]) > 5
+      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="prometheus.*|promxy.*|.*-admission-controller.*|*-aws-*|route53-manager.*|*-gcp-*"}[1h]) > 5
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -102,7 +102,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="prometheus.*|promxy.*|.*-admission-controller.*|*-aws-*|route53-manager.*|*-gcp-*"}[1h]) > 5
+      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="prometheus.*|promxy.*|.*-admission-controller.*|*-aws-*|aws-*|route53-manager.*|*-gcp-*|gcp-*"}[1h]) > 5
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/23780

This PR:

- Stops Rocket being alerted for AWS and GCP.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
