### PR TITLE
Updating 'vpa' slo availability to 99%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update 'vpa' slo availability to 99%
+
 ## [2.62.0] - 2022-11-25
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -371,8 +371,8 @@ spec:
         service: vertical-pod-autoscaler
       record: raw_slo_errors
 
-    # SLO targets for VPA -- 99,9% availability
-    - expr: "vector((1 - 0.999))"
+    # SLO targets for VPA -- 99% availability
+    - expr: "vector((1 - 0.99))"
       labels:
         area: platform
         service: vertical-pod-autoscaler


### PR DESCRIPTION
This PR:
Update the `vpa` slo availibility to 99%.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
