### PR TITLE
Exclude bastion machines from status phase check since they are always in Provisioned state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix `MachineUnhealthyPhase` rule to exclude bastion nodes
+- Fix `MachineDeploymentReplicasMismatch` rule to exclude bastion nodes and fix description
 
 ## [2.82.3] - 2023-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix `MachineUnhealthyPhase` rule to exclude bastion nodes
+
 ## [2.82.3] - 2023-03-07
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
@@ -23,7 +23,7 @@ spec:
             topic: managementcluster
 
         - alert: MachineDeploymentReplicasMismatch
-          expr: capi_machinedeployment_spec_replicas{} != capi_machinedeployment_status_replicas_available{}
+          expr: capi_machinedeployment_spec_replicas{name!~".*bastion.*"} != capi_machinedeployment_status_replicas_available{}
           for: 1h
           labels:
             area: kaas
@@ -33,7 +33,7 @@ spec:
             topic: managementcluster
           annotations:
             description: |-
-              {{`The clusters {{$labels.cluster_name}} machinedeployment {{$labels.exported_namespace}}/{{$labels.machinedeployment}} does not match the expected number of replicas for longer than 1h.`}}
+              {{`The clusters {{$labels.cluster_name}} machinedeployment {{$labels.exported_namespace}}/{{$labels.name}} does not match the expected number of replicas for longer than 1h.`}}
 
         - alert: MachinePoolReplicasMismatch
           expr: capi_machinepool_spec_replicas{} != capi_machinepool_status_replicas_available{}

--- a/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
@@ -13,7 +13,7 @@ spec:
           annotations:
             description: |-
               {{`Machine {{ $labels.exported_namespace}}/{{ $labels.name }} stuck in phase {{ $labels.phase }} for more than 30 minutes.`}}
-          expr: capi_machine_status_phase{phase!~"Running"} > 0
+          expr: capi_machine_status_phase{phase!~"Running", name!~".*bastion.*"} > 0
           for: 30m
           labels:
             area: kaas

--- a/test/tests/providers/capz/capi.rules.test.yml
+++ b/test/tests/providers/capz/capi.rules.test.yml
@@ -24,6 +24,31 @@ tests:
               phase: Failed
             exp_annotations:
               description: "Machine giantswarm/clippaxy-72jq5 stuck in phase Failed for more than 30 minutes."
+    - interval: 1m
+      input_series:
+        - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+          values: "0+3x75"
+        - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+          values: "0+3x75"
+        - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+          values: "0+3x75"
+        - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+          values: "0+2x75"
+      alert_rule_test:
+        - alertname: MachineDeploymentReplicasMismatch
+          eval_time: 75m
+          exp_alerts:
+            - exp_labels:
+                area: kaas
+                cancel_if_outside_working_hours: "true"
+                severity: notify
+                team: clippy
+                topic: managementcluster
+                cluster_name: clippaxy
+                name: clippaxy-def99
+                exported_namespace: giantswarm
+                exp_annotations:
+                description: "The clusters clippaxy machinedeployment giantswarm/clippaxy-def99 does not match the expected number of replicas for longer than 1h."
   - interval: 1m
     input_series:
       - series: 'capi_machinepool_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'

--- a/test/tests/providers/capz/capi.rules.test.yml
+++ b/test/tests/providers/capz/capi.rules.test.yml
@@ -24,31 +24,31 @@ tests:
               phase: Failed
             exp_annotations:
               description: "Machine giantswarm/clippaxy-72jq5 stuck in phase Failed for more than 30 minutes."
-    - interval: 1m
-      input_series:
-        - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
-          values: "0+3x75"
-        - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
-          values: "0+3x75"
-        - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
-          values: "0+3x75"
-        - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
-          values: "0+2x75"
-      alert_rule_test:
-        - alertname: MachineDeploymentReplicasMismatch
-          eval_time: 75m
-          exp_alerts:
-            - exp_labels:
-                area: kaas
-                cancel_if_outside_working_hours: "true"
-                severity: notify
-                team: clippy
-                topic: managementcluster
-                cluster_name: clippaxy
-                name: clippaxy-def99
-                exported_namespace: giantswarm
-              exp_annotations:
-                description: "The clusters clippaxy machinedeployment giantswarm/clippaxy-def99 does not match the expected number of replicas for longer than 1h."
+  - interval: 1m
+    input_series:
+      - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinedeployment_spec_replicas{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+        values: "0+3x75"
+      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="clippaxy", name="clippaxy-def99", exported_namespace="giantswarm"}'
+        values: "0+2x75"
+    alert_rule_test:
+      - alertname: MachineDeploymentReplicasMismatch
+        eval_time: 75m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              cluster_name: clippaxy
+              name: clippaxy-def99
+              exported_namespace: giantswarm
+            exp_annotations:
+              description: "The clusters clippaxy machinedeployment giantswarm/clippaxy-def99 does not match the expected number of replicas for longer than 1h."
   - interval: 1m
     input_series:
       - series: 'capi_machinepool_spec_replicas{cluster_name="clippaxy", name="clippaxy-def00", exported_namespace="giantswarm"}'

--- a/test/tests/providers/capz/capi.rules.test.yml
+++ b/test/tests/providers/capz/capi.rules.test.yml
@@ -47,7 +47,7 @@ tests:
                 cluster_name: clippaxy
                 name: clippaxy-def99
                 exported_namespace: giantswarm
-                exp_annotations:
+              exp_annotations:
                 description: "The clusters clippaxy machinedeployment giantswarm/clippaxy-def99 does not match the expected number of replicas for longer than 1h."
   - interval: 1m
     input_series:

--- a/test/tests/providers/openstack/capi.rules.test.yml
+++ b/test/tests/providers/openstack/capi.rules.test.yml
@@ -26,13 +26,13 @@ tests:
               description: "Machine giantswarm/galaxy-72jq5 stuck in phase Failed for more than 30 minutes."
   - interval: 1m
     input_series:
-      - series: 'capi_machinedeployment_spec_replicas{cluster_name="galaxy", machinedeployment="galaxy-72jq5", exported_namespace="giantswarm"}'
+      - series: 'capi_machinedeployment_spec_replicas{cluster_name="galaxy", name="galaxy-72jq5", exported_namespace="giantswarm"}'
         values: "0+3x75"
-      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="galaxy", machinedeployment="galaxy-72jq5", exported_namespace="giantswarm"}'
+      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="galaxy", name="galaxy-72jq5", exported_namespace="giantswarm"}'
         values: "0+3x75"
-      - series: 'capi_machinedeployment_spec_replicas{cluster_name="galaxy", machinedeployment="galaxy-72jzy", exported_namespace="giantswarm"}'
+      - series: 'capi_machinedeployment_spec_replicas{cluster_name="galaxy", name="galaxy-72jzy", exported_namespace="giantswarm"}'
         values: "0+3x75"
-      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="galaxy", machinedeployment="galaxy-72jzy", exported_namespace="giantswarm"}'
+      - series: 'capi_machinedeployment_status_replicas_available{cluster_name="galaxy", name="galaxy-72jzy", exported_namespace="giantswarm"}'
         values: "0+2x75"
     alert_rule_test:
       - alertname: MachineDeploymentReplicasMismatch

--- a/test/tests/providers/openstack/capi.rules.test.yml
+++ b/test/tests/providers/openstack/capi.rules.test.yml
@@ -45,7 +45,7 @@ tests:
               team: rocket
               topic: managementcluster
               cluster_name: galaxy
-              machinedeployment: galaxy-72jzy
+              name: galaxy-72jzy
               exported_namespace: giantswarm
             exp_annotations:
               description: "The clusters galaxy machinedeployment giantswarm/galaxy-72jzy does not match the expected number of replicas for longer than 1h."


### PR DESCRIPTION
Fix `MachineUnhealthy` by excluding bastion host which are always stuck in `Provisioned` State

![image](https://user-images.githubusercontent.com/2085772/223729963-45466399-dfe6-4b31-a7de-323c1f1201bc.png)

and `MachineDeploymentReplicasMismatch`

![image](https://user-images.githubusercontent.com/2085772/223730923-c7aed57c-393d-4738-9a0d-8a251bf4f683.png)


### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
