### PR TITLE
Alert for IRSA certificate expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Go and bash scripts to check for potential missing labels in alerting rules for each provider
+- Add alert to check IRSA certificate expiration.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -22,6 +22,18 @@ spec:
         severity: page
         team: phoenix
         topic: cert-manager
+    - alert: IRSACertificateSecretWillExpireInLessThanTwoWeeks
+      annotations:
+        description: '{{`IRSA Pod Identity Webhook Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
+      expr: (cert_exporter_secret_not_after{name=~"aws-pod-identity-webhook.*"} - time()) < 2 * 7 * 24 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: phoenix
+        topic: cert-manager
     - alert: CertificateSecretWillExpireInLessThanTwoWeeks
       annotations:
         description: '{{`Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'


### PR DESCRIPTION
Related issue: https://github.com/giantswarm/giantswarm/issues/24987

This PR alert team phoenix in case the AWS Pod Identity Webhook for IRSA
is going to expire. Currently this is crucial for customers who already
relying on IRSA to use IAM roles.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).