### PR TITLE
prometheus-agent alerts: increase delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Custom makefile which executes the go script to check inhibition labels
+- prometheus-agent alerts delay increased from 10m to 30m
 
 ## [2.70.5] - 2022-12-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Prometheus agent remote write is failing.`}}'
         summary: Prometheus agent fails to send samples to remote write endpoint.
         opsrecipe: prometheus-agent-remote-write-failed/
-      expr: absent_over_time(up{instance="prometheus-agent"}[10m])
+      expr: absent_over_time(up{instance="prometheus-agent"}[30m])
       for: 10m
       labels:
         area: empowerment


### PR DESCRIPTION
We're receiving a lot of false alerts for prometheus-agent which should be inhibited (on clusters where prometheus-agent is not supposed to be installed).
See https://gigantic.slack.com/archives/C01176DKNP4/p1672686479445259?thread_ts=1672680007.864779&cid=C01176DKNP4

This PR increases delay, so there's more chances the inhibition is set before it fires.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
