### PR TITLE
Add SLO alert for Cilium Agent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add SLO alert for Cilium Agent.
+
 ## [2.54.0] - 2022-10-17
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -329,6 +329,26 @@ spec:
         service: managed-alertmanager
       record: raw_slo_errors
 
+    # -- Cilium
+    # We assume one request/second for each cilium-agent replica
+    - expr: label_replace(count(cilium_version) * 60, "service", "cilium-agent", "", "")
+      labels:
+        class: MEDIUM
+        area: kaas
+      record: raw_slo_requests
+      # record number of errors.
+    - expr: label_replace(sum(cilium_errors_warnings_total{app="cilium-agent",level="error"}), "service", "cilium-agent", "", "")
+      labels:
+        area: kaas
+        class: MEDIUM
+      record: raw_slo_errors
+      # -- 99% availability
+    - expr: "vector((1 - 0.99))"
+      labels:
+        area: kaas
+        service: cilium-agent
+      record: slo_target
+
       # -- generic stuff
       # -- standard burnrates based on https://sre.google/workbook/alerting-on-slos/#6-multiwindow-multi-burn-rate-alerts
     - expr: "vector(36)"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1510

This PR:

- adds SLO alerting for cilium agent on all management clusters

this is an SLO alert, meaning it can't be made to page only during business hours.
The threshold is arbitrary and it might be too noisy, but there is no other way but test this.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [x] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
