### PR TITLE
Silence `IRSATooManyErrors` during cluster creation and deletion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Silence `IRSATooManyErrors` during cluster creation and deletion.
+
 ## [2.83.0] - 2023-03-16
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -166,6 +166,8 @@ spec:
       for: 10m
       labels:
         area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: phoenix


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C02HLSDH3DZ/p1678982180275759

This PR silences the irsa errors during cluster creation

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
