### PR TITLE
Increase time for VaultIsDown from 15 to 20 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase time for VaultIsDown from 15 to 20 minutes.
+
 ## [2.70.4] - 2022-12-29
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Vault is down.`}}'
         opsrecipe: vault-is-down/
       expr: vault_up == 0
-      for: 15m
+      for: 20m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25177, this is a minor improvement for the sake of less noise during holidays.

This PR increases time for VaultIsDown from 15 to 20 minutes because lately we are often surpassing 15 min threshold.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
