### PR TITLE
Fix prometheus-agent rules for KVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - updated README with doc about the UT syntax
 
+### Fixed
+
+- Ensure Prometheus Agent alerts are not running on `kvm` installations.
+
 ## [2.67.0] - 2022-12-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -1,3 +1,4 @@
+{{- if ne .Values.managementCluster.provider.kind "kvm" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -24,3 +25,4 @@ spec:
         area: empowerment
         team: atlas
         topic: monitoring
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -1,3 +1,4 @@
+{{- if ne .Values.managementCluster.provider.kind "kvm" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -26,3 +27,4 @@ spec:
         cancel_if_cluster_is_not_running_prometheus_agent: "true"
         cancel_if_cluster_status_creating: true
         cancel_if_cluster_status_deleting: true
+{{- end }}


### PR DESCRIPTION
This PR:

- fixes prometheusagent rules so they are not deployed on KVM towards https://github.com/giantswarm/giantswarm/issues/24807

### Checklist

- [x] Update changelog in CHANGELOG.md.
