### PR TITLE
Add FluxWorkqueueTooLong alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `FluxWorkqueueTooLong` alert.
+
 ### Changed
 
 - Narrow down Flux `FluxKustomizationFailed` alert.

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -240,3 +240,17 @@ spec:
         severity: notify
         team: honeybadger
         topic: releng
+    - alert: FluxWorkqueueTooLong
+      annotations:
+        description: |-
+          {{`Flux artifacts are stuck in work queue for over 30 minutes and are not being reconciled.`}}
+        opsrecipe: fluxcd-workqueue-too-long/
+      expr: |
+        sum by (name, namespace) (workqueue_unfinished_work_seconds{namespace=~"flux-giantswarm|flux-system"}) > 1800.0
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: honeybadger
+        topic: releng


### PR DESCRIPTION
- add FluxWorkqueueTooLong alert
- update CHANGELOG

This PR:
- adds FluxWorkqueueTooLong alert (opsrecipe https://github.com/giantswarm/giantswarm/pull/24378)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
