### PR TITLE
Update the cortex rules for requests and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix cortex recording rules for requests and limits
+
 ## [2.76.0] - 2023-02-01
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -138,18 +138,14 @@ spec:
       record: aggregation:kubernetes:persistentvolumeclaim_resource_requests_storage_bytes
     - expr: count(kube_persistentvolumeclaim_info) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:persistentvolumeclaim_total
-    - expr: sum(kube_pod_container_resource_limits_cpu_cores) by (cluster_type, cluster_id)
+    - expr: sum(kube_pod_container_resource_limits{resource="cpu", unit="core", organization="giantswarm"}) by (cluster_type, cluster_id, container)
       record: aggregation:kubernetes:pod_resource_limits_cpu_cores
-    - expr: sum(kube_pod_container_resource_limits_memory_bytes) by (cluster_type, cluster_id)
+    - expr: sum(kube_pod_container_resource_limits{resource="memory", unit="bytes", organization="giantswarm"}) by (cluster_type, cluster_id, container)
       record: aggregation:kubernetes:pod_resource_limits_memory_bytes
-    - expr: sum(kube_pod_container_resource_requests_cpu_cores) by (cluster_type, cluster_id)
+    - expr: sum(kube_pod_container_resource_requests{resource="cpu", unit="core", organization="giantswarm"}) by (cluster_type, cluster_id, container)
       record: aggregation:kubernetes:pod_resource_requests_cpu_cores
-    - expr: topk(10, sum(kube_pod_container_resource_requests_cpu_cores) by (cluster_type, cluster_id, pod)) by (cluster_id)
-      record: aggregation:kubernetes:top10_pod_resource_requests_cpu_cores
-    - expr: sum(kube_pod_container_resource_requests_memory_bytes) by (cluster_type, cluster_id)
+    - expr: sum(kube_pod_container_resource_requests{resource="memory", unit="bytes", organization="giantswarm"}) by (cluster_type, cluster_id, container)
       record: aggregation:kubernetes:pod_resource_requests_memory_bytes
-    - expr: topk(10, sum(kube_pod_container_resource_requests_memory_bytes) by (cluster_type, cluster_id, pod)) by (cluster_id)
-      record: aggregation:kubernetes:top10_pod_resource_requests_memory_bytes
     - expr: count(kube_pod_created) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:pod_total
     - expr: sum(kube_pod_status_ready{condition="false"}) by (cluster_type, cluster_id)


### PR DESCRIPTION
The metric structure has changed in kube-state-metrics 2.0.0

I've removed the top 10 and added all apps.

Coming from this Slack thread: https://gigantic.slack.com/archives/CEYM0KY5D/p1675342494515759

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
