### PR TITLE
Fix fluent-bit down alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix fluentbit down alert.
-
-### Fixed
-
 - Ensure Prometheus Agent alerts are not running on `kvm` installations.
 
 ## [2.67.0] - 2022-12-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Split cert-manager & cert expiring alerts per provider
+- Split cert-manager & cert expiring alerts per provider.
 
 ### Changed
 
-- updated README with doc about the UT syntax
+- updated README with doc about the UT syntax.
+
+### Fixed
+
+- Fix fluentbit down alert.
 
 ## [2.67.0] - 2022-12-08
 

--- a/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
@@ -47,12 +47,12 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    # This alert ensures our fluent-bit daemon sets are running on the management clusters for customers that configured it.
+    # This alert ensures our fluent-bit daemon sets are running on the management clusters nodes for customers that configured it.
     - alert: FluentbitDown
       annotations:
-        description: '{{`Fluentbit ({{ $labels.instance }}) is down.`}}'
+        description: '{{`Fluentbit is down on node ({{ $labels.node }}).`}}'
         opsrecipe: fluentbit-down/
-      expr: sum(up{app="fluent-logshipping-app"}) by (app, cluster_id, cluster_type, installation, job, namespace, provider, instance, node) == 0
+      expr: sum(up{app="fluent-logshipping-app"}) by (app, cluster_id, cluster_type, installation, job, namespace, provider, node) == 0
       for: 15m
       labels:
         area: empowerment


### PR DESCRIPTION
This PR:

- fixes the fluent-bit down alert hence closing  https://github.com/giantswarm/giantswarm/issues/25001

We added the [instance label ](https://github.com/giantswarm/prometheus-rules/pull/510/files) to the alert to fix the description but this caused the alert to trigger when the pod restarted as can be seen here:

![image](https://user-images.githubusercontent.com/2787548/207054448-5e395d7f-3e0d-4e55-aedf-63596da3c2eb.png)

To fix this, this PR removes the instance label and change the description to be about the node as fluent-bit runs as a daemonset so the instance or pod is irrelevant.


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
