### PR TITLE
Add dummy inhibitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ship per-team Kyverno policy information to Grafana cloud.
+- Dummy inhibition alerting rules to make ci happy.
 
 ## [2.73.0] - 2023-01-16
 

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -37,6 +37,26 @@ spec:
         kube_state_metrics_down: "true"
         team: phoenix
         topic: status
+    # TODO: fix with real expr 
+    - alert: ScrapeTimeout
+      annotations:
+        description: '{{`Never fires (dummy alert).`}}'
+      expr: vector(0)
+      labels:
+        area: empowerment
+        scrape_timeout: "true"
+        team: phoenix
+        topic: monitoring
+    # TODO: fix with real expr
+    - alert: ApiServerDown
+      annotations:
+        description: '{{`Never fires (dummy alert).`}}'
+      expr: vector(0)
+      labels:
+        area: empowerment
+        apiserver_down: "true"
+        team: phoenix
+        topic: monitoring
     {{- if or (eq .Values.managementCluster.provider.kind "azure") (eq .Values.managementCluster.provider.kind "aws") }}
     - alert: InhibitionClusterWithoutWorkerNodes
       annotations:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25340

This PR adds dummy inhibition labels to allow the new CI to pass. 

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
