### PR TITLE
Setting team label to 'atlas' for vpa slo recording rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Setting `label_application_giantswarm_io_team` label to `atlas` for vpa slo recording rules
 - Fix `make test` on macos
 
 ## [2.60.1] - 2022-11-14

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -351,7 +351,7 @@ spec:
 
     # -- VPA
     # Amount of requests for VPA
-    - expr: "label_replace(count(up{app=~'vertical-pod-autoscaler.*'}) by (cluster_type,cluster_id), "label_application_giantswarm_io_team", "atlas", "", "")"
+    - expr: label_replace(count(up{app=~'vertical-pod-autoscaler.*'}) by (cluster_type,cluster_id), "label_application_giantswarm_io_team", "atlas", "", "")
       labels:
         class: MEDIUM
         area: platform
@@ -364,7 +364,7 @@ spec:
     # and summed with 1 so the final result is 0 : no error recorded.
     # If up was unsuccessful, there is an error. Up returns 0, multiplied by -1 and summed
     # with 1 so the final result is 1 : 1 error is recorded .
-    - expr: "label_replace(sum((up{app=~'vertical-pod-autoscaler.*'} * -1) + 1) by (cluster_id, cluster_type), "label_application_giantswarm_io_team", "atlas", "", "")"
+    - expr: label_replace(sum((up{app=~'vertical-pod-autoscaler.*'} * -1) + 1) by (cluster_id, cluster_type), "label_application_giantswarm_io_team", "atlas", "", "")
       labels:
         class: MEDIUM
         area: platform

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -351,7 +351,7 @@ spec:
 
     # -- VPA
     # Amount of requests for VPA
-    - expr: "count(up{app=~'vertical-pod-autoscaler.*'}) by (cluster_type,cluster_id)"
+    - expr: "label_replace(count(up{app=~'vertical-pod-autoscaler.*'}) by (cluster_type,cluster_id), "label_application_giantswarm_io_team", "atlas", "", "")"
       labels:
         class: MEDIUM
         area: platform
@@ -364,7 +364,7 @@ spec:
     # and summed with 1 so the final result is 0 : no error recorded.
     # If up was unsuccessful, there is an error. Up returns 0, multiplied by -1 and summed
     # with 1 so the final result is 1 : 1 error is recorded .
-    - expr: "sum((up{app=~'vertical-pod-autoscaler.*'} * -1) + 1) by (cluster_id, cluster_type)"
+    - expr: "label_replace(sum((up{app=~'vertical-pod-autoscaler.*'} * -1) + 1) by (cluster_id, cluster_type), "label_application_giantswarm_io_team", "atlas", "", "")"
       labels:
         class: MEDIUM
         area: platform


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24111

Setting team label to 'atlas' for vpa slo recording rules

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
