### PR TITLE
Ensure PrometheusCriticalJobScrapingFailure does not page on kvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert previous fix.
+- Ensure `PrometheusCriticalJobScrapingFailure` does not page on kvm.
+
 ## [2.70.1] - 2022-12-15
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -1,3 +1,4 @@
+{{- if ne .Values.managementCluster.provider.kind "kvm" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -24,3 +25,4 @@ spec:
         area: empowerment
         team: atlas
         topic: monitoring
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -65,6 +65,7 @@ spec:
         team: atlas
         topic: observability
         cancel_if_outside_working_hours: "true"
+{{- if ne .Values.managementCluster.provider.kind "kvm" }}
     - alert: PrometheusCriticalJobScrapingFailure
       annotations:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}
@@ -97,3 +98,4 @@ spec:
         cancel_if_cluster_is_not_running_prometheus_agent: "true"
         cancel_if_cluster_status_creating: true
         cancel_if_cluster_status_deleting: true
+{{- end }}


### PR DESCRIPTION
This PR:

- fix agent on kvm

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
