### PR TITLE
Fix cluster autoscaler alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Raise `ClusterAutoscalerUnneededNodes` alert threshould to 4 hours.
+- Raise `ClusterAutoscalerUnneededNodes` alert threshold to 4 hours.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise `ClusterAutoscalerUnneededNodes` alert threshould to 4 hours.
+
+### Removed
+
+- Remove `ClusterAutoscalerUnschedulablePods` alert as it is too unreliable.
+
 ## [2.73.2] - 2023-01-18
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -12,28 +12,12 @@ spec:
   groups:
   - name: cluster-autoscaler
     rules:
-    - alert: ClusterAutoscalerUnschedulablePods
-      annotations:
-        description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has unschedulable pods.`}}'
-        opsrecipe: cluster-autoscaler-scaling/
-      expr: cluster_autoscaler_unschedulable_pods_count > 0
-      for: 30m
-      labels:
-        area: managedservices
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        cancel_if_cluster_has_no_workers: "true"
-        severity: page
-        team: phoenix
-        topic: cluster-autoscaler
     - alert: ClusterAutoscalerUnneededNodes
       annotations:
         description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has unneeded nodes.`}}'
         opsrecipe: cluster-autoscaler-scaling/
       expr: cluster_autoscaler_unneeded_nodes_count > 0
-      for: 30m
+      for: 240m
       labels:
         area: managedservices
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25330

- Raise `ClusterAutoscalerUnneededNodes` alert threshold to 4 hours.

because of cooldown mechanism, there might be a significant delay between when a node is unneeded and when CA deletes it. raising the `for` field of this alert to 4h should prevent false alerts while still catching long term problems.

- Remove `ClusterAutoscalerUnschedulablePods` alert as it is too unreliable.

there are many reasons why pods are unschedulable, and only a portion of those are related to cluster not being able to scale. Unfortunately we don't have an easy way to tell if a pod is unschedulable because of cluster autoscaler so we can't help but delete this alert.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
