### PR TITLE
rename promtool based gh worklow jobs

### DIFF
--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -1,13 +1,22 @@
-name: test
+name: alert-test
+run-name: run unit and conformance tests
 
 on: [pull_request]
 
 jobs:
-  gitleaks:
+  promtool-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - name: run tests
-        run: make test
+      - name: run promtool unit tests
+        run: make test-rules
+  inhibition-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+      - name: run inhibition tests
+        run: make test-inhibitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- rename github workflow based unit tests
+
 ### Fixed
 
 - fix ManagedCertificateCRWillExpireInLessThanTwoWeeks unit tests


### PR DESCRIPTION
This PR renamed the `promtool test` based unit tests from `test/gitleaks` --> `promtool-tests/promtool-unit-tests`.
It also fixes a broken unit test which has landed on `master` due non-blocking permissions on `master` branch.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
