### PR TITLE
Remove gcp from workingHoursOnly list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - removed "workingHoursOnly" template from loki and crossplane tests
+- removed inhibition of GCP alerts from outside working hours
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -40,7 +40,7 @@ phoenix
 {{- end -}}
 
 {{- define "workingHoursOnly" -}}
-{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack") -}}
+{{- if has .Values.managementCluster.provider.kind (list "openstack") -}}
 "true"
 {{- else -}}
 "false"


### PR DESCRIPTION
This PR:

Removes inhibition of gcp alerts outside of working hours. We now have stable gcp clusters and these alerts should be enabled.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
