### PR TITLE
remove blackbox-exporter rules for KVM clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Drop `blackbox-exporter` alerts for KVM clusters.
+
 ## [2.53.0] - 2022-10-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -12,18 +12,6 @@ spec:
   groups:
   - name: kvm
     rules:
-    # If the blackbox-exporter itself goes down, we are blind to endpoint issues and should be alerted.
-    - alert: BlackboxExporterEndpointDown
-      annotations:
-        description: '{{`Blackbox exporter endpoint ({{ $labels.instance }}) is down.`}}'
-        opsrecipe: blackbox-exporter-endpoint-down/
-      expr: up{job=~"blackbox-exporter-.*"} == 0
-      for: 5m
-      labels:
-        area: kaas
-        severity: page
-        team: rocket
-        topic: observability
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -157,28 +157,6 @@ spec:
         service: node-exporter
       record: slo_target
 
-      # -- blackbox-exporter
-      # record number of endpoints.
-    - expr: count(probe_success) by (cluster_id, cluster_type)
-      labels:
-        class: MEDIUM
-        area: kaas
-        service: blackbox-exporter
-      record: raw_slo_requests
-      # record of number of endpoints that are down.
-    - expr: sum(1 - probe_success) by (cluster_id, cluster_type)
-      labels:
-        area: kaas
-        class: MEDIUM
-        service: blackbox-exporter
-      record: raw_slo_errors
-      # -- 99.999% availability
-    - expr: "vector((1 - 0.9999))"
-      labels:
-        area: kaas
-        service: blackbox-exporter
-      record: slo_target
-
     # -- managed-apps
     # -- error recording rules
     # record when pods of a daemonset with label "label_giantswarm_io_monitoring_basic_sli" are down


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/24078

This PR:

- removes blackbox-exporter alerts added in https://github.com/giantswarm/prometheus-rules/pull/94/

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
