### PR TITLE
Split Calico alerts per provider team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make `NodeExporterDeviceError` only if relevant disk scraping fails.
+- Split Calico notify alerts per provider team
 
 ## [2.80.1] - 2023-02-14
 

--- a/helm/prometheus-rules/templates/alerting-rules/calico.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/calico.rules.yml
@@ -20,7 +20,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: CalicoNodeMemoryHighUtilization
       annotations:
@@ -35,7 +35,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: phoenix
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
 {{- if eq .Values.managementCluster.provider.kind "kvm" }}
     - alert: CalicoNodeFailingToSaveIptables
@@ -51,7 +51,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
     - alert: CalicoNodeFailingToRestoreIptables
       annotations:
@@ -66,6 +66,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: kubernetes
 {{- end }}


### PR DESCRIPTION
KVM installations are 'notifying' in #alert-phoenix channel - let's split it per provider as we need clean data for SLO alerts