### PR TITLE
Fix inhibitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update dummy inhibitions' expressions
+
 ## [2.80.0] - 2023-02-13
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -41,7 +41,7 @@ spec:
     - alert: ScrapeTimeout
       annotations:
         description: '{{`Never fires (dummy alert).`}}'
-      expr: vector(0)
+      expr: vector(0) > 1
       labels:
         area: empowerment
         scrape_timeout: "true"
@@ -51,7 +51,7 @@ spec:
     - alert: ApiServerDown
       annotations:
         description: '{{`Never fires (dummy alert).`}}'
-      expr: vector(0)
+      expr: vector(0) > 1
       labels:
         area: empowerment
         apiserver_down: "true"


### PR DESCRIPTION
This PR changes the expression of two dummy inhibitions to prevent them from firing.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
