### PR TITLE
Fix PersistentVolumeSpaceTooLow alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `PersistentVolumeSpaceTooLow` alert.
+
 ### Changed
 
 - Silence `IRSATooManyErrors` during cluster creation and deletion.

--- a/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
@@ -63,7 +63,7 @@ spec:
       annotations:
         description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         opsrecipe: low-disk-space/#persistent-volume
-      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod_id) group_left label_replace(kube_pod_info{priority_class!="prometheus"}, "pod_id", "$1", "uid", "(.*)")) < 10
+      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod) group_left kube_pod_info{priority_class!="prometheus"}) < 10
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
In an effort to reduce memory usage of Prometheus, I investigated some of the most used labels and uid is one of them. After noticing that it is only used for one prometheus rules, I checked if I could find alternatives to drop this label and acually noticed the alert was incorrectly configured, probably after some upgrade that removed the original labels.


This PR fixes the `PersistentVolumeSpaceTooLow` as it's currently not working.

As you can see [here](https://prometheus.g8s.gauss.eu-west-1.aws.gigantic.io/gauss/graph?g0.expr=100%20*%20((node_filesystem_free_bytes%7Bmountpoint%3D~%22(%2Frootfs)%3F%2Fvar%2Flib%2Fkubelet.*%22%7D%20%2F%20node_filesystem_size_bytes%7Bmountpoint%3D~%22(%2Frootfs)%3F%2Fvar%2Flib%2Fkubelet.*%22%7D))&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) there is currently no pod_id label in the metric. It is only available in the mountpoint label that the original query did not extract.


The joined query has a pod label that matches the one from the previous metric.

You can see the [fixed query](https://prometheus.g8s.gauss.eu-west-1.aws.gigantic.io/gauss/graph?g0.expr=100%20*%20((node_filesystem_free_bytes%7Bmountpoint%3D~%22(%2Frootfs)%3F%2Fvar%2Flib%2Fkubelet.*%22%7D%20%2F%20node_filesystem_size_bytes%7Bmountpoint%3D~%22(%2Frootfs)%3F%2Fvar%2Flib%2Fkubelet.*%22%7D)%20*%20on%20(pod)%20group_left%20()%20kube_pod_info%7Bpriority_class!%3D%22prometheus%22%7D)&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) returns results whereas the previous one was empty

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
