### PR TITLE
Adding app to alert rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `app` differentiator to the `FluxSourceFailed` alert.
+
 ## [2.82.0] - 2023-02-28
 
 ### Changed
@@ -139,7 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add recording rule for expiry time of identity provider oauth app secrets managed by dex operator. 
+- Add recording rule for expiry time of identity provider oauth app secrets managed by dex operator.
 
 ## [2.71.1] - 2023-01-09
 
@@ -1762,4 +1766,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/giantswarm/prometheus-rules/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/giantswarm/prometheus-rules/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/giantswarm/prometheus-rules/releases/tag/v0.1.0
-

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -82,7 +82,7 @@ spec:
         description: |-
           {{`Flux {{ $labels.kind }} {{ $labels.name }} in ns {{ $labels.namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         opsrecipe: fluxcd-failing-source/
-      expr: gotk_reconcile_condition{type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster", namespace=~".*giantswarm.*"} > 0
+      expr: gotk_reconcile_condition{app="flux-giantswarm-monitoring", type="Ready", status="False", kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster", namespace=~".*giantswarm.*"} > 0
       for: 2h
       labels:
         area: kaas
@@ -116,7 +116,7 @@ spec:
           sum(increase(gotk_reconcile_duration_seconds_sum{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
           /
           sum(increase(gotk_reconcile_duration_seconds_count{app="flux-giantswarm-monitoring",namespace="flux-giantswarm",kind=~"Kustomization|HelmRelease"}[10m])) by (kind,name,cluster_id,installation)
-          ) 
+          )
         >bool 360)[7d:10m])
         / (7*24*6) < 0.97
       for: 10m


### PR DESCRIPTION
Narrow down the alert rule.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
