### PR TITLE
add dex operator alerts in working hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial version of `CAPZ` related alerting rules
+- Add `ClusterAutoscalerUnneededNodes` and `ClusterAutoscalerUnschedulablePods`
 
 ### Changed
 
 - Removed Cilium alerts as those were for tests only
 - Move `NodeExporter*` alert ownership to provider team
+- Remove `ClusterAutoScalerErrors`
 
 ## [2.72.0] - 2023-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version of `CAPZ` related alerting rules
 - Add `ClusterAutoscalerUnneededNodes` and `ClusterAutoscalerUnschedulablePods`
+- Add `DexSecretExpired` and `ManagementClusterDexAppMissing` alerts in working hours.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -12,12 +12,28 @@ spec:
   groups:
   - name: cluster-autoscaler
     rules:
-    - alert: ClusterAutoscalerErrors
+    - alert: ClusterAutoscalerUnschedulablePods
       annotations:
-        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has increased errors.`}}'
+        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has unschedulable pods.`}}'
         opsrecipe: cluster-autoscaler-scaling/
-      expr: increase(cluster_autoscaler_errors_total[10m]) > 0
-      for: 15m
+      expr: cluster_autoscaler_unschedulable_pods_count > 0
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        severity: page
+        team: phoenix
+        topic: cluster-autoscaler
+    - alert: ClusterAutoscalerUnneededNodes
+      annotations:
+        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has unneeded nodes.`}}'
+        opsrecipe: cluster-autoscaler-scaling/
+      expr: cluster_autoscaler_unneeded_nodes_count > 0
+      for: 30m
       labels:
         area: managedservices
         cancel_if_cluster_status_creating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -24,7 +24,7 @@ spec:
         topic: dex
     - alert: DexSecretExpired
       annotations:
-        description: '{{`Dex operator running on {{ $labels.installation }} failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
+        description: '{{`dex-operator running on {{ $labels.installation }} failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
         opsrecipe: dex-operator/
       expr: min by(app_registration_name, app_owner, app_namespace, provider_name, provider_type, installation) (aggregation:dex_operator_idp_secret_expiry_time) - time() < 60*60*12
       for: 30m

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -36,7 +36,7 @@ spec:
         topic: dex
     - alert: ManagementClusterDexAppMissing
       annotations:
-        description: '{{`Dex operator did not register a dex-app in {{ $labels.app_namespace }} namespace on {{ $labels.installation }}.`}}'
+        description: '{{`dex-operator did not register a dex-app in {{ $labels.app_namespace }} namespace on {{ $labels.installation }}.`}}'
         opsrecipe: dex-operator/
       expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm"}) == 1
       for: 30m

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -25,7 +25,7 @@ spec:
     - alert: DexSecretExpired
       annotations:
         description: '{{`Dex operator running on {{ $labels.installation }} failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
-        opsrecipe: dex-secret-expired/
+        opsrecipe: dex-operator/
       expr: min by(app_registration_name, app_owner, app_namespace, provider_name, provider_type, installation) (aggregation:dex_operator_idp_secret_expiry_time) - time() < 60*60*12
       for: 30m
       labels:
@@ -37,7 +37,7 @@ spec:
     - alert: ManagementClusterDexAppMissing
       annotations:
         description: '{{`Dex operator did not register a dex-app in {{ $labels.app_namespace }} namespace on {{ $labels.installation }}.`}}'
-        opsrecipe: dex-app-missing/
+        opsrecipe: dex-operator/
       expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm"}) == 1
       for: 30m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -24,7 +24,7 @@ spec:
         topic: dex
     - alert: DexSecretExpired
       annotations:
-        description: '{{`dex-operator running on {{ $labels.installation }} failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
+        description: '{{`dex-operator failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
         opsrecipe: dex-operator/
       expr: min by(app_registration_name, app_owner, app_namespace, provider_name, provider_type, installation) (aggregation:dex_operator_idp_secret_expiry_time) - time() < 60*60*12
       for: 30m
@@ -36,7 +36,7 @@ spec:
         topic: dex
     - alert: ManagementClusterDexAppMissing
       annotations:
-        description: '{{`dex-operator did not register a dex-app in {{ $labels.app_namespace }} namespace on {{ $labels.installation }}.`}}'
+        description: '{{`dex-operator did not register a dex-app in giantswarm namespace.`}}'
         opsrecipe: dex-operator/
       expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm"}) == 1
       for: 30m

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -22,3 +22,27 @@ spec:
         severity: page
         team: rainbow
         topic: dex
+    - alert: DexSecretExpired
+      annotations:
+        description: '{{`Dex operator running on {{ $labels.installation }} failed to renew secret of {{ $labels.app_registration_name }} for {{ $labels.app_owner }} on provider {{ $labels.provider_type }}.`}}'
+        opsrecipe: dex-secret-expired/
+      expr: min by(app_registration_name, app_owner, app_namespace, provider_name, provider_type, installation) (aggregation:dex_operator_idp_secret_expiry_time) - time() < 60*60*12
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: rainbow
+        topic: dex
+    - alert: ManagementClusterDexAppMissing
+      annotations:
+        description: '{{`Dex operator did not register a dex-app in {{ $labels.app_namespace }} namespace on {{ $labels.installation }}.`}}'
+        opsrecipe: dex-app-missing/
+      expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm"}) == 1
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: rainbow
+        topic: dex


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1809

This PR adds alerts for dex-operator in business hours.
`DexSecretExpired` pages in case a dex oauth secret was not renewed by dex-operator.
`ManagementClusterDexAppMissing` pages in case there is no registered dex oauth app for a management cluster reconciled by dex-operator.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
