### PR TITLE
Add external secrets rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ship per-team Kyverno policy information to Grafana cloud.
+- Add basic rule that checks for deployments of `external-secrets` on MCs during business hours.
+
+### Removed
+
+- Remove `CrossplaneHelmReleaseFailed` alert because `FluxHelmReleaseFailed` triggers for the same thing. As long as the releases are stored in `flux-giantswarm`, but they have to be kept there because of our multi-tenant flux setup.
 
 ## [2.73.0] - 2023-01-16
 

--- a/helm/prometheus-rules/templates/alerting-rules/crossplane.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/crossplane.rules.yml
@@ -26,17 +26,3 @@ spec:
         severity: page
         team: honeybadger
         topic: managementcluster
-    # This triggers if the HelmRelease fails for Crossplane itself. Could come up when rolling out an upgrade to Crossplane.
-    - alert: CrossplaneHelmReleaseFailed
-      annotations:
-        description: |-
-          {{`Crossplane HelmRelease {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
-        opsrecipe: fluxcd-failing-helmrelease/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="management_cluster", namespace=~".*giantswarm.*", name="crossplane"} > 0
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: honeybadger
-        topic: releng

--- a/helm/prometheus-rules/templates/alerting-rules/external-secrets.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/external-secrets.rules.yml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: external-secrets.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: external-secrets
+    rules:
+    # This alert is for any deployment being in failed status in the `external-secrets` namespace.
+    - alert: DeploymentNotSatisfiedExternalSecrets
+      annotations:
+        description: '{{`ExternalSecrets related deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace="external-secrets"} > 0
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: honeybadger
+        topic: managementcluster

--- a/test/tests/providers/global/crossplane.rules.test.yml
+++ b/test/tests/providers/global/crossplane.rules.test.yml
@@ -79,39 +79,3 @@ tests:
             exp_annotations:
               description: "Crossplane related deployment crossplane/caicloud-event-exporter is not satisfied."
               opsrecipe: "deployment-not-satisfied/"
-  - interval: 1m
-    input_series:
-      - series: 'gotk_reconcile_condition{app="customer-flux-monitoring", cluster_id="gauss", cluster_type="management_cluster", container="manager", customer="giantswarm", installation="gauss", instance="100.64.4.137:8080", job="gauss-prometheus/workload-gauss/0", kind="HelmRelease", name="crossplane", namespace="flux-giantswarm", node="ip-10-0-5-152.eu-west-1.compute.internal", organization="giantswarm", pod="helm-controller-8cf7d5bb4-gshxz", provider="aws", service_priority="highest", status="False", type="Ready"}'
-        values: "0+0x20 1+0x20"
-    alert_rule_test:
-      - alertname: CrossplaneHelmReleaseFailed
-        eval_time: 32m
-        exp_alerts:
-          - exp_labels:
-              alertname: CrossplaneHelmReleaseFailed
-              app: customer-flux-monitoring
-              area: kaas
-              cancel_if_outside_working_hours: "true"
-              cluster_id: gauss
-              cluster_type: management_cluster
-              container: manager
-              customer: giantswarm
-              installation: gauss
-              instance: 100.64.4.137:8080
-              job: gauss-prometheus/workload-gauss/0
-              kind: HelmRelease
-              name: crossplane
-              namespace: flux-giantswarm
-              node: ip-10-0-5-152.eu-west-1.compute.internal
-              organization: giantswarm
-              pod: helm-controller-8cf7d5bb4-gshxz
-              provider: aws
-              service_priority: highest
-              severity: page
-              status: False
-              team: honeybadger
-              topic: releng
-              type: Ready
-            exp_annotations:
-              description: "Crossplane HelmRelease crossplane in ns flux-giantswarm on gauss/gauss is stuck in Failed state."
-              opsrecipe: "fluxcd-failing-helmrelease/"

--- a/test/tests/providers/global/externa-secrets.rules.test.yml
+++ b/test/tests/providers/global/externa-secrets.rules.test.yml
@@ -1,0 +1,119 @@
+---
+rule_files:
+  - external-secrets.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets", workload_type="deployment"}'
+        values: "0+0x20 1+0x100"
+    alert_rule_test:
+      - alertname: DeploymentNotSatisfiedCrossplane
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              alertname: DeploymentNotSatisfiedExternalSecrets
+              app: kube-state-metrics
+              area: managedservices
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: gauss
+              cluster_type: management_cluster
+              container: kube-state-metrics
+              customer: giantswarm
+              deployment: external-secrets
+              installation: gauss
+              instance: 100.64.6.226:8080
+              job: gauss-prometheus/workload-gauss/0
+              namespace: external-secrets
+              node: ip-10-0-5-161.eu-west-1.compute.internal
+              organization: giantswarm
+              pod: kube-state-metrics-fd99568b6-fnhdv
+              provider: aws
+              service_priority: highest
+              severity: page
+              team: honeybadger
+              topic: managementcluster
+              workload_name: external-secrets
+              workload_type: deployment
+            exp_annotations:
+              description: "ExternalSecrets related deployment external-secrets/external-secrets is not satisfied."
+              opsrecipe: "deployment-not-satisfied/"
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-cert-controller", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-cert-controller", workload_type="deployment"}'
+        values: "0+0x20 1+0x100"
+    alert_rule_test:
+      - alertname: DeploymentNotSatisfiedCrossplane
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              alertname: DeploymentNotSatisfiedExternalSecrets
+              app: kube-state-metrics
+              area: managedservices
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: gauss
+              cluster_type: management_cluster
+              container: kube-state-metrics
+              customer: giantswarm
+              deployment: external-secrets-cert-controller
+              installation: gauss
+              instance: 100.64.6.226:8080
+              job: gauss-prometheus/workload-gauss/0
+              namespace: external-secrets
+              node: ip-10-0-5-161.eu-west-1.compute.internal
+              organization: giantswarm
+              pod: kube-state-metrics-fd99568b6-fnhdv
+              provider: aws
+              service_priority: highest
+              severity: page
+              team: honeybadger
+              topic: managementcluster
+              workload_name: external-secrets-cert-controller
+              workload_type: deployment
+            exp_annotations:
+              description: "ExternalSecrets related deployment external-secrets/external-secrets-cert-controller is not satisfied."
+              opsrecipe: "deployment-not-satisfied/"
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-webhook", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-webhook", workload_type="deployment"}'
+        values: "0+0x20 1+0x100"
+    alert_rule_test:
+      - alertname: DeploymentNotSatisfiedCrossplane
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              alertname: DeploymentNotSatisfiedExternalSecrets
+              app: kube-state-metrics
+              area: managedservices
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: gauss
+              cluster_type: management_cluster
+              container: kube-state-metrics
+              customer: giantswarm
+              deployment: external-secrets-webhook
+              installation: gauss
+              instance: 100.64.6.226:8080
+              job: gauss-prometheus/workload-gauss/0
+              namespace: external-secrets
+              node: ip-10-0-5-161.eu-west-1.compute.internal
+              organization: giantswarm
+              pod: kube-state-metrics-fd99568b6-fnhdv
+              provider: aws
+              service_priority: highest
+              severity: page
+              team: honeybadger
+              topic: managementcluster
+              workload_name: external-secrets-webhook
+              workload_type: deployment
+            exp_annotations:
+              description: "ExternalSecrets related deployment external-secrets/external-secrets-webhook is not satisfied."
+              opsrecipe: "deployment-not-satisfied/"

--- a/test/tests/providers/global/external-secrets.rules.test.yml
+++ b/test/tests/providers/global/external-secrets.rules.test.yml
@@ -8,7 +8,7 @@ tests:
       - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets", workload_type="deployment"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
-      - alertname: DeploymentNotSatisfiedCrossplane
+      - alertname: DeploymentNotSatisfiedExternalSecrets
         eval_time: 60m
         exp_alerts:
           - exp_labels:
@@ -46,7 +46,7 @@ tests:
       - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-cert-controller", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-cert-controller", workload_type="deployment"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
-      - alertname: DeploymentNotSatisfiedCrossplane
+      - alertname: DeploymentNotSatisfiedExternalSecrets
         eval_time: 60m
         exp_alerts:
           - exp_labels:
@@ -84,7 +84,7 @@ tests:
       - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-webhook", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-webhook", workload_type="deployment"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
-      - alertname: DeploymentNotSatisfiedCrossplane
+      - alertname: DeploymentNotSatisfiedExternalSecrets
         eval_time: 60m
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1768

- Add basic rule that checks for deployments of `external-secrets` on MCs during business hours
- Remove CrossplaneHelmReleaseFailed alert because FluxHelmReleaseFailed triggers for the same thing. As long as the releases are stored in `flux-giantswarm` but they have to be kept there because of our multi-tenant flux setup.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
