### PR TITLE
Ship Kyverno resource counts to cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ship Kyverno-related resource counts to Grafana Cloud.
+
 ## [2.84.0] - 2023-03-21
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/cortex.rules.yml
@@ -233,6 +233,9 @@ spec:
     # Kyverno failing policies
     - expr: sum(kyverno_policy_results_total{rule_result="fail"}) by (policy_type, policy_name)
       record: aggregation:kyverno_policy_failures
+    # Kyverno-related resource counts by kind
+    - expr: sum(etcd_kubernetes_resources_count{kind=~".*.kyverno.io|clusterpolicyreports.wgpolicyk8s.io|policyreports.wgpolicyk8s.io"}) by (cluster_id, kind)
+      record: aggregation:kyverno_resource_counts
     # Kyverno policy status by team
     - expr: |-
         sum(


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26347

This PR ships the count of each type of Kyverno resource to cortex to help measure the impact of performance improvements and identify potential trouble spots.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
