### PR TITLE
Split `ManagedCertificateCRWillExpireInLessThanTwoWeeks` alert between giantswarm and customer secrets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Turn `AzureClusterCreationFailed`'s severity from `notify` to page.
+- Split `ManagedCertificateCRWillExpireInLessThanTwoWeeks` alert between giantswarm and customer secrets.
 
 ### Added
 

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -49,7 +49,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace!~"kube-system|giantswarm"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace!~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -45,14 +45,25 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: cert-manager
-    - alert: ManagedCertificateCRWillExpireInLessThanTwoWeeks
+    - alert: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
         team: {{ include "providerTeam" . }}
+        topic: cert-manager
+    - alert: CustomerManagedCertificateCRWillExpireInLessThanTwoWeeks
+      annotations:
+        description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace!~"kube-system|giantswarm"} - time()) < 2 * 7 * 24 * 60 * 60
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: se
         topic: cert-manager

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -49,7 +49,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace!~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",namespace!~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25670

This PR makes the ManagedCertificateCRWillExpireInLessThanTwoWeeks alert page either the provider team (for gs-owned certs) or the SEs (for customer owned certs) instead of always paging the team

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
