### PR TITLE
fix AppWithoutTeamAnnotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- alert AppWithoutTeamLabel renamed to AppWithoutTeamAnnotation
+- alert AppWithoutTeamAnnotation opsrecipe
+- unit tests for AppWithoutTeamAnnotation
+- AppWithoutTeamAnnotation fires only during working hours
+
 ## [2.70.3] - 2022-12-19
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -91,10 +91,10 @@ spec:
         cancel_if_outside_working_hours: "true"
         severity: page
         topic: releng
-    - alert: AppWithoutTeamLabel
+    - alert: AppWithoutTeamAnnotation
       annotations:
         description: '{{`App {{ $labels.name }} has no team label.`}}'
-        opsrecipe: app-without-team-label/
+        opsrecipe: app-without-team-annotation/
       # we have this Frankenstein for namespace checks because go (and prometheus) don't support negative lookaheads in regex
       expr: label_replace(app_operator_app_info{team=~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       for: 40m
@@ -104,7 +104,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: true
         severity: notify
         team: atlas
         topic: releng

--- a/test/tests/providers/global/app.rules.test.yml
+++ b/test/tests/providers/global/app.rules.test.yml
@@ -3,6 +3,7 @@ rule_files:
   - app.rules.yml
 
 tests:
+  # WorkloadClusterAppFailed tests
   - interval: 1m
     input_series:
       - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="aws", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
@@ -47,3 +48,55 @@ tests:
             exp_annotations:
               description: "Workload Cluster App giantswarm/cilium, version 0.2.6 is  in pending-upgrade state. "
               opsrecipe: app-failed/
+
+  # AppWithoutTeamAnnotation tests
+  - interval: 1m
+    input_series:
+      - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="aws", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
+        values: "1+0x100"
+      - series: 'app_operator_app_info{app="userd", catalog="control-plane-catalog", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="vodafone", deployed_version="1.2.1", endpoint="web", installation="gauss", instance="app-exporter", job="app-exporter", name="userd", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-64f9c4fb7b-d77pv", provider="aws", service="app-exporter", service_priority="highest", status="deployed", team="noteam", upgrade_available="false", version="1.2.1", version_mismatch="false"}'
+        values: "1+0x100"
+    alert_rule_test:
+      - alertname: AppWithoutTeamAnnotation
+        eval_time: 30m
+        exp_alerts:
+      - alertname: AppWithoutTeamAnnotation
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              alertname: AppWithoutTeamAnnotation
+              app: userd
+              area: managedservices
+              cancel_if_apiserver_down: true
+              cancel_if_cluster_status_creating: true
+              cancel_if_cluster_status_deleting: true
+              cancel_if_cluster_status_updating: true
+              cancel_if_outside_working_hours: true
+              catalog: control-plane-catalog
+              cluster_id: gauss
+              cluster_missing: false
+              cluster_type: management_cluster
+              customer: vodafone
+              deployed_version: 1.2.1
+              endpoint: web
+              installation: gauss
+              instance: app-exporter
+              job: app-exporter
+              name: userd
+              namespace: giantswarm
+              node: ip-10-0-5-93.eu-west-1.compute.internal
+              organization: giantswarm
+              pod: app-exporter-64f9c4fb7b-d77pv
+              provider: aws
+              service: app-exporter
+              service_priority: highest
+              severity: notify
+              status: deployed
+              team: atlas
+              topic: releng
+              upgrade_available: false
+              version: 1.2.1
+              version_mismatch: false
+            exp_annotations:
+              description: App userd has no team label.
+              opsrecipe: app-without-team-annotation/


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24816

This PR:

- remames alert `AppWithoutTeamLabel` to `AppWithoutTeamAnnotation`
- updates opsrecipe for alert `AppWithoutTeamAnnotation`
- adds unit tests for AppWithoutTeamAnnotation
- changes AppWithoutTeamAnnotation to fire only during working hours

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Add Unit tests
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
- [ ] Alerting rules must have a comment documenting why it needs to exist.
- [ ] Consider creating a dashboard (if it does not exist already) to help oncallers monitor the status of the issue.
