### PR TITLE
Remove Cilium SLO alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version of `CAPZ` related alerting rules
 
+### Changed
+
+- Removed Cilium alerts as those were for tests only
+
 ## [2.72.0] - 2023-01-09
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -329,26 +329,6 @@ spec:
         service: managed-alertmanager
       record: raw_slo_errors
 
-    # -- Cilium
-    # We assume one request/second for each cilium-agent replica
-    - expr: label_replace(count(cilium_version) * 60, "service", "cilium-agent", "", "")
-      labels:
-        class: MEDIUM
-        area: kaas
-      record: raw_slo_requests
-      # record number of errors.
-    - expr: label_replace(sum(cilium_errors_warnings_total{app="cilium-agent",level="error"}), "service", "cilium-agent", "", "")
-      labels:
-        area: kaas
-        class: MEDIUM
-      record: raw_slo_errors
-      # -- 99% availability
-    - expr: "vector((1 - 0.99))"
-      labels:
-        area: kaas
-        service: cilium-agent
-      record: slo_target
-
     # -- VPA
     # Amount of requests for VPA
     - expr: label_replace(count(up{app=~'vertical-pod-autoscaler.*'}) by (cluster_type,cluster_id), "label_application_giantswarm_io_team", "atlas", "", "")


### PR DESCRIPTION
We are removing the Cilium alerts as those were added to test generic Cilium alerts that proven to be flaky. We will have to rework those in the future. 

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
