### PR TITLE
disable business hours field for storage alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `cancel_if_outside_working_hours` for `disk.workload-cluster.rules`
+
 ## [2.60.0] - 2022-11-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `cancel_if_outside_working_hours` for `disk.workload-cluster.rules`
+
 ## [2.57.0] - 2022-11-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
@@ -19,7 +19,6 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -43,7 +42,6 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -55,7 +53,6 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -67,7 +64,6 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage

--- a/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
@@ -19,7 +19,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -43,7 +43,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -55,7 +55,7 @@ spec:
       for: 30m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
@@ -67,7 +67,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage


### PR DESCRIPTION
This PR:

Disables business hours field for disk workload clusters until US is taken into account. 
for: https://github.com/giantswarm/flexshopper/issues/333

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
