### PR TITLE
KongIngressControllerConfigurationPushErrorCountTooHigh to business hours only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move `KongIngressControllerConfigurationPushErrorCountTooHigh` alerting rule to business hours only.
+
 ### Removed
 
 - Drop `blackbox-exporter` alerts for KVM clusters.

--- a/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
@@ -39,7 +39,7 @@ spec:
         area: managedservices
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage
         topic: kong


### PR DESCRIPTION
This PR:

- Changes KongIngressControllerConfigurationPushErrorCountTooHigh to only alert during business hours

We found that this is usually because of a bad configuration change. Team Cabbage will iterate on this alert to see if its required at all or can be changed to something more useful.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
