### PR TITLE
Inhibit PrometheusAgentFailing when cluster is creating/deleting

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -25,3 +25,5 @@ spec:
         team: atlas
         topic: observability
         cancel_if_cluster_is_not_running_prometheus_agent: "true"
+        cancel_if_cluster_status_creating: true
+        cancel_if_cluster_status_deleting: true

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -18,6 +18,8 @@ tests:
               team: atlas
               topic: observability
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: true
+              cancel_if_cluster_status_deleting: true
             exp_annotations:
               description: "Prometheus agent remote write is failing."
               opsrecipe: "prometheus-agent-remote-write-failed/"


### PR DESCRIPTION
This PR:

- inhibits the `PrometheusAgentFailing` alert when the cluster is creating or deleting

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [x] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
