### PR TITLE
Inhibit WorkloadClusterAppNotInstalled when there are no worker nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Inhibit `WorkloadClusterAppNotInstalled` when there are no workers.
+
 ## [2.59.0] - 2022-11-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -71,6 +71,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
         severity: page
         sig: none
         topic: releng


### PR DESCRIPTION
This PR:

- inhibits WorkloadClusterAppFailed alert when the cluster has no worker nodes

### Checklist

- [x] Update changelog in CHANGELOG.md.
