### PR TITLE
Add `FlowcontrolTooManyRequests` when one fairness bucket is being hit too hard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `OperatorNotReconcilingRocket` to page excluding cert operator.
 - new loki alert: `LokiRingUnhealthy`
 - PR template now asks to add unit tests
+- Add `FlowcontrolTooManyRequests` when one fairness bucket is being hit too hard.
 
 ## [2.50.0] - 2022-09-26
 

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -21,3 +21,15 @@ spec:
         severity: page
         team: {{include "providerTeam" .}}
         topic: kubernetes
+    - alert: FlowcontrolTooManyRequests
+      annotations:
+        description: '{{`Cluster {{ $labels.installation }}/{{ $labels.cluster_id }}: there are too many API requests for flow schema {{ $labels.flow_schema }}.`}}'
+        opsrecipe: flowcontrol-rejected-requests/
+      expr: sum(irate(apiserver_flowcontrol_dispatched_requests_total[1m])) by (priority_level) > min(apiserver_flowcontrol_request_concurrency_limit) by (priority_level)
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{include "providerTeam" .}}
+        topic: kubernetes


### PR DESCRIPTION
This PR:

- Adds a new alert when there are too many requests to API server for a certain fairness bucket


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
