### PR TITLE
add initial CAPZ CR alerting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Initial version of `CAPZ` related alerting rules
+
 ## [2.72.0] - 2023-01-09
 
 ### Added

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -40,7 +40,7 @@ phoenix
 {{- end -}}
 
 {{- define "workingHoursOnly" -}}
-{{- if has .Values.managementCluster.provider.kind (list "openstack") -}}
+{{- if has .Values.managementCluster.provider.kind (list "openstack" "capz") -}}
 "true"
 {{- else -}}
 "false"

--- a/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.managementCluster.provider.kind "openstack") (eq .Values.managementCluster.provider.kind "gcp") }}
+{{- if or (eq .Values.managementCluster.provider.kind "openstack") (eq .Values.managementCluster.provider.kind "gcp") (eq .Values.managementCluster.provider.kind "capz") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -35,6 +35,19 @@ spec:
             description: |-
               {{`The clusters {{$labels.cluster_name}} machinedeployment {{$labels.exported_namespace}}/{{$labels.machinedeployment}} does not match the expected number of replicas for longer than 1h.`}}
 
+        - alert: MachinePoolReplicasMismatch
+          expr: capi_machinepool_spec_replicas{} != capi_machinepool_status_replicas_available{}
+          for: 1h
+          labels:
+            area: kaas
+            cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
+            severity: notify
+            team: {{include "providerTeam" .}}
+            topic: managementcluster
+          annotations:
+            description: |-
+              {{`The clusters {{$labels.cluster_name}} machinepool {{$labels.exported_namespace}}/{{$labels.name}} does not match the expected number of replicas for longer than 1h.`}}
+
         - alert: KubeadmControlPlaneReplicasMismatch
           expr: capi_kubeadmcontrolplane_spec_replicas != capi_kubeadmcontrolplane_status_replicas_ready
           # 90min at max 3 replicas results in maximum of 30 minutes per control-plane machine.
@@ -60,5 +73,5 @@ spec:
             topic: managementcluster
           annotations:
             description: |-
-              {{`Cluster {{$labels.exported_namespace}}/{{$labels.cluster_name}} is in a non healthy phase.`}}
+              {{`Cluster {{$labels.exported_namespace}}/{{$labels.name}} is in a non healthy phase.`}}
 {{- end }}

--- a/test/conf/providers
+++ b/test/conf/providers
@@ -1,2 +1,3 @@
 openstack
 aws
+capz

--- a/test/tests/providers/capz/capi.rules.test.yml
+++ b/test/tests/providers/capz/capi.rules.test.yml
@@ -1,0 +1,97 @@
+rule_files:
+  - capi.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'capi_machine_status_phase{cluster_name="clippaxy", name="clippaxy-72jq5", exported_namespace="giantswarm", phase="Running"}'
+        values: "1+0x10 0+0x35"
+      - series: 'capi_machine_status_phase{cluster_name="clippaxy", name="clippaxy-72jq5", exported_namespace="giantswarm", phase="Failed"}'
+        values: "0+0x10 1+0x35"
+    alert_rule_test:
+      - alertname: MachineUnhealthyPhase
+        eval_time: 45m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              cluster_name: clippaxy
+              name: clippaxy-72jq5
+              exported_namespace: giantswarm
+              phase: Failed
+            exp_annotations:
+              description: "Machine giantswarm/clippaxy-72jq5 stuck in phase Failed for more than 30 minutes."
+  - interval: 1m
+    input_series:
+      - series: 'capi_machinepool_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinepool_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinepool_spec_replicas{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinepool_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+        values: "0+2x75"
+    alert_rule_test:
+      - alertname: MachinePoolReplicasMismatch
+        eval_time: 75m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              cluster_name: clippaxy
+              name: clippaxy-def99
+              exported_namespace: giantswarm
+            exp_annotations:
+              description: "The clusters clippaxy machinepool giantswarm/clippaxy-def99 does not match the expected number of replicas for longer than 1h."
+  - interval: 1m
+    input_series:
+      - series: 'capi_kubeadmcontrolplane_spec_replicas{cluster_name="clippaxy", name="clippaxy-72jq5", exported_namespace="giantswarm"}'
+        values: "0+3x100"
+      - series: 'capi_kubeadmcontrolplane_status_replicas_ready{cluster_name="clippaxy", name="clippaxy-72jq5", exported_namespace="giantswarm"}'
+        values: "0+3x100"
+      - series: 'capi_kubeadmcontrolplane_spec_replicas{cluster_name="clippaxy", name="clippaxy-72jzy", exported_namespace="giantswarm"}'
+        values: "0+3x100"
+      - series: 'capi_kubeadmcontrolplane_status_replicas_ready{cluster_name="clippaxy", name="clippaxy-72jzy", exported_namespace="giantswarm"}'
+        values: "0+2x100"
+    alert_rule_test:
+      - alertname: KubeadmControlPlaneReplicasMismatch
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              cluster_name: clippaxy
+              name: clippaxy-72jzy
+              exported_namespace: giantswarm
+            exp_annotations:
+              description: "The clusters clippaxy kubeadmcontrolplane giantswarm/clippaxy-72jzy does not match the expected number of replicas for longer than 90 minutes."
+  - interval: 1m
+    input_series:
+      - series: 'capi_cluster_status_phase{name="clippaxy", exported_namespace="giantswarm", phase="Provisioned"}'
+        values: "1+0x75"
+      - series: 'capi_cluster_status_phase{name="clippaxy", exported_namespace="giantswarm", phase="Pending"}'
+        values: "1+0x75"
+    alert_rule_test:
+      - alertname: ClusterUnhealthyPhase
+        eval_time: 75m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              name: clippaxy
+              exported_namespace: giantswarm
+              phase: Pending
+            exp_annotations:
+              description: "Cluster giantswarm/clippaxy is in a non healthy phase."

--- a/test/tests/providers/capz/cert-manager.rules.test.yml
+++ b/test/tests/providers/capz/cert-manager.rules.test.yml
@@ -1,0 +1,48 @@
+---
+rule_files:
+  - cert-manager.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{app="cert-manager-app", cluster_id="12345", cluster_type="workload_cluster", container="cert-manager", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="12345-prometheus/workload-12345/0", namespace="kube-system", node="ip-10-0-0-0.eu-central-1.compute.internal", organization="giantswarm", pod="cert-manager-controller-7fcc585578-gnprd", provider="openstack", service_priority="highest"}'
+        values: "0+0x60"
+    alert_rule_test:
+      - alertname: CertManagerDown
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              alertname: CertManagerDown
+              app: cert-manager-app
+              area: kaas
+              cancel_if_cluster_status_creating: true
+              cancel_if_cluster_status_deleting: true
+              cancel_if_kubelet_down: true
+              cancel_if_outside_working_hours: true
+              cluster_id: 12345
+              cluster_type: workload_cluster
+              container: cert-manager
+              customer: giantswarm
+              instance: 10.0.0.0:1234
+              ip: 10.0.0.0
+              job: 12345-prometheus/workload-12345/0
+              namespace: kube-system
+              node: ip-10-0-0-0.eu-central-1.compute.internal
+              organization: giantswarm
+              pod: cert-manager-controller-7fcc585578-gnprd
+              provider: openstack
+              installation: gollem
+              service_priority: highest
+              severity: page
+              team: clippy
+              topic: cert-manager
+            exp_annotations:
+              description: "cert-manager in namespace kube-system is down."
+              opsrecipe: "cert-manager-down/"
+  - interval: 1m
+    input_series:
+      - series: 'up{app="cert-manager-app", cluster_id="12345", cluster_type="workload_cluster", container="cert-manager", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="12345-prometheus/workload-12345/0", namespace="kube-system", node="ip-10-0-0-0.eu-central-1.compute.internal", organization="giantswarm", pod="cert-manager-controller-7fcc585578-gnprd", provider="openstack", service_priority="highest"}'
+        values: "1+0x60"
+    alert_rule_test:
+      - alertname: CertManagerDown
+        eval_time: 15m

--- a/test/tests/providers/capz/certificate.all.rules.test.yml
+++ b/test/tests/providers/capz/certificate.all.rules.test.yml
@@ -1,0 +1,92 @@
+---
+rule_files:
+  - certificate.all.rules.yml
+
+tests:
+  # CertificateSecretWillExpireInLessThanTwoWeeks within 2 weeks of expiration
+  - interval: 1d
+    input_series:
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+        values: "2678400x60"
+    alert_rule_test:
+      - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
+        eval_time: 20d
+        exp_alerts:
+          - exp_labels:
+              alertname: CertificateSecretWillExpireInLessThanTwoWeeks
+              app: cert-exporter-deployment
+              area: kaas
+              cancel_if_outside_working_hours: true
+              cluster_id: gollem
+              cluster_type: management_cluster
+              container: cert-exporter
+              customer: giantswarm
+              instance: 10.0.0.0:1234
+              job: gollem-prometheus/workload-gollem/0
+              namespace: giantswarm
+              node: 10.0.0.0
+              organization: giantswarm
+              pod: cert-exporter-deployment-5c47b4c55c-49wt9
+              provider: kvm
+              name: athena-certs-secret
+              installation: gollem
+              service_priority: highest
+              severity: page
+              secretkey: tls.crt
+              team: clippy
+              topic: cert-manager
+            exp_annotations:
+              description: "Certificate stored in Secret giantswarm/athena-certs-secret on gollem will expire in less than two weeks."
+              opsrecipe: "managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/"
+  # CertificateSecretWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
+  - interval: 1d
+    input_series:
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+        values: "2678400x60"
+    alert_rule_test:
+      - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
+        eval_time: 10d
+  # ManagedCertificateCRWillExpireInLessThanTwoWeeks within 2 weeks of expiration
+  - interval: 1d
+    input_series:
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+        values: "2678400x60"
+    alert_rule_test:
+      - alertname: ManagedCertificateCRWillExpireInLessThanTwoWeeks
+        eval_time: 20d
+        exp_alerts:
+          - exp_labels:
+              alertname: ManagedCertificateCRWillExpireInLessThanTwoWeeks
+              app: cert-exporter-deployment
+              area: kaas
+              cancel_if_outside_working_hours: true
+              cluster_id: 12345
+              cluster_type: workload_cluster
+              container: cert-exporter
+              customer: giantswarm
+              instance: 10.0.0.0:1234
+              job: 12345-prometheus/workload-12345/0
+              namespace: kube-system
+              node: 10.0.0.0
+              organization: giantswarm
+              pod: cert-exporter-deployment-57bbbfd856-8r8dr
+              provider: kvm
+              name: kiam-agent
+              installation: gollem
+              service_priority: highest
+              severity: page
+              team: clippy
+              topic: cert-manager
+              issuer_ref: kiam-ca-issuer
+              managed_issuer: true
+            exp_annotations:
+              description: "Certificate CR kube-system/kiam-agent on 12345 will expire in less than two weeks."
+              opsrecipe: "managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/"
+  # ManagedCertificateCRWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
+  - interval: 1d
+    input_series:
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+        values: "2678400x60"
+    alert_rule_test:
+      - alertname: ManagedCertificateCRWillExpireInLessThanTwoWeeks
+        eval_time: 10d

--- a/test/tests/providers/openstack/capi.rules.test.yml
+++ b/test/tests/providers/openstack/capi.rules.test.yml
@@ -76,9 +76,9 @@ tests:
               description: "The clusters galaxy kubeadmcontrolplane giantswarm/galaxy-72jzy does not match the expected number of replicas for longer than 90 minutes."
   - interval: 1m
     input_series:
-      - series: 'capi_cluster_status_phase{cluster_name="galaxy", name="galaxy-72jq5", exported_namespace="giantswarm", phase="Provisioned"}'
+      - series: 'capi_cluster_status_phase{name="galaxy", exported_namespace="giantswarm", phase="Provisioned"}'
         values: "1+0x75"
-      - series: 'capi_cluster_status_phase{cluster_name="galaxy", name="galaxy-86jq5", exported_namespace="giantswarm", phase="Pending"}'
+      - series: 'capi_cluster_status_phase{name="galaxy", exported_namespace="giantswarm", phase="Pending"}'
         values: "1+0x75"
     alert_rule_test:
       - alertname: ClusterUnhealthyPhase
@@ -90,8 +90,7 @@ tests:
               severity: notify
               team: rocket
               topic: managementcluster
-              cluster_name: galaxy
-              name: galaxy-86jq5
+              name: galaxy
               exported_namespace: giantswarm
               phase: Pending
             exp_annotations:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
