### PR TITLE
Update promtool and fix makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update prometheus tool to `2.41.0` and Fix bash in chart-template target.
+
 ### Added
 
 - Ship per-team Kyverno policy information to Grafana cloud.

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -24,7 +24,7 @@ install-tools:
 template-chart: install-tools
 	# prepare the helm chart
 	test/hack/bin/architect helm template --dir helm/prometheus-rules --dry-run
-	./test/hack/bin/template-chart.sh
+	bash ./test/hack/bin/template-chart.sh
 
 test-inhibitions: install-tools template-chart
 	# test whether inhibition labels are well defined

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # let's have reproducable tests - pin to specific versions
 ARCHITECT_VERSION="6.8.0"
-PROMETHEUS_VERSION="2.39.1"
+PROMETHEUS_VERSION="2.41.0"
 HELM_VERSION="3.9.0"
 YQ_VERSION="4.26.1"
 


### PR DESCRIPTION
Now we're running Prometheus 2.41 on our clusters, we can upgrade promtool for the tests too.