### PR TITLE
Change ownership of cert-manager related apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change ownership of Cert-manager related alerts
+
 ## [2.55.0] - 2022-10-24
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -23,7 +23,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: cabbage
+        team: phoenix
         topic: observability
     - alert: CertManagerDown
       annotations:
@@ -32,12 +32,12 @@ spec:
       expr: up{app=~"cert-manager-(app|controller)"} == 0
       for: 15m
       labels:
-        area: managedapps
+        area: kaas
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         severity: page
-        team: cabbage
+        team: phoenix
         topic: cert-manager
     - alert: CertManagerTooManyCertificateRequests
       annotations:
@@ -46,8 +46,8 @@ spec:
       expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
       for: 15m
       labels:
-        area: managedservices
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: cabbage
+        team: phoenix
         topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -17,10 +17,10 @@ spec:
       expr: (cert_exporter_secret_not_after{name=~"kiam.*"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
       labels:
-        area: managedapps
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: cabbage
+        team: phoenix
         topic: cert-manager
     - alert: CertificateSecretWillExpireInLessThanTwoWeeks
       annotations:
@@ -29,10 +29,10 @@ spec:
       expr: (cert_exporter_secret_not_after{name!~"kiam.*",cluster_type="management_cluster"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
       labels:
-        area: managedapps
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: cabbage
+        team: phoenix
         topic: cert-manager
     - alert: ManagedCertificateCRWillExpireInLessThanTwoWeeks
       annotations:
@@ -41,8 +41,8 @@ spec:
       expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 15m
       labels:
-        area: managedapps
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: cabbage
+        team: phoenix
         topic: cert-manager


### PR DESCRIPTION
This PR:

- changes the owner of cert-manager related apps, following the ownership spreadsheet .
  - KIAM specific cert alert to phoenix
  - generic cert expiration certs to hydra

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
