### PR TITLE
prometheus-agent rule: add dashboard link (prometheus remote-write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Custom makefile which executes the go script to check inhibition labels
+- prometheus-agent rule: add dashboard link (prometheus remote-write)
 
 ## [2.70.5] - 2022-12-30
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Any Alert includes:
 
 * Recommended annotations:
   - [opsrecipe](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/)
-  - `dashboard` reference, built from `uid`/`title` in dashboard definition or copied from existing link
+  - `dashboard` reference, built from `uid`/`title` in dashboard definition or copied from existing link.
+      - If you dashboard has no `uid` make sure to update it with one, otherwise `uid` will differ between installations.
+      - Title is not used as-is: punctuation, spaces, upper case letters are changed. Look at the name in the dashboard URL on a grafana instance to check the right syntax.
 
 * Mandatory labels:
    - `area`

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -17,6 +17,7 @@ spec:
         description: '{{`Prometheus agent remote write is failing.`}}'
         summary: Prometheus agent fails to send samples to remote write endpoint.
         opsrecipe: prometheus-agent-remote-write-failed/
+        dashboard: BG-1wO5Vk/prometheus-remote-write
       expr: absent_over_time(up{instance="prometheus-agent"}[10m])
       for: 10m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Prometheus agent remote write is failing.`}}'
         summary: Prometheus agent fails to send samples to remote write endpoint.
         opsrecipe: prometheus-agent-remote-write-failed/
-        dashboard: BG-1wO5Vk/prometheus-remote-write
+        dashboard: promRW001/prometheus-remote-write
       expr: absent_over_time(up{instance="prometheus-agent"}[10m])
       for: 10m
       labels:

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -21,7 +21,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
             exp_annotations:
-              dashboard: "BG-1wO5Vk/prometheus-remote-write"
+              dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
               opsrecipe: "prometheus-agent-remote-write-failed/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -21,6 +21,7 @@ tests:
               cancel_if_cluster_status_creating: true
               cancel_if_cluster_status_deleting: true
             exp_annotations:
+              dashboard: "BG-1wO5Vk/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
               opsrecipe: "prometheus-agent-remote-write-failed/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25049

This is the dashboard I used the most when debugging prometheus-agent, thought it would be worth adding it to the alert.


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
