### PR TITLE
fix: ownership - change honeybadger to cabbage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixes ownership of kong*, cert-manager* and external-dns* from team-honeybadger to team-cabbage
+- fixes ownership of kong and external-dns from team-honeybadger to team-cabbage
+- fixes ownership of cert-manager from team-honeybadger to team-hydra
 
 ## [2.51.0] - 2022-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fixes ownership of kong*, cert-manager* and external-dns* from team-honeybadger to team-cabbage
+
 ## [2.51.0] - 2022-09-29
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -239,12 +239,13 @@ spec:
         sig: none
         team: rocket
         topic: releng
-    # If apps can't be installed multiple teams could be paged. So we route to honeybadger.
+    # If apps can't be installed multiple teams could be paged. So we route to honeybadger. Only for supported apps
+    # (coming from `giantswarm` catalog)
     - alert: WorkloadClusterAppNotInstalled
       annotations:
         description: '{{`Workload Cluster App {{ if $labels.exported_namespace }}{{ $labels.exported_namespace }}{{ else }}{{ $labels.namespace }}{{ end }}/{{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      expr: label_replace(app_operator_app_info{status="not-installed", catalog!~"control-plane-.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status="not-installed", catalog="giantswarm"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 30m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -35,17 +35,29 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: observability
-    - alert: WorkloadClusterManagedDeploymentNotSatisfied
+    - alert: WorkloadClusterManagedDeploymentNotSatisfiedCabbage
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*|external-dns.*|kong.*"} > 0
+      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"external-dns.*|kong.*"} > 0
       for: 30m
       labels:
         area: managedservices
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: cabbage
+        topic: releng
+    - alert: WorkloadClusterManagedDeploymentNotSatisfiedHydra
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
+      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*"} > 0
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: hydra
         topic: releng
     - alert: WorkloadClusterDeploymentScaledDownToZero
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -45,7 +45,7 @@ spec:
         area: managedservices
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: honeybadger
+        team: cabbage
         topic: releng
     - alert: WorkloadClusterDeploymentScaledDownToZero
       annotations:


### PR DESCRIPTION
This PR:

- fixes ownership of kong*, cert-manager* and external-dns* to team-cabbage, according to [this spreadsheet](https://docs.google.com/spreadsheets/d/1GNXAbYo_HyjjRusd2KTGttuORBkX9iMdgnNp-xTQ9sw/edit#gid=0)
