### PR TITLE
upgraded test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - removed "workingHoursOnly" template from loki and crossplane tests
+- upgraded Promtool and Architect for tests
 
 ### Fixed
 

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # let's have reproducable tests - pin to specific versions
-ARCHITECT_VERSION="6.5.0"
-PROMETHEUS_VERSION="2.28.1"
+ARCHITECT_VERSION="6.8.0"
+PROMETHEUS_VERSION="2.39.1"
 HELM_VERSION="3.9.0"
 YQ_VERSION="4.26.1"
 


### PR DESCRIPTION
This PR:

- upgrades promtool and architect for tests

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
