### PR TITLE
Handle aws-pod-identity-webhook with optional prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Handle `aws-pod-identity-webhook` with optional prefix.
+
 ## [2.66.0] - 2022-12-08
 
 ### Added
@@ -28,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Route `NoKyvernoPodRunning` alert with team label. 
+- Route `NoKyvernoPodRunning` alert with team label.
 - Silence some Flux alerts outside of business hours.
 
 ## [2.63.1] - 2022-11-30

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook.*"} > 0
       for: 30m
       labels:
         area: kaas


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

This PR:

- ensures matching `aws-pod-identity-webhook` with an optional prefix (as introduced in https://github.com/giantswarm/aws-pod-identity-webhook/pull/42)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
