### PR TITLE
Labels check for each provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Go and bash scripts to check for potential missing labels in alerting rules
+- Go and bash scripts to check for potential missing labels in alerting rules for each provider
 
 ### Changed
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -5,7 +5,7 @@ clean-dry-run: ## dry run for `make clean` - print all untracked files
 .PHONY: clean
 clean: ## Clean the git work dir and remove all untracked files
 	# clean stage
-	git clean -xdf -- test/hack/bin
+	git clean -xdf -- test/hack/bin test/hack/output
 	git checkout -- helm/prometheus-rules/Chart.yaml
 	git checkout -- helm/prometheus-rules/values.yaml
 
@@ -27,7 +27,7 @@ template-chart: install-tools
 
 test-inhibitions: install-tools template-chart
 	# test whether inhibition labels are well defined
-	test/hack/bin/helm template helm/prometheus-rules --output-dir test/hack/output
+	./test/hack/bin/template-chart.sh
 	cd test/hack/checkLabels; go run main.go
 
 restore-chart:

--- a/test/hack/bin/.gitignore
+++ b/test/hack/bin/.gitignore
@@ -4,3 +4,4 @@
 !.gitignore
 !verify-rules.sh
 !fetch-tools.sh
+!template-chart.sh

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 local GIT_WORKDIR
-GIT_WORKDIR=$(git rev-parse --show-toplevel)
+GIT_WORKDIR="$(git rev-parse --show-toplevel)"
 
 local -a providers
 mapfile -t providers <"$GIT_WORKDIR/test/conf/providers"

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+local GIT_WORKDIR
+GIT_WORKDIR=$(git rev-parse --show-toplevel)
+
+local -a providers
+mapfile -t providers <"$GIT_WORKDIR/test/conf/providers"
+
+for provider in "${providers[@]}"; do
+    echo "Templating chart for provider: $provider"
+
+    helm template \
+    "$GIT_WORKDIR"/helm/prometheus-rules \
+    --set="managementCluster.provider.kind=$provider" \
+    --output-dir "$GIT_WORKDIR"/test/hack/output/"$provider"
+
+done

--- a/test/hack/checkLabels/main.go
+++ b/test/hack/checkLabels/main.go
@@ -68,6 +68,7 @@ func getMissingLabels() ([]string, error) {
 		return nil, err
 	}
 
+	// One iterates over all the different providers' directories
 	dirs, _ := ioutil.ReadDir(target_output)
 	for _, dir := range dirs {
 		if dir.IsDir() {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24956

This PR allows the labels checking script to perform for each provider, thus avoiding false missing labels in the output.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
