### PR TITLE
fix: when there are no reconciliations, the metric was counting as a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable `cancel_if_outside_working_hours` for `disk.workload-cluster.rules`
 
+### Fixed 
+
+- Flux slow reconciliation error budget was counting periods with suspended reconciliation as failures
+
 ## [2.60.0] - 2022-11-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -110,14 +110,14 @@ spec:
           {{`Flux object {{ $labels.kind }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is below the error threshold of its error budget.`}}
         opsrecipe: fluxcd-slow-reconciliation/
       expr: |
-        sum_over_time(
+        1-sum_over_time(
         (
           (
           sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           /
           sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           ) 
-        <=bool 360)[7d:10m])
+        >bool 360)[7d:10m])
         / (7*24*6) < 0.97
       for: 10m
       labels:


### PR DESCRIPTION
When Flux reconciliations were suspended, the average reconciliation time in the 10 min window was "NaN". Unfrotunately, this counted as a failure. Now the metric checks if the value is over the threshold by reverting the comparison (`NaN > 360` is `false`) and reverses the final ration with `1-`.