### PR TITLE
Improve prometheus-agent inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve InhibitionClusterIsNotRunningPrometheusAgent to fire on each cluster.
+
 ## [2.64.0] - 2022-11-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -18,7 +18,7 @@ spec:
     - alert: InhibitionClusterIsNotRunningPrometheusAgent
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) is not running Prometheus Agent.`}}'
-      expr: count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (prometheus_build_info{app="prometheus",instance="prometheus-agent"})
+      expr: (count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (kube_statefulset_created{namespace="kube-system",statefulset="prometheus-prometheus-agent"}  > 0))
       labels:
         cluster_is_not_running_prometheus_agent: "true"
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -11,15 +11,14 @@ spec:
   - name: inhibit.prometheus-agent
     rules:
     # this inhibition fires when a cluster is not running prometheus-agent.
-    # we retrieve the list of existing cluster IDs from `kube_namespace_created`
-    # then compare it with the list of deployed observability-bundles from `app_operator_app_info`
+    # we retrieve the list of existing cluster IDs from `prometheus_build_info` with app="prometheus"
+    # then compare it with the list of `prometheus_build_info` with instance="prometheus-agent"
     # 
-    # Will only produce data (and inhibitions) on MC because it's where app_operator is running
-    # but that's enough to have the inhibitions on the installation-global alertmanager
+    # Will produce data (and inhibitions) on MC/WC.
     - alert: InhibitionClusterIsNotRunningPrometheusAgent
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) is not running Prometheus Agent.`}}'
-      expr: count(label_replace(kube_namespace_created{namespace=~".+-prometheus"}, "cluster_id", "$1", "namespace", "(.+)-prometheus") ) by (cluster_id) unless count(label_replace(app_operator_app_info{app="observability-bundle",status="deployed",name=~".+-observability-bundle"},"cluster_id", "$1", "name", "(.+)-observability-bundle")) by (cluster_id)
+      expr: count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (prometheus_build_info{app="prometheus",instance="prometheus-agent"})
       labels:
         cluster_is_not_running_prometheus_agent: "true"
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -11,8 +11,8 @@ spec:
   - name: inhibit.prometheus-agent
     rules:
     # this inhibition fires when a cluster is not running prometheus-agent.
-    # we retrieve the list of existing cluster IDs from `prometheus_build_info` with app="prometheus"
-    # then compare it with the list of `prometheus_build_info` with instance="prometheus-agent"
+    # If we have prometheus-agent statefulset, it means prometheus-agent is installed on this cluster
+    # so, raise an inhibition unless prometheus-agent runs on the cluster 
     # 
     # Will produce data (and inhibitions) on MC/WC.
     - alert: InhibitionClusterIsNotRunningPrometheusAgent

--- a/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
@@ -5,9 +5,11 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'app_operator_app_info{app="observability-bundle",status="deployed",name="test2-observability-bundle",cluster_id="gauss",version="1.1.0"}'
+      - series: 'prometheus_build_info{app="prometheus",cluster_id="gauss",instance="localhost:9090"}'
         values: "1+0x20 0+0x100"
-      - series: 'kube_namespace_created{namespace="test1-prometheus",name="prometheus-test1"}'
+      - series: 'prometheus_build_info{app="prometheus",cluster_id="test1",instance="localhost:9090"}'
+        values: "1+0x20 0+0x100"
+      - series: 'prometheus_build_info{app="prometheus",cluster_id="gauss",instance="prometheus-agent"}'
         values: "1+0x20 0+0x100"
     alert_rule_test:
       - alertname: InhibitionClusterIsNotRunningPrometheusAgent

--- a/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
@@ -6,20 +6,21 @@ tests:
   - interval: 1m
     input_series:
       - series: 'prometheus_build_info{app="prometheus",cluster_id="gauss",instance="localhost:9090"}'
-        values: "1+0x20 0+0x100"
-      - series: 'prometheus_build_info{app="prometheus",cluster_id="test1",instance="localhost:9090"}'
-        values: "1+0x20 0+0x100"
-      - series: 'prometheus_build_info{app="prometheus",cluster_id="gauss",instance="prometheus-agent"}'
-        values: "1+0x20 0+0x100"
+        values: "1+0x40"
+      - series: 'kube_statefulset_created{namespace="kube-system",cluster_id="gauss",statefulset="prometheus-prometheus-agent"}'
+        values: "1+0x20 0+0x20"
     alert_rule_test:
       - alertname: InhibitionClusterIsNotRunningPrometheusAgent
         eval_time: 1m
+      - alertname: InhibitionClusterIsNotRunningPrometheusAgent
+        eval_time: 22m
         exp_alerts:
           - exp_labels:
               area: empowerment
               team: atlas
               topic: monitoring
               cluster_is_not_running_prometheus_agent: "true"
-              cluster_id: "test1"
+              cluster_id: "gauss"
             exp_annotations:
-              description: "Cluster (test1) is not running Prometheus Agent."
+              description: "Cluster (gauss) is not running Prometheus Agent."
+


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/24807

### Summary

Change the inhibition to 🔥  on each cluster, 
Even if MC is down the inhibition is still firing for WC and thus will inhibit alerts of WCs...

#### Explanation 

We compare the list of `prometheus_build_info{app="prometheus"}` with the list of `prometheus_build_info{app="prometheus",instance="prometheus-agent"}`

we get a clusterID, If a cluster missing `instance="prometheus-agent"`.

### Testing

TBD


/cc @hervenicol 