### PR TITLE
fix-fluent-bit-alert-description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inhibit `WorkloadClusterAppNotInstalled` when there are no workers.
 
+### Fixed
+
+- Fix `FluentBitDown` alert description.
+
 ## [2.59.0] - 2022-11-14
 
 ### Changed
 
 - FluxKustomizationFailed "stuck" time increased from 10m to 20m
 - Flux slow reconciliation switched to error budget alert
-
-### Fixed
-
-- Fix `FluentBitDown` alert description.
 
 ## [2.58.0] - 2022-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FluxKustomizationFailed "stuck" time increased from 10m to 20m
 - Flux slow reconciliation switched to error budget alert
 
+### Fixed
+
+- Fix `FluentBitDown` alert description.
+
 ## [2.58.0] - 2022-11-10
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
@@ -47,11 +47,12 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    # This alert ensures our fluent-bit daemon sets are running on the management clusters for customers that configured it.
     - alert: FluentbitDown
       annotations:
         description: '{{`Fluentbit ({{ $labels.instance }}) is down.`}}'
         opsrecipe: fluentbit-down/
-      expr: sum(up{app="fluent-logshipping-app"}) by (app, cluster_id, cluster_type, installation, job, namespace, provider, node) == 0
+      expr: sum(up{app="fluent-logshipping-app"}) by (app, cluster_id, cluster_type, installation, job, namespace, provider, instance, node) == 0
       for: 15m
       labels:
         area: empowerment


### PR DESCRIPTION
This PR:

- fixes the fluent bit down alert description (missing the instance labels)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
