### PR TITLE
Add alerting to page once critical prometheus target is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Imrove `PrometheusJobScrapingFailure` once prometheus target is down.
+- Add `PrometheusCriticalJobScrapingFailure` to page once critical prometheus target is down.
 
 ## [2.64.0] - 2022-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Imrove `PrometheusJobScrapingFailure` once prometheus target is down.
+
 ## [2.64.0] - 2022-11-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve InhibitionClusterIsNotRunningPrometheusAgent to fire on each cluster.
 - Raise `PrometheusJobScrapingFailure` duration from 1h to 1d.
 
-
 ## [2.64.0] - 2022-11-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -57,8 +57,22 @@ spec:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}
         summary: Prometheus fails to scrape all targets in a job.
         opsrecipe: prometheus-job-scraping-failure/
+      expr: (count(up == 0) BY (job, installation, cluster_id) / count(up) BY (job, installation, cluster_id)) == 1
+      for: 1h # increase this value when changing severity to page
+      labels:
+        area: empowerment
+        severity: notify
+        team: atlas
+        topic: observability
+        cancel_if_outside_working_hours: "true"
+
+    - alert: PrometheusCriticalJobScrapingFailure
+      annotations:
+        description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}
+        summary: Prometheus fails to scrape all targets in a job.
+        opsrecipe: prometheus-job-scraping-failure/
       expr: (count(up{app=~"kubernetes|kube-controller-manager|kube-scheduler|kubelet|node-exporter|kube-state-metrics"} == 0) BY (app,job, installation, cluster_id) / count(up{app=~"kubernetes|kube-controller-manager|kube-scheduler|kubelet|node-exporter|kube-state-metrics"}) BY (app, job, installation, cluster_id)) == 1
-      for: 3d # increase this value when changing severity to page
+      for: 3d
       labels:
         area: empowerment
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -57,11 +57,13 @@ spec:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}
         summary: Prometheus fails to scrape all targets in a job.
         opsrecipe: prometheus-job-scraping-failure/
-      expr: (count(up == 0) BY (job, installation, cluster_id) / count(up) BY (job, installation, cluster_id)) == 1
-      for: 1h # increase this value when changing severity to page
+      expr: (count(up{app=~"kubernetes|kube-controller-manager|kube-scheduler|kubelet|node-exporter|kube-state-metrics"} == 0) BY (app,job, installation, cluster_id) / count(up{app=~"kubernetes|kube-controller-manager|kube-scheduler|kubelet|node-exporter|kube-state-metrics"}) BY (app, job, installation, cluster_id)) == 1
+      for: 3d # increase this value when changing severity to page
       labels:
         area: empowerment
-        severity: notify
+        severity: page
         team: atlas
         topic: observability
         cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_status_creating: true
+        cancel_if_cluster_status_deleting: true

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -67,7 +67,6 @@ templates/alerting-rules/node.workload_cluster.rules.yml
 templates/alerting-rules/operatorkit.rules.yml
 templates/alerting-rules/prometheus-meta-operator.rules.yml
 templates/alerting-rules/prometheus-operator.rules.yml
-templates/alerting-rules/prometheus.rules.yml
 templates/alerting-rules/release.rules.yml
 templates/alerting-rules/secret.rules.yml
 templates/alerting-rules/service-level.rules.yml

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -34,7 +34,7 @@ tests:
         eval_time: 4d
       # This alert fires for both critical and non-critical targets
       - alertname: PrometheusJobScrapingFailure
-        eval_time: 6d
+        eval_time: 7d
         exp_alerts:
           - exp_labels:
               area: empowerment

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -2,6 +2,8 @@
 rule_files:
   - prometheus.rules.yml
 
+# Setting evaluation interval to 1h
+# to make it faster on long test duration.
 evaluation_interval: 1h
 
 tests:
@@ -9,6 +11,7 @@ tests:
     input_series:
       - series: 'up{app="kubernetes",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-apiserver-gauss/0"}'
         values: "1+0x240"
+      # critcal target up for 5d and down for 5d
       - series: 'up{app="kube-controller-manager",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-controller-manager-gauss/0"}'
         values: "1+0x120 0+0x120"
       - series: 'up{app="kube-scheduler",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-scheduler-gauss/0"}'
@@ -19,14 +22,49 @@ tests:
         values: "1+0x240"
       - series: 'up{app="kube-state-metrics",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kube-state-metrics-gauss/0"}'
         values: "1+0x240"
+      # non-critcal target up for 5d and down for 5d
+      - series: 'up{app="app-exporter",installation="gauss",cluster_id="gauss",job="gauss-prometheus/app-exporter-gauss/0"}'
+        values: "1+0x120 0+0x120"
     alert_rule_test:
-      - alertname: PrometheusJobScrapingFailure
-        eval_time: 3h
+      - alertname: PrometheusCriticalJobScrapingFailure
+        eval_time: 30m
       - alertname: PrometheusJobScrapingFailure
         eval_time: 1d
-      - alertname: PrometheusJobScrapingFailure
+      - alertname: PrometheusCriticalJobScrapingFailure
         eval_time: 4d
+      # This alert fires for both critical and non-critical targets
       - alertname: PrometheusJobScrapingFailure
+        eval_time: 6d
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: notify
+              team: atlas
+              topic: observability
+              cancel_if_outside_working_hours: "true"
+              cluster_id: "gauss"
+              installation: "gauss"
+              job: "gauss-prometheus/kubernetes-controller-manager-gauss/0"
+            exp_annotations:
+              opsrecipe: "prometheus-job-scraping-failure/"
+              summary: "Prometheus fails to scrape all targets in a job."
+              description: "Prometheus gauss/gauss has failed to scrape all targets in gauss-prometheus/kubernetes-controller-manager-gauss/0 job."
+          - exp_labels:
+              area: empowerment
+              severity: notify
+              team: atlas
+              topic: observability
+              cancel_if_outside_working_hours: "true"
+              cluster_id: "gauss"
+              installation: "gauss"
+              job: "gauss-prometheus/app-exporter-gauss/0"
+            exp_annotations:
+              opsrecipe: "prometheus-job-scraping-failure/"
+              summary: "Prometheus fails to scrape all targets in a job."
+              description: "Prometheus gauss/gauss has failed to scrape all targets in gauss-prometheus/app-exporter-gauss/0 job."
+
+      # This fires only for critical target down.
+      - alertname: PrometheusCriticalJobScrapingFailure
         eval_time: 9d
         exp_alerts:
           - exp_labels:

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -1,0 +1,47 @@
+---
+rule_files:
+  - prometheus.rules.yml
+
+evaluation_interval: 1h
+
+tests:
+  - interval: 1h
+    input_series:
+      - series: 'up{app="kubernetes",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-apiserver-gauss/0"}'
+        values: "1+0x240"
+      - series: 'up{app="kube-controller-manager",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-controller-manager-gauss/0"}'
+        values: "1+0x120 0+0x120"
+      - series: 'up{app="kube-scheduler",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-scheduler-gauss/0"}'
+        values: "1+0x240"
+      - series: 'up{app="kubelet",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-kubelet-gauss/0"}'
+        values: "1+0x240"
+      - series: 'up{app="node-exporter",installation="gauss",cluster_id="gauss",job="gauss-prometheus/node-exporter-gauss/0"}'
+        values: "1+0x240"
+      - series: 'up{app="kube-state-metrics",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kube-state-metrics-gauss/0"}'
+        values: "1+0x240"
+    alert_rule_test:
+      - alertname: PrometheusJobScrapingFailure
+        eval_time: 3h
+      - alertname: PrometheusJobScrapingFailure
+        eval_time: 1d
+      - alertname: PrometheusJobScrapingFailure
+        eval_time: 4d
+      - alertname: PrometheusJobScrapingFailure
+        eval_time: 9d
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              app: "kube-controller-manager"
+              cluster_id: "gauss"
+              installation: "gauss"
+              job: "gauss-prometheus/kubernetes-controller-manager-gauss/0"
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: true
+              cancel_if_cluster_status_deleting: true
+            exp_annotations:
+              opsrecipe: "prometheus-job-scraping-failure/"
+              summary: "Prometheus fails to scrape all targets in a job."
+              description: "Prometheus gauss/gauss has failed to scrape all targets in gauss-prometheus/kubernetes-controller-manager-gauss/0 job."


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24062

Fires an alert if prometheus fails to scrape k8s components for 3 days.

Worked with @hervenicol on the tests 

