### PR TITLE
add PrometheusMissingGrafanaCloud alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `PrometheusMissingGrafanaCloud` alert.
+
 ## [2.76.0] - 2023-02-01
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -27,6 +27,18 @@ spec:
         team: atlas
         topic: observability
     ## Pages Atlas when prometheus fails to send samples to cortex
+    - alert: PrometheusMissingGrafanaCloud
+      annotations:
+        description: '{{`Prometheus is not sending data to Grafana Cloud.`}}'
+        opsrecipe: prometheus-missing-grafana-cloud/
+      expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud"})
+      for: 1h
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
     - alert: PrometheusFailsToCommunicateWithRemoteStorageAPI
       annotations:
         description: '{{`Prometheus can''t communicate with Remote Storage API at {{ $labels.url }}.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -29,7 +29,7 @@ spec:
     ## Pages Atlas when prometheus fails to send samples to cortex
     - alert: PrometheusMissingGrafanaCloud
       annotations:
-        description: '{{`Prometheus is not sending data to Grafana Cloud.`}}'
+        description: 'Prometheus is not sending data to Grafana Cloud.'
         opsrecipe: tbd/
       expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud"})
       for: 1h

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -30,7 +30,7 @@ spec:
     - alert: PrometheusMissingGrafanaCloud
       annotations:
         description: '{{`Prometheus is not sending data to Grafana Cloud.`}}'
-        opsrecipe: prometheus-missing-grafana-cloud/
+        opsrecipe: tbd/
       expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud"})
       for: 1h
       labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25711

This PR adds the `PrometheusMissingGrafanaCloud` alert to detect when the configuration for Grafana Cloud is missing in Prometheus.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).