### PR TITLE
Disable bastion monitoring for CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add alert to page when `Cluster` is stuck on deletion.
 
+### Changed
+
+- Disable bastion monitoring rules for CAPA
+
 ## [2.60.2] - 2022-11-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -70,7 +70,7 @@ true
 {{- end -}}
 
 {{- define "isBastionBeingMonitored" -}}
-{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere") -}}
+{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere" "capa") -}}
 false
 {{- else -}}
 true


### PR DESCRIPTION
This PR:

The NoHealthyJumphost alert checks if there's a node-exporter instance on the bastion. On CAPA the bastion doesn't even join the cluster, so there's nothing running on it


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
