### PR TITLE
alert for dex only on management clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Alert for `dex` only in management clusters.
+
 ## [2.73.1] - 2023-01-18
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: dex.rules
   namespace: {{ .Values.namespace  }}
 spec:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
