### PR TITLE
added find-alerts.sh tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* small tool to look for / filter alerts
+
 ## [2.70.0] - 2022-12-14
 
 ### Fixed

--- a/scripts/find-alerts.sh
+++ b/scripts/find-alerts.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Contributed during Xmas 2022 hackathon.
+#
+
+# Example how to run it:
+# scripts/find-alerts.sh '.labels.team=="atlas"' '.labels.cancel_if_outside_working_hours=="true"' '.labels.severity=="page"'
+# => will report all alerts for team Atlas that page but are canceled out of working hours.
+
+# /!\ This script is provided as-is.
+# It won't break anything in your files, but parameters management, help, error handling is missing.
+# Meaning: no guarantee about the quality of generated output
+
+# In this place we can file helm-generated rules
+rulesFilesDir=test/tests/providers/aws/
+# => prerequisite: have files generated. for instance "make test" starts with generating files.
+
+# Custom (user-provided) filters
+selectQueries=("$@")
+
+# Build `jq` query from filters given as parameters
+selectQueriesString="$(printf "| select(%s)\n" "${selectQueries[@]}")"
+
+# For each rules file
+for rulesFile in "$rulesFilesDir"/*.rules.yml; do
+
+    # Retrieve (in an array) alert names that match the query
+    mapfile -t alertsList < <(
+        yq -ojson "$rulesFile" 2>/dev/null \
+        | jq '.groups[].rules[]
+            '"$selectQueriesString"'
+            | .alert' 2>/dev/null
+    ) || continue
+
+    # Console output
+    for alert in "${alertsList[@]}"; do
+        echo "alert $alert - file $(basename "$rulesFile")"
+    done
+done


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25092

This PR:

- adds a script `find-alerts.sh` that helps find and filter alerts.

Example:
```
[prometheus-rules]$ scripts/find-alerts.sh '.labels.team=="atlas"' '.labels.cancel_if_outside_working_hours=="true"' '.labels.severity=="page"'                                                                                                                                 
alert "ManagementClusterDaemonSetNotSatisfiedAtlas" - file daemonset.management-cluster.rules.yml
alert "ManagementClusterDaemonSetNotSatisfiedChinaAtlas" - file daemonset.management-cluster.rules.yml
alert "DataDiskPersistentVolumeSpaceTooLow" - file disk.management-cluster.rules.yml
alert "ElasticsearchClusterHealthStatusYellow" - file elasticsearch.rules.yml
alert "ElasticsearchDataVolumeSpaceTooLow" - file elasticsearch.rules.yml
alert "ElasticsearchHeapUsageWarning" - file elasticsearch.rules.yml
alert "FluentbitTooManyErrors" - file fluentbit.rules.yml
alert "FluentbitDown" - file fluentbit.rules.yml
alert "FluentdMemoryHighUtilization" - file fluentd.rules.yml
alert "GrafanaDown" - file grafana.management-cluster.rules.yml
alert "GrafanaFolderPermissionsDown" - file grafana.management-cluster.rules.yml
alert "GrafanaFolderPermissionsCronjobFails" - file grafana.management-cluster.rules.yml
alert "KubeConfigMapCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeDaemonSetCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeDeploymentCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeEndpointCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeNamespaceCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeNodeCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubePodCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeReplicaSetCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeSecretCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "KubeServiceCreatedMetricMissing" - file kube-state-metrics.rules.yml
alert "LokiRingUnhealthy" - file loki.all.rules.yml
alert "ManagedLoggingElasticsearchDataNodesNotSatisfied" - file managed-logging.rules.yml
alert "ManagedLoggingElasticsearchClusterDown" - file managed-logging.rules.yml
alert "NodeExporterDeviceError" - file node-exporter.all.rules.yml
alert "PrometheusMetaOperatorReconcileErrors" - file prometheus-meta-operator.rules.yml
alert "PrometheusOperatorListErrors" - file prometheus-operator.rules.yml
alert "PrometheusOperatorWatchErrors" - file prometheus-operator.rules.yml
alert "PrometheusOperatorSyncFailed" - file prometheus-operator.rules.yml
alert "PrometheusOperatorReconcileErrors" - file prometheus-operator.rules.yml
alert "PrometheusOperatorNodeLookupErrors" - file prometheus-operator.rules.yml
alert "PrometheusOperatorNotReady" - file prometheus-operator.rules.yml
alert "PrometheusOperatorRejectedResources" - file prometheus-operator.rules.yml
alert "PrometheusFailsToCommunicateWithRemoteStorageAPI" - file prometheus.rules.yml
alert "PrometheusRuleFailures" - file prometheus.rules.yml
alert "PrometheusCriticalJobScrapingFailure" - file prometheus.rules.yml
alert "CadvisorDown" - file up.all.rules.yml
```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
