### PR TITLE
Fix ClusterEtcdDBSizeTooLarge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix ClusterEtcdDBSizeTooLarge alerts.
+
 ## [2.80.1] - 2023-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add team labels to prometheus rules for https://github.com/giantswarm/prometheus-meta-operator/pull/1181
 - Split Calico notify alerts per provider team
 
-
 ## [2.80.1] - 2023-02-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"} > 0.5
+      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"} > 0.5
       for: 24h
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -27,8 +27,8 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="management_cluster"} > 0.5
-      for: 24h
+      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="management_cluster"} / etcd_server_quota_backend_bytes{cluster_type="management_cluster"}) * 100 > 80
+      for: 90m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"} > 0.5
+      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"} > 0.5
       for: 24h
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -43,8 +43,8 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
-      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} - etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"}) / etcd_mvcc_db_total_size_in_use_in_bytes{cluster_type="workload_cluster"} > 0.5
-      for: 24h
+      expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} / etcd_server_quota_backend_bytes{cluster_type="workload_cluster"}) * 100 > 80
+      for: 90m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26054

With `etcd 3.5` `etcd_debugging_mvcc_db_total_size_in_bytes` is dropped
as a metric and got replaced with `etcd_mvcc_db_total_size_in_bytes`.

This is currently the reason why we don't get paged when we hit
`NOSPACE` in etcd.

The good news is it's also working with our older clusters which still using `etcd 3.4`

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).