### PR TITLE
Fix node_status metrics for cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - rename github workflow based unit tests
+- fix node_status metrics for cortex
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -114,12 +114,18 @@ spec:
       record: aggregation:kubernetes:master_node_created
     - expr: count(kube_namespace_created) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:namespace_total
-    - expr: sum(kube_node_status_allocatable_cpu_cores) by (cluster_type, cluster_id)
+    - expr: sum(kube_node_status_allocatable{resource="cpu", unit="core"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:node_allocatable_cpu_cores_total
-    - expr: sum(kube_node_status_allocatable_memory_bytes) by (cluster_type, cluster_id)
+    - expr: sum(kube_node_status_allocatable{resource="memory", unit="byte"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:node_allocatable_memory_bytes
-    - expr: sum(kube_node_status_allocatable_pods) by (cluster_type, cluster_id)
+    - expr: sum(kube_node_status_allocatable{resource="pods", unit="integer"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:node_allocatable_pods_total
+    - expr: sum(kube_node_status_capacity{resource="cpu", unit="core"}) by (cluster_type, cluster_id)
+      record: aggregation:kubernetes:node_capacity_cpu_cores_total
+    - expr: sum(kube_node_status_capacity{resource="memory", unit="byte"}) by (cluster_type, cluster_id)
+      record: aggregation:kubernetes:node_capacity_memory_bytes
+    - expr: sum(kube_node_status_capacity{resource="pods", unit="integer"}) by (cluster_type, cluster_id)
+      record: aggregation:kubernetes:node_capacity_pods_total
     - expr: sum(kube_node_status_condition{condition="DiskPressure", status="true"}) by (cluster_type, cluster_id)
       record: aggregation:kubernetes:node_disk_pressure_total
     - expr: sum(kube_node_status_condition{condition="MemoryPressure", status="true"}) by (cluster_type, cluster_id)


### PR DESCRIPTION
The metric structure has changed in kube-state-metrics 2.0.0. I also added `node_status_capacity`.

See: https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.0.0-alpha

Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
