### PR TITLE
unit tests: add aws and fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- unit tests for AWS
+
+### Changed
+
+- removed "workingHoursOnly" template from loki and crossplane tests
+
 ## [2.67.0] - 2022-12-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/crossplane.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/crossplane.rules.yml
@@ -22,7 +22,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: false
         severity: page
         team: honeybadger
         topic: managementcluster
@@ -36,7 +36,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: false
         severity: page
         team: honeybadger
         topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: false
         severity: page
         team: atlas
         topic: observability
@@ -44,7 +44,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: false
         severity: page
         team: atlas
         topic: observability

--- a/test/conf/providers
+++ b/test/conf/providers
@@ -1,1 +1,2 @@
 openstack
+aws

--- a/test/tests/providers/global/crossplane.rules.test.yml
+++ b/test/tests/providers/global/crossplane.rules.test.yml
@@ -18,7 +18,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
               cancel_if_cluster_status_updating: true
-              cancel_if_outside_working_hours: true
+              cancel_if_outside_working_hours: false
               cluster_id: gauss
               cluster_type: management_cluster
               container: kube-state-metrics
@@ -56,7 +56,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
               cancel_if_cluster_status_updating: true
-              cancel_if_outside_working_hours: true
+              cancel_if_outside_working_hours: false
               cluster_id: gauss
               cluster_type: management_cluster
               container: kube-state-metrics
@@ -91,7 +91,7 @@ tests:
               alertname: CrossplaneHelmReleaseFailed
               app: customer-flux-monitoring
               area: kaas
-              cancel_if_outside_working_hours: true
+              cancel_if_outside_working_hours: false
               cluster_id: gauss
               cluster_type: management_cluster
               container: manager

--- a/test/tests/providers/global/loki.all.rules.test.yml
+++ b/test/tests/providers/global/loki.all.rules.test.yml
@@ -27,7 +27,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
               cancel_if_cluster_status_updating: true
-              cancel_if_outside_working_hours: true
+              cancel_if_outside_working_hours: false
               cancel_if_scrape_timeout: true
               job: zj88t-prometheus/workload-zj88t/0
               namespace: loki
@@ -53,7 +53,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
               cancel_if_cluster_status_updating: true
-              cancel_if_outside_working_hours: true
+              cancel_if_outside_working_hours: false
               cancel_if_scrape_timeout: true
               job: zj88t-prometheus/workload-zj88t/0
               namespace: loki


### PR DESCRIPTION
This PR adds unit tests for AWS.

By doing so, I discovered that `workingHoursOnly` template was a hard "if it's GCP or Openstack" condition.

This means:
* I don't see the point in it
* it makes tests behave different in unexpected ways on different providers
* it makes alerting behave different in unexpected ways on different providers

So, for tests to be consistent, I removed it from the rules that already have tests running, and set the "default value for most providers" (ie `false`) instead.


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
