### PR TITLE
Tune prometheus-cant-communicate-with-remote-storage-api alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tuned prometheus-cant-communicate-with-remote-storage-api alert
+
 ## [2.86.0] - 2023-03-27
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`Prometheus can''t communicate with Remote Storage API at {{ $labels.url }}.`}}'
         opsrecipe: prometheus-cant-communicate-with-remote-storage-api/
-      expr: rate(prometheus_remote_storage_samples_failed_total[1h]) > 0.1 or rate(prometheus_remote_storage_samples_total[1h]) == 0 or rate(prometheus_remote_storage_metadata_retried_total[5m]) > 0
+      expr: rate(prometheus_remote_storage_samples_failed_total[10m]) > 0.1 or rate(prometheus_remote_storage_samples_total[10m]) == 0 or rate(prometheus_remote_storage_metadata_retried_total[10m]) > 0
       for: 1h
       labels:
         area: empowerment


### PR DESCRIPTION
Avoids alerts when we have a short peak of failures.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
