### PR TITLE
doc: how to add dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix `PrometheusCriticalJobScrapingFailure` alert by ignoring bastion node exporters and add the prometheus-agent not running inhibition because we know targets prior to that will have k8s component scraping failing.
 
+### Added
+
+- Documented how to add dashboard link
+
 ## [2.69.0] - 2022-12-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ here is an example:
         annotations:
             description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
             opsrecipe: app-failed/
+            dashboard: UniqueID/app-failed
         expr: app_operator_app_info{status!~"(?i:(deployed|cordoned))", catalog=~"control-plane-.*",team="atlas"}
         for: 30m
         labels:
@@ -40,8 +41,13 @@ here is an example:
 
 Any Alert includes:
 
-* A description
-* An [opsrecipe](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/) 
+* Mandatory annotations:
+  - `description`
+
+* Recommended annotations:
+  - [opsrecipe](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/)
+  - `dashboard` reference, built from `uid`/`title` in dashboard definition or copied from existing link
+
 * Mandatory labels:
    - `area`
    - `team`


### PR DESCRIPTION
This PR:

- adds documentation on how to add a grafana dashboard link to your rules.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
