### PR TITLE
Flux slow reconciliation as error budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Flux slow reconciliation switched to error budget alert
+
 ## [2.57.0] - 2022-11-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -106,13 +106,18 @@ spec:
     - alert: FluxReconciliationLongErrorBudgetLow
       annotations:
         description: |-
-          {{`Flux controller {{ $labels.controller }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is reconciling very slowly.`}}
+          {{`Flux object {{ $labels.kind }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is below the error threshold of its error budget.`}}
         opsrecipe: fluxcd-slow-reconciliation/
       expr: |
-        1.0 -
-sum_over_time(sum by (kind,name) (rate(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind="GitRepository"}[10m]) >bool 0.05)[30d:10m])
-/
-43200
+        1 - sum_over_time(
+(
+  (
+  sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
+  /
+  sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
+  ) 
+>bool 360)[30d:10m])
+/ (30*24*6)
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -117,8 +117,8 @@ spec:
           /
           sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           ) 
-        <=bool 360)[30d:10m])
-        / (30*24*6)
+        <=bool 360)[7d:10m])
+        / (7*24*6) < 0.97
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -103,6 +103,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         team: honeybadger
         topic: releng
+# this alert checks average reconciliation times in 10 min windows, then calculates monthly error budget usage for it
     - alert: FluxReconciliationLongErrorBudgetLow
       annotations:
         description: |-
@@ -110,14 +111,14 @@ spec:
         opsrecipe: fluxcd-slow-reconciliation/
       expr: |
         1 - sum_over_time(
-(
-  (
-  sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
-  /
-  sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
-  ) 
->bool 360)[30d:10m])
-/ (30*24*6)
+        (
+          (
+          sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
+          /
+          sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
+          ) 
+        >bool 360)[30d:10m])
+        / (30*24*6)
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -103,14 +103,16 @@ spec:
         cancel_if_outside_working_hours: "true"
         team: honeybadger
         topic: releng
-    - alert: FluxReconciliationTakingTooLong
+    - alert: FluxReconciliationLongErrorBudgetLow
       annotations:
         description: |-
           {{`Flux controller {{ $labels.controller }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is reconciling very slowly.`}}
         opsrecipe: fluxcd-slow-reconciliation/
       expr: |
-        (sum(rate(controller_runtime_reconcile_time_seconds_sum{app=~".*flux.*", namespace=~".*giantswarm.*"}[5m])) by (installation, cluster_id, controller) /
-        sum(rate(controller_runtime_reconcile_time_seconds_count{app=~".*flux.*", namespace=~".*giantswarm.*"}[5m])) by (installation, cluster_id, controller)) > 60
+        1.0 -
+sum_over_time(sum by (kind,name) (rate(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind="GitRepository"}[10m]) >bool 0.05)[30d:10m])
+/
+43200
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -110,14 +110,14 @@ spec:
           {{`Flux object {{ $labels.kind }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is below the error threshold of its error budget.`}}
         opsrecipe: fluxcd-slow-reconciliation/
       expr: |
-        1 - sum_over_time(
+        sum_over_time(
         (
           (
           sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           /
           sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           ) 
-        >bool 360)[30d:10m])
+        <=bool 360)[30d:10m])
         / (30*24*6)
       for: 10m
       labels:


### PR DESCRIPTION
This PR:

- changes "slow Flux reconciliation error" to an error budget based one

## How does it work

As it involves some calculations that are not obvious, let me try to walk the rule step by step.

### Description

For each `Kustomization` or `HelmRelease` we check an average reconciliation time in the last 10 minutes. If it was longer than 360 s, we count such a 10-minute sample as a 'failed' metric, otherwise we consider it 'good'. Now, we split a week (7 d) into 10 min windows, count the number of them with a 'good' metric value and compare to the total number of 10 min windows in 7 days (7*24*6).

This is the percentage of time in the last 7 days when our metric was 'good'. If it falls below 0.97, we alert.

### Warnings

- Akita is slow (we know it), and the value of the metric is around 0.93 there, so below our SLO of 0.97

### Rule

```
sum_over_time(
(
  (
  sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  /
  sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  ) 
<=bool 360)[7d:10m])
/ (7*24*6) 
```

Let's check it step by step.

We start with checking how much all the reconciliations matching a filter took in the last 10 minutes (it's a sum of all the samples)

```
increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])
```

As metrics can come from different pods, we have to sum app all the partial sums aggregating by `kind,name,...`

```
sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
```

Now, we use almost the same expression but with `_count` metric suffix to learn how many reconciliations there were in those 10 minutes. We divide the first part by this part to get an average reconciliation time in the last 10 m:

```
(
  sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  /
  sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  )
```

And we check whether it is lower than our acceptable threshold of 360 s (bool check, so the result is `false/true 0/1`)

```
(
  (
  sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  /
  sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
  ) 
<=bool 360)
```

The rest is just sub-quering this query every 10 mins for the last 7 d with `[7d:10m]` and counting the number of 'good' samples with `sum_over_time`. Last thing, we divide the number of 'good' 10 min samples by the number of all 10 min samples in 7 d. 