### PR TITLE
Add `AzureServicePrincipalExpirationMetricsMissing` alert 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AzureServicePrincipalExpirationMetricsMissing` firing on `gollum` only to catch when the service principal expiration metrics are missing.
+
 ## [2.74.0] - 2023-01-18
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
@@ -175,6 +175,17 @@ spec:
         severity: notify
         team: phoenix
         topic: observability
+    - alert: AzureServicePrincipalExpirationMetricsMissing
+      annotations:
+        description: '{{`Service Principal expiration metrics are missing on gollum.`}}'
+      expr: absent(azure_operator_service_principal_token_expiration) AND on () up{cluster_id="gollum"}
+      for: 4h
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: phoenix
+        topic: azure
     - alert: AzureServicePrincipalExpiresInOneMonth
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} will expire in less than one month.`}}'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25398

This PR adds a new alert firing on `gollum` only to catch when the service principal expiration metrics are missing.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
