### PR TITLE
dex-secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rule for expiry time of identity provider oauth app secrets managed by dex operator. 
+
 ## [2.71.1] - 2023-01-09
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -219,6 +219,9 @@ spec:
       record: aggregation:dex_requests_status_ok
     - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_email, user_name)
       record: aggregation:grafana_analytics_sessions_total
+    # Dex operator metrics for expiry time of identity provider oauth app secrets 
+    - expr: dex_operator_idp_secret_expiry_time
+      record: aggregation:dex_operator_idp_secret_expiry_time
     # Requests to the deprecated k8s authenticator. TODO: Get rid of this recording rule when the component is no longer used.
     - expr: nginx_ingress_controller_requests{ingress="dex-k8s-authenticator"}
       record: aggregation:dex_k8s_authenticator_requests


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1809
This PR adds a recording rule for expiry time of identity provider oauth app secrets managed by dex operator so we can see all the existing oauth apps and when their secret will expire on the central grafana.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
