### PR TITLE
Add container memory/cpu usage for MCs to cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - rename github workflow based unit tests
 - fix typo in memory request/limit recording rule
+- add container memory/cpu usage for MCs to cortex
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -266,3 +266,8 @@ spec:
       record: aggregation:giantswarm:aws_servicequotas_operator_quota_applied_request_errors
     - expr: sum(aws_servicequotas_operator_quota_applied_values) by (account_id,service_name,quota_description,quota_code) / count(aws_servicequotas_operator_quota_applied_values) by (account_id,service_name,quota_description,quota_code)
       record: aggregation:giantswarm:aws_servicequotas_operator_quota_applied_values
+    # Management Cluster Usage
+    - expr: sum(container_memory_usage_bytes{cluster_type="management_cluster"}) by (container)
+      record: aggregation:container:memory_usage_bytes
+    - expr: sum(rate(container_cpu_usage_seconds_total{cluster_type="management_cluster"}[2m])) by (container)
+      record: aggregation:container:cpu_usage_cores


### PR DESCRIPTION
This adds aggregated memory and CPU usage of apps on the management cluster to cortex. 

Towards: https://github.com/giantswarm/giantswarm/issues/25709

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
