### PR TITLE
Unit tests: filter files to test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- unit tests: you can run tests against a specific file
+
 ## [2.62.1] - 2022-11-29
 
 - Update 'vpa' slo availability to 99%

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -13,7 +13,7 @@ clean: ## Clean the git work dir and remove all untracked files
 
 .PHONY: test
 test: install-tools ## run unit tests for alerting rules
-	bash test/hack/bin/verify-rules.sh
+	bash test/hack/bin/verify-rules.sh "$(test_filter)"
 
 install-tools:
 	./test/hack/bin/fetch-tools.sh

--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ Show a summary of encountered errors
 Show success
 ```
 
+#### Hints
+
+You can filter which rules files you will test with a regular expression:
+```
+make test test_filter=grafana
+make test test_filter=gr.*na
+```
+
 [unit testing rules]: https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/
 
 ### SLO Framework integration

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Show success
 
 You can filter which rules files you will test with a regular expression:
 ```
+make test test_filter=grafana.management-cluster.rules.yml
 make test test_filter=grafana
 make test test_filter=gr.*na
 ```

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -19,6 +19,8 @@ array_contains() {
 }
 
 main() {
+    # Filter (grep) rules files to test
+    filter="${1:-}"
 
     START_TIME="$(date +%s)"
     echo "$(date '+%H:%M:%S') promtool: start"
@@ -71,6 +73,7 @@ main() {
 
         for file in "${all_files[@]}"; do
 
+            [[ ! "$file" =~ .*$filter.* ]] && continue
 
             echo "###  Testing $file"
 


### PR DESCRIPTION
This PR adds a feature to the unit tests:
we can now filter which files we want to test.

Allows faster iteration when writing a unit test.

### How it works:

* with a word:
```
$ make test test_filter=grafana
./test/hack/bin/fetch-tools.sh
bash test/hack/bin/verify-rules.sh "grafana"
21:21:30 promtool: start
### Helm chart preparation
2022/11/29 21:21:30 templating helm chart
dir: /home/herve/github/giantswarm/prometheus-rules/helm/prometheus-rules
sha: 0a10680da4981651be16a504fa7228e5a8c04d0d
tag: 
app-version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
2022/11/29 21:21:30 templated helm chart
### Running tests for provider: openstack
###  Testing templates/alerting-rules/grafana.management-cluster.rules.yml
###    extracting /home/herve/github/giantswarm/prometheus-rules/test/providers/openstack/grafana.management-cluster.rules.yml
###    promtool check rules /home/herve/github/giantswarm/prometheus-rules/test/tests/providers/openstack/grafana.management-cluster.rules.yml
###    promtool test rules grafana.management-cluster.rules.test.yml - global
21:21:31 promtool: end (Elapsed time: 1s)

Congratulations!  Prometheus rules have been promtool checked and tested
```

* with a regex:
```
[prometheus-rules]$ make test test_filter=gr.*na
./test/hack/bin/fetch-tools.sh
bash test/hack/bin/verify-rules.sh "gr.*na"
21:22:30 promtool: start
### Helm chart preparation
2022/11/29 21:22:30 templating helm chart
dir: /home/herve/github/giantswarm/prometheus-rules/helm/prometheus-rules
sha: 0a10680da4981651be16a504fa7228e5a8c04d0d
tag: 
app-version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
2022/11/29 21:22:30 templated helm chart
### Running tests for provider: openstack
###  Testing templates/alerting-rules/grafana.management-cluster.rules.yml
###    extracting /home/herve/github/giantswarm/prometheus-rules/test/providers/openstack/grafana.management-cluster.rules.yml
###    promtool check rules /home/herve/github/giantswarm/prometheus-rules/test/tests/providers/openstack/grafana.management-cluster.rules.yml
###    promtool test rules grafana.management-cluster.rules.test.yml - global
21:22:31 promtool: end (Elapsed time: 1s)

Congratulations!  Prometheus rules have been promtool checked and tested
```

* with no parameter:
```
[prometheus-rules]$ make test                   
./test/hack/bin/fetch-tools.sh
bash test/hack/bin/verify-rules.sh ""
21:19:12 promtool: start
### Helm chart preparation
2022/11/29 21:19:12 templating helm chart
dir: /home/herve/github/giantswarm/prometheus-rules/helm/prometheus-rules
sha: 0a10680da4981651be16a504fa7228e5a8c04d0d
tag: 
app-version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
version: 2.62.1-0a10680da4981651be16a504fa7228e5a8c04d0d
2022/11/29 21:19:12 templated helm chart
### Running tests for provider: openstack
###  Testing templates/alerting-rules/alertmanager-dashboard.rules.yml
###    extracting /home/herve/github/giantswarm/prometheus-rules/test/providers/openstack/alertmanager-dashboard.rules.yml
Error: could not find template templates/alerting-rules/alertmanager-dashboard.rules.yml in chart
###    Failed extracting rules file templates/alerting-rules/alertmanager-dashboard.rules.yml
###  Testing templates/alerting-rules/alertmanager.rules.yml
###    extracting /home/herve/github/giantswarm/prometheus-rules/test/providers/openstack/alertmanager.rules.yml
###    promtool check rules /home/herve/github/giantswarm/prometheus-rules/test/tests/providers/openstack/alertmanager.rules.yml
###    Skipping templates/alerting-rules/alertmanager.rules.yml: listed in test/conf/promtool_ignore
###  Testing templates/alerting-rules/apiserver.management-cluster.rules.yml
###    extracting /home/herve/github/giantswarm/prometheus-rules/test/providers/openstack/apiserver.management-cluster.rules.yml
###    promtool check rules /home/herve/github/giantswarm/prometheus-rules/test/tests/providers/openstack/apiserver.management-cluster.rules.yml
###    Skipping templates/alerting-rules/apiserver.management-cluster.rules.yml: listed in test/conf/promtool_ignore
[...]
```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
