### PR TITLE
Update azure.management-cluster.rules.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Turn `AzureClusterCreationFailed`'s severity from `notify` to page.
+
 ## [2.75.0] - 2023-01-23
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: phoenix
         topic: azure
     - alert: AzureClusterUpgradeFailed


### PR DESCRIPTION
Turn `AzureClusterCreationFailed`'s severity from `notify` to page.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
