### PR TITLE
PR templates: ask to add tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Changelog must always be updated.
 ### Checklist
 
 - [ ] Update changelog in CHANGELOG.md.
+- [ ] Add Unit tests
 - [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
 - [ ] Alerting rules must have a comment documenting why it needs to exist.
 - [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Change `OperatorNotReconcilingRocket` to page excluding cert operator.
+- PR template now asks to add unit tests
 
 ## [2.50.0] - 2022-09-26
 


### PR DESCRIPTION
Now we have some unit tests for alerts, I think this should be part of the PR template.

So, this PR adds a "Add unit tests" to the Github pull request template.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
