### PR TITLE
Add team labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make `NodeExporterDeviceError` only if relevant disk scraping fails.
+- Add team labels to prometheus rules for https://github.com/giantswarm/prometheus-meta-operator/pull/1181
 
 ## [2.80.1] - 2023-02-14
 

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -23,6 +23,7 @@ app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace 
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- end -}}

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -23,7 +23,7 @@ app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace 
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- end -}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18281

This PR adds the team label to prometheus rules so they can be picked up by the change introduced in https://github.com/giantswarm/prometheus-meta-operator/pull/1181

### Checklist

- [x] Update CHANGELOG.md
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
