### PR TITLE
add dashboard to prometheus alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- added dashboard to `PrometheusFailsToCommunicateWithRemoteStorageAPI` alert
+
 ## [2.86.1] - 2023-03-28
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -51,6 +51,7 @@ spec:
         severity: page
         team: atlas
         topic: observability
+        dashboard: promRW001/prometheus-remote-write
     - alert: PrometheusRuleFailures
       annotations:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.2f" $value }} time(s).`}}


### PR DESCRIPTION
Towards: [#inc-2023-03-31-thunder-thunder-prometheusfailstocommunicatewithremotestorag](https://gigantic.slack.com/archives/C051L1DLVLZ)

This PR adds a dashboard to `PrometheusFailsToCommunicateWithRemoteStorageAPI` alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
