### PR TITLE
Add kong rules test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unit test for kong rules
+
 ## [2.82.4] - 2023-03-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Datastore of Kong in namespace {{ $labels.namespace }} is not reachable.`}}'
         opsrecipe: managed-app-kong/#kong-datastore-not-reachable
-      expr: kong_datastore_reachable == 0
+      expr: up{job="kong_datastore_reachable"} == 0
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Datastore of Kong in namespace {{ $labels.namespace }} is not reachable.`}}'
         opsrecipe: managed-app-kong/#kong-datastore-not-reachable
-      expr: up{job="kong_datastore_reachable"} == 0
+      expr: kong_datastore_reachable == 0
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
@@ -22,7 +22,7 @@ spec:
         area: managedservices
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: cabbage
         topic: kong

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -44,7 +44,6 @@ templates/alerting-rules/inhibit.all.rules.yml
 templates/alerting-rules/inhibit.management-cluster.rules.yml
 templates/alerting-rules/job.rules.yml
 templates/alerting-rules/kiam.rules.yml
-templates/alerting-rules/kong.rules.yml
 templates/alerting-rules/kube-state-metrics.rules.yml
 templates/alerting-rules/kubelet.management-cluster.rules.yml
 templates/alerting-rules/kubelet.workload-cluster.rules.yml

--- a/test/tests/providers/aws/kong.rules.test.yml
+++ b/test/tests/providers/aws/kong.rules.test.yml
@@ -1,0 +1,28 @@
+---
+rule_files:
+  - kong.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="kong_datastore_reachable", namespace="giantswarm", provider="aws"}'
+        values: '0+0x10'
+    alert_rule_test:
+      - alertname: KongDatastoreNotReachable
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              alertname: KongDatastoreNotReachable
+              area: managedservices
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "false"
+              job: kong_datastore_reachable
+              namespace: giantswarm
+              provider: aws
+              severity: page
+              team: cabbage
+              topic: kong
+            exp_annotations:
+              description: "Datastore of Kong in namespace giantswarm is not reachable."
+              opsrecipe: managed-app-kong/#kong-datastore-not-reachable

--- a/test/tests/providers/global/kong.rules.test.yml
+++ b/test/tests/providers/global/kong.rules.test.yml
@@ -5,8 +5,8 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{job="kong_datastore_reachable", namespace="giantswarm", provider="aws"}'
-        values: '0+0x10'
+      - series: 'up{job="kong_datastore_reachable", namespace="giantswarm"}'
+        values: '0+0x10 '
     alert_rule_test:
       - alertname: KongDatastoreNotReachable
         eval_time: 10m
@@ -19,7 +19,6 @@ tests:
               cancel_if_outside_working_hours: "false"
               job: kong_datastore_reachable
               namespace: giantswarm
-              provider: aws
               severity: page
               team: cabbage
               topic: kong

--- a/test/tests/providers/global/kong.rules.test.yml
+++ b/test/tests/providers/global/kong.rules.test.yml
@@ -5,7 +5,7 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kong_datastore_reachable{namespace="giantswarm"}'
+      - series: 'kong_datastore_reachable{cluster_id="deu01", installation="anteater", instance="localhost:8080", namespace="kong-internal", pod="kong-app-internal"}'
         values: '0+0x20 1+0x20 _x20'
     alert_rule_test:
       - alertname: KongDatastoreNotReachable
@@ -17,10 +17,14 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "false"
-              namespace: giantswarm
+              cluster_id: deu01
+              installation: anteater
+              instance: localhost:8080
+              namespace: kong-internal
+              pod: kong-app-internal
               severity: page
               team: cabbage
               topic: kong
             exp_annotations:
-              description: "Datastore of Kong in namespace giantswarm is not reachable."
+              description: "Datastore of Kong in namespace kong-internal is not reachable."
               opsrecipe: managed-app-kong/#kong-datastore-not-reachable

--- a/test/tests/providers/global/kong.rules.test.yml
+++ b/test/tests/providers/global/kong.rules.test.yml
@@ -5,8 +5,8 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{job="kong_datastore_reachable", namespace="giantswarm"}'
-        values: '0+0x10 '
+      - series: 'kong_datastore_reachable{namespace="giantswarm"}'
+        values: '0+0x20 1+0x20 _x20'
     alert_rule_test:
       - alertname: KongDatastoreNotReachable
         eval_time: 10m
@@ -17,7 +17,6 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "false"
-              job: kong_datastore_reachable
               namespace: giantswarm
               severity: page
               team: cabbage

--- a/test/tests/providers/global/kong.rules.test.yml
+++ b/test/tests/providers/global/kong.rules.test.yml
@@ -6,10 +6,14 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kong_datastore_reachable{cluster_id="deu01", installation="anteater", instance="localhost:8080", namespace="kong-internal", pod="kong-app-internal"}'
-        values: '0+0x20 1+0x20 _x20'
+        values: '_x20 1+0x10 0+0x20'
     alert_rule_test:
       - alertname: KongDatastoreNotReachable
-        eval_time: 10m
+        eval_time: 20m
+      - alertname: KongDatastoreNotReachable
+        eval_time: 30m
+      - alertname: KongDatastoreNotReachable
+        eval_time: 50m
         exp_alerts:
           - exp_labels:
               alertname: KongDatastoreNotReachable


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23854

This PR adds a unit test for `kong.rules.yml`

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
