### PR TITLE
Make `NodeExporterDeviceError` only if relevant disk scraping fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `NodeExporterDeviceError` only if relevant disk scraping fails.
+
 ## [2.80.1] - 2023-02-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`NodeExporter Mountpoint {{ $labels.mountpoint }} on device {{ $labels.device }} on {{ $labels.instance }} is erroring.`}}'
         opsrecipe: node-exporter-device-error/
-      expr: node_filesystem_device_error == 1
+      expr: node_filesystem_device_error{mountpoint=~"(/rootfs)?/var/(log|lib/kubelet.*|lib/kubelet|lib/etcd|lib/docker|lib/containerd)",cluster_type="management_cluster"} == 1 or node_filesystem_device_error{mountpoint=~"(/rootfs)?/var/(log|lib/kubelet|lib/etcd|lib/docker|lib/containerd)",cluster_type="workload_cluster"} == 1
       for: 10m
       labels:
         area: kaas

--- a/test/tests/providers/aws/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/aws/node-exporter.all.rules.test.yml
@@ -38,7 +38,7 @@ tests:
   # NodeExporterDeviceError tests
   - interval: 1m
     input_series:
-      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/usr"}'
+      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet", cluster_type="workload_cluster"}'
         values: "_x20 1+0x20 0+0x20"
     alert_rule_test:
       - alertname: NodeExporterDeviceError
@@ -54,13 +54,14 @@ tests:
               alertname: NodeExporterDeviceError
               area: "kaas"
               cancel_if_outside_working_hours: "true"
+              cluster_type: "workload_cluster"
               device: "/dev/mapper/usr"
               fstype: "ext4"
               instance: "10.0.5.111:10300"
-              mountpoint: "/usr"
+              mountpoint: "/var/lib/kubelet"
               severity: "page"
               team: "phoenix"
               topic: "observability"
             exp_annotations:
-              description: "NodeExporter Mountpoint /usr on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
+              description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
               opsrecipe: "node-exporter-device-error/"

--- a/test/tests/providers/capz/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/capz/node-exporter.all.rules.test.yml
@@ -38,7 +38,7 @@ tests:
   # NodeExporterDeviceError tests
   - interval: 1m
     input_series:
-      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/usr"}'
+      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet", cluster_type="workload_cluster"}'
         values: "_x20 1+0x20 0+0x20"
     alert_rule_test:
       - alertname: NodeExporterDeviceError
@@ -54,13 +54,14 @@ tests:
               alertname: NodeExporterDeviceError
               area: "kaas"
               cancel_if_outside_working_hours: "true"
+              cluster_type: "workload_cluster"
               device: "/dev/mapper/usr"
               fstype: "ext4"
               instance: "10.0.5.111:10300"
-              mountpoint: "/usr"
+              mountpoint: "/var/lib/kubelet"
               severity: "page"
               team: "clippy"
               topic: "observability"
             exp_annotations:
-              description: "NodeExporter Mountpoint /usr on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
+              description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
               opsrecipe: "node-exporter-device-error/"

--- a/test/tests/providers/openstack/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/openstack/node-exporter.all.rules.test.yml
@@ -38,7 +38,7 @@ tests:
   # NodeExporterDeviceError tests
   - interval: 1m
     input_series:
-      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/usr"}'
+      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet"}'
         values: "_x20 1+0x20 0+0x20"
     alert_rule_test:
       - alertname: NodeExporterDeviceError
@@ -57,10 +57,10 @@ tests:
               device: "/dev/mapper/usr"
               fstype: "ext4"
               instance: "10.0.5.111:10300"
-              mountpoint: "/usr"
+              mountpoint: "/var/lib/kubelet"
               severity: "page"
               team: "rocket"
               topic: "observability"
             exp_annotations:
-              description: "NodeExporter Mountpoint /usr on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
+              description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
               opsrecipe: "node-exporter-device-error/"

--- a/test/tests/providers/openstack/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/openstack/node-exporter.all.rules.test.yml
@@ -38,7 +38,7 @@ tests:
   # NodeExporterDeviceError tests
   - interval: 1m
     input_series:
-      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet"}'
+      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet",cluster_type="workload_cluster"}'
         values: "_x20 1+0x20 0+0x20"
     alert_rule_test:
       - alertname: NodeExporterDeviceError
@@ -61,6 +61,7 @@ tests:
               severity: "page"
               team: "rocket"
               topic: "observability"
+              cluster_type: "workload_cluster"
             exp_annotations:
               description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
               opsrecipe: "node-exporter-device-error/"

--- a/test/tests/providers/openstack/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/openstack/node-exporter.all.rules.test.yml
@@ -38,7 +38,7 @@ tests:
   # NodeExporterDeviceError tests
   - interval: 1m
     input_series:
-      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet",cluster_type="workload_cluster"}'
+      - series: 'node_filesystem_device_error{device="/dev/mapper/usr", fstype="ext4", instance="10.0.5.111:10300", mountpoint="/var/lib/kubelet", cluster_type="workload_cluster"}'
         values: "_x20 1+0x20 0+0x20"
     alert_rule_test:
       - alertname: NodeExporterDeviceError
@@ -54,6 +54,7 @@ tests:
               alertname: NodeExporterDeviceError
               area: "kaas"
               cancel_if_outside_working_hours: "true"
+              cluster_type: "workload_cluster"
               device: "/dev/mapper/usr"
               fstype: "ext4"
               instance: "10.0.5.111:10300"
@@ -61,7 +62,6 @@ tests:
               severity: "page"
               team: "rocket"
               topic: "observability"
-              cluster_type: "workload_cluster"
             exp_annotations:
               description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."
               opsrecipe: "node-exporter-device-error/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23451

This PR makes alert less noisy by only checking success of scraping of disks we actually care about

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
