### PR TITLE
Ship team name with Kyverno policy status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ship per-team Kyverno policy information to Grafana cloud.
+
 ## [2.73.0] - 2023-01-16
 
 ### Fixed
@@ -17,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version of `CAPZ` related alerting rules
 - Add `ClusterAutoscalerUnneededNodes` and `ClusterAutoscalerUnschedulablePods`
-- Ship per-team Kyverno policy information to Grafana cloud.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version of `CAPZ` related alerting rules
 - Add `ClusterAutoscalerUnneededNodes` and `ClusterAutoscalerUnschedulablePods`
+- Ship per-team Kyverno policy information to Grafana cloud.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -232,7 +232,23 @@ spec:
     - expr: sum(kyverno_policy_results_total{rule_result="fail"}) by (policy_type, policy_name)
       record: aggregation:kyverno_policy_failures
     # Kyverno policy status by team
-    - expr: sum(label_join(policy_report_result{policy!="check-deprecated-apis-1-25", kind="Deployment"}, "deployment", ",", "name")) by (deployment, policy, status) * on(deployment) group_left(team, app) sum(sum(label_join(kube_deployment_labels{}, "app", ",", "label_app_kubernetes_io_name")) by (deployment, app) * on(app) group_left(team) sum(app_operator_app_info{team!="noteam"}) by (app, team)) by (team, deployment, app)
+    - expr: |-
+        sum(
+          label_join(policy_report_result{
+            policy!="check-deprecated-apis-1-25",
+            kind="Deployment"
+            }, "deployment", ",", "name")
+        ) by (deployment, policy, status) 
+        * on(deployment) group_left(team, app) 
+        sum(
+          sum(
+            label_join(kube_deployment_labels{}, "app", ",", "label_app_kubernetes_io_name")
+          ) by (deployment, app) 
+          * on(app) group_left(team) 
+          sum(
+            app_operator_app_info{team!="noteam"}
+          ) by (app, team)
+        ) by (team, deployment, app)
       record: aggregation:kyverno_policy_status_team
     # Starboard unique vulnerability counts by severity
     - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -231,6 +231,9 @@ spec:
     # Kyverno failing policies
     - expr: sum(kyverno_policy_results_total{rule_result="fail"}) by (policy_type, policy_name)
       record: aggregation:kyverno_policy_failures
+    # Kyverno policy status by team
+    - export: sum(label_join(policy_report_result{policy!="check-deprecated-apis-1-25", kind="Deployment"}, "deployment", ",", "name")) by (deployment, policy, status) * on(deployment) group_left(team, app) sum(sum(label_join(kube_deployment_labels{}, "app", ",", "label_app_kubernetes_io_name")) by (deployment, app) * on(app) group_left(team) sum(app_operator_app_info{team!="noteam"}) by (app, team)) by (team, deployment, app)
+      record: aggregation:kyverno_policy_status_team
     # Starboard unique vulnerability counts by severity
     - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)
       record: aggregation:starboard_unique_vulnerability_count

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -232,7 +232,7 @@ spec:
     - expr: sum(kyverno_policy_results_total{rule_result="fail"}) by (policy_type, policy_name)
       record: aggregation:kyverno_policy_failures
     # Kyverno policy status by team
-    - export: sum(label_join(policy_report_result{policy!="check-deprecated-apis-1-25", kind="Deployment"}, "deployment", ",", "name")) by (deployment, policy, status) * on(deployment) group_left(team, app) sum(sum(label_join(kube_deployment_labels{}, "app", ",", "label_app_kubernetes_io_name")) by (deployment, app) * on(app) group_left(team) sum(app_operator_app_info{team!="noteam"}) by (app, team)) by (team, deployment, app)
+    - expr: sum(label_join(policy_report_result{policy!="check-deprecated-apis-1-25", kind="Deployment"}, "deployment", ",", "name")) by (deployment, policy, status) * on(deployment) group_left(team, app) sum(sum(label_join(kube_deployment_labels{}, "app", ",", "label_app_kubernetes_io_name")) by (deployment, app) * on(app) group_left(team) sum(app_operator_app_info{team!="noteam"}) by (app, team)) by (team, deployment, app)
       record: aggregation:kyverno_policy_status_team
     # Starboard unique vulnerability counts by severity
     - expr: count(count by (vulnerability_id, severity) (starboard_exporter_vulnerabilityreport_image_vulnerability)) by (severity)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/256

This PR adds an aggregation that looks like:
```
kyverno_policy_status_team{app="starboard-exporter", deployment="starboard-exporter", policy="restrict-seccomp", status="pass", team="shield"}
```

This will be used for creating org-level dashboards so teams can more easily track their failing policies.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
