### PR TITLE
Raise `PrometheusJobScrapingFailure` duration from 1h to 1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise `PrometheusJobScrapingFailure` duration from 1h to 1d.
+
 ## [2.64.0] - 2022-11-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -58,7 +58,7 @@ spec:
         summary: Prometheus fails to scrape all targets in a job.
         opsrecipe: prometheus-job-scraping-failure/
       expr: (count(up == 0) BY (job, installation, cluster_id) / count(up) BY (job, installation, cluster_id)) == 1
-      for: 1h # increase this value when changing severity to page
+      for: 1d
       labels:
         area: empowerment
         severity: notify


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24062

Raise `PrometheusJobScrapingFailure` duration from 1h to 1d