### PR TITLE
silence Flux.*Failed alerts outside of business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Silence some Flux alerts outside of business hours.
+
 ## [2.63.1] - 2022-11-30
 
 ### Changed
@@ -61,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable `cancel_if_outside_working_hours` for `disk.workload-cluster.rules`
 
-### Fixed 
+### Fixed
 
 - Flux slow reconciliation error budget was counting periods with suspended reconciliation as failures
 

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -34,7 +34,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: honeybadger
         topic: releng
@@ -60,7 +60,7 @@ spec:
       for: 20m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: honeybadger
         topic: releng
@@ -86,7 +86,7 @@ spec:
       for: 2h
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: honeybadger
         topic: releng


### PR DESCRIPTION
This PR:

- Silences additional Flux alerts outside of business hours.

Towards https://github.com/giantswarm/giantswarm/issues/24660

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [x] Alerting rules must have a comment documenting why it needs to exist.
- [x] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
