### PR TITLE
FluxKustomizationFailed stuck time increased from 10m to 20m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- FluxKustomizationFailed "stuck" time increased from 10m to 20m
+
 ## [2.57.0] - 2022-11-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -57,7 +57,7 @@ spec:
           {{`Flux Kustomization {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-kustomization/
       expr: gotk_reconcile_condition{app="flux-giantswarm-monitoring", type="Ready", status="False", kind="Kustomization", cluster_type="management_cluster", namespace=~".*giantswarm.*"} > 0
-      for: 10m
+      for: 20m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}


### PR DESCRIPTION
In this PR:

- FluxKustomizationFailed "stuck" time increased from 10m to 20m

We have Kustomizations that go over 10 mins while working fine, we need to increase the time we consider a kustomization to be 'stuck'