### PR TITLE
Fix kubelet down inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `kubelet_down` inhibition alert.
+
 ## [2.68.0] - 2022-12-12
 
 ### Added
@@ -21,10 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix fluentbit down alert.
 - Ensure Prometheus Agent alerts are not running on `kvm` installations.
-
-### Fixed
-
-- Fix `kubelet_down` inhibition alert.
 
 ## [2.67.0] - 2022-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - updated README with doc about the UT syntax
 
+### Fixed
+
+- Fix `kubelet_down` inhibition alert.
+
 ## [2.67.0] - 2022-12-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ Official documentation for inhibit rules can be found here: https://www.promethe
 The base principle of an `source_matcher` inhibit_rule is:
 > if an alert is currently firing with a `source_matcher` label, then inhibit all alerts that have a `target_matcher` label
 
-
-
 ### Recording rules
 
 The recording rules are located `helm/prometheus-rules/templates/recording-rules`

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -29,13 +29,14 @@ spec:
       annotations:
         description: '{{`cert-manager in namespace {{ $labels.namespace }} is down.`}}'
         opsrecipe: cert-manager-down/
-      expr: up{app=~"cert-manager-(app|controller)"} == 0
+      expr: label_replace(up{app=~"cert-manager-(app|controller)"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
+        cancel_if_kubelet_down: "true"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -23,6 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_master_node_down: "true"
+        cancel_if_kubelet_down: "true"
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd

--- a/helm/prometheus-rules/templates/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/external-dns.rules.yml
@@ -46,7 +46,7 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: external-dns-down/
-      expr: up{app=~"external-dns-(app|monitoring)"} == 0
+      expr: label_replace(up{app=~"external-dns-(app|monitoring)"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: managedservices
@@ -54,6 +54,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_kiam_has_errors: "true"
+        cancel_if_kubelet_down: "true"
         severity: page
         team: cabbage
         topic: external-dns

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -69,13 +69,14 @@ spec:
       annotations:
         description: '{{`nginx-ingress-controller-app in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: nginx-ingress-controller-app-down/
-      expr: up{app=~".*nginx-ingress-controller-app.*"} == 0
+      expr: label_replace(up{app=~".*nginx-ingress-controller-app.*"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: managedapps
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_kubelet_down: "true"
         severity: page
         team: cabbage
         topic: ingress

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -21,7 +21,7 @@ spec:
         team: phoenix
         topic: monitoring
     - alert: InhibitionKubeletDown
-      expr: up{app="kubelet"} == 0
+      expr: label_replace(up{app="kubelet"}, "ip", "$1", "instance", "(.+):\\d+") == 0
       labels:
         kubelet_down: true
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`ChartOperator ({{ $labels.instance }}) is down.`}}'
         opsrecipe: chart-operator-down/
-      expr: up{app=~"chart-operator.*"} == 0
+      expr: label_replace(up{app=~"chart-operator.*"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: managedservices
@@ -22,7 +22,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
+        cancel_if_kubelet_down: "true"
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`Cadvisor ({{ $labels.instance }}) is down.`}}'
         opsrecipe: kubelet-is-down/
-      expr: up{app="cadvisor"} == 0
+      expr: label_replace(up{app="cadvisor"}, "ip", "$1", "instance", "(.+):\\d+") == 0
       for: 1h
       labels:
         area: kaas
@@ -48,7 +48,7 @@ spec:
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'
         opsrecipe: kube-state-metrics-down/
-      expr: up{app="kube-state-metrics"} == 0
+      expr: label_replace(up{app="kube-state-metrics"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: kaas
@@ -57,6 +57,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_any_kube_state_metrics_down: "true"
         cancel_if_cluster_has_no_workers: "true"
+        cancel_if_kubelet_down: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: atlas

--- a/test/tests/providers/aws/cert-manager.rules.test.yml
+++ b/test/tests/providers/aws/cert-manager.rules.test.yml
@@ -17,12 +17,14 @@ tests:
               area: kaas
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
+              cancel_if_kubelet_down: true
               cancel_if_outside_working_hours: true
               cluster_id: 12345
               cluster_type: workload_cluster
               container: cert-manager
               customer: giantswarm
               instance: 10.0.0.0:1234
+              ip: 10.0.0.0
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system
               node: ip-10-0-0-0.eu-central-1.compute.internal

--- a/test/tests/providers/openstack/cert-manager.rules.test.yml
+++ b/test/tests/providers/openstack/cert-manager.rules.test.yml
@@ -17,12 +17,14 @@ tests:
               area: kaas
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
+              cancel_if_kubelet_down: true
               cancel_if_outside_working_hours: true
               cluster_id: 12345
               cluster_type: workload_cluster
               container: cert-manager
               customer: giantswarm
               instance: 10.0.0.0:1234
+              ip: 10.0.0.0
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system
               node: ip-10-0-0-0.eu-central-1.compute.internal


### PR DESCRIPTION
This PR:

- fixes kubelet down inhibition and it's application towards https://github.com/giantswarm/giantswarm/issues/24746

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests. sadly not today
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
