### PR TITLE
Use `pod` label rather than `container` label to match for critical pods in `ManagementClusterCriticalPodNotRunning`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `pod` label rather than `container` label to match for critical pods in `ManagementClusterCriticalPodNotRunning`.
+
 ## [2.71.0] - 2023-01-05
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/management-cluster.rules.yml
@@ -76,7 +76,7 @@ spec:
       annotations:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
-      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
+      expr: kube_pod_container_status_running{pod=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler).*"} != 1
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24986

This PR changes how critical pods are detected in MCs.
Before this PR the `container` label was used to get `api-server`, `scheduler` and `controller-manager` pods, but that also selected pods from unrelated app `scan-vulnerabilityreport` having the same `container` label.
By using pod name matching rather than container label we fix this problem.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
