### PR TITLE
add opsrecipe test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Alert `LinkerdDeploymentNotSatisfied` for managed Linkerd deployments.
+- New `make test-opsrecipes` target
 
 ## [2.87.0] - 2023-04-06
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -31,6 +31,10 @@ test-inhibitions: install-tools template-chart
 	./test/hack/bin/get-inhibition.sh
 	cd test/hack/checkLabels; go run main.go
 
+test-opsrecipes: install-tools template-chart
+    # Check if opsrecipes are valid
+	./test/hack/bin/check-opsrecipes.sh
+
 restore-chart:
 	@## Revert Chart version
 	@yq e -i '.version = "[[ .Version ]]"' helm/prometheus-rules/Chart.yaml

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -32,7 +32,7 @@ test-inhibitions: install-tools template-chart
 	cd test/hack/checkLabels; go run main.go
 
 test-opsrecipes: install-tools template-chart
-    # Check if opsrecipes are valid
+	# Check if opsrecipes are valid
 	./test/hack/bin/check-opsrecipes.sh
 
 restore-chart:

--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ To Update `kubernetes-mixin` recording rules:
 
 You can run all tests by running `make test`.
 
-There are 2 different types tests implemented:
+There are 3 different types tests implemented:
 
 - [Prometheus rules unit tests](#prometheus-rules-unit-tests)
 - [Alertmanager inhibition dependency check](#alertmanager-inhibition-dependency-check)
+- [Opsrecipe check](#opsrecipe-check)
 
 ---
 
@@ -297,3 +298,9 @@ The inhibition labels checking script is also run automatically at PR's creation
 - Inhibition checking script does not trigger at PR's creation : stuck in `pending` state. Must push empty commit to trigger it
 - When ran for the first time in a PR (after empty commit) usually fails to retrieve the alertmanager config file's data and thus fires error stating that all labels are missing.
 - Must manually re-run the action for it to pass
+
+## Opsrecipe check
+
+You can run `make test-opsrecipes` to check if linked opsrecipes are valid.
+
+This check is not part of the global `make test` command until we fix all missing / wrong opsrecipes.

--- a/test/hack/bin/.gitignore
+++ b/test/hack/bin/.gitignore
@@ -6,3 +6,4 @@
 !fetch-tools.sh
 !template-chart.sh
 !get-inhibition.sh
+!check-opsrecipes.sh

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -69,7 +69,10 @@ main() {
         isInArray "$prettyRulesFilename" "${checkedRules[@]}" \
             && continue
 
-        while read -r alertname opsrecipe overflow ; do
+        while read -r alertname opsrecipe severity overflow ; do
+
+            # Discard non-paging alerts
+            [[ "$severity" != "page" ]] && continue
 
             # Get rid of anchors
             opsrecipe="${opsrecipe%%#*}"
@@ -97,7 +100,7 @@ main() {
             if [[ "$DEBUG_MODE" != "false" ]]; then
                 echo "file $prettyRulesFilename / alert: $alertname / recipe: $opsrecipe - OK"
             fi
-        done < <(yq -o json "$rulesFile" | jq -j '.spec.groups[].rules[] | .alert, " ", .annotations.opsrecipe, "\n"')
+        done < <(yq -o json "$rulesFile" | jq -j '.spec.groups[].rules[] | .alert, " ", .annotations.opsrecipe, " ", .labels.severity, "\n"')
 
         checkedRules+=("$prettyRulesFilename")
     done

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -euo pipefail
+
+# List of generated rules
+RULES_FILES=(./test/hack/output/*/prometheus-rules/templates/alerting-rules/*)
+#RULES_FILES=(./test/hack/output/*/prometheus-rules/templates/alerting-rules/up*)
+
+DEBUG_MODE=false
+CHECK_EXTRADATA_ERRORS=false
+CHECK_NORECIPE_ERRORS=true
+CHECK_UNEXISTINGRECIPE_ERRORS=true
+
+# Parameters:
+# - an element
+# - an array
+# Returns:
+# - 0 if element is not found in the array
+# - 1 if element is found in the array
+isInArray () {
+    referenceElement="$1" && shift
+    array=("$@")
+
+    for element in "${array[@]}"; do
+        [[ "$element" == "$referenceElement" ]] \
+            && return 0
+    done
+    return 1
+}
+
+listOpsRecipes () {
+    # find list of opsrecipes from git repo
+    tmpDir="$(mktemp -d)"
+    git clone --depth 1 --single-branch -b main -q git@github.com:giantswarm/giantswarm.git "$tmpDir"
+    find "$tmpDir"/content/docs/support-and-ops/ops-recipes -name \*.md \
+        | sed -n 's_'"$tmpDir"'/content/docs/support-and-ops/ops-recipes/\(.*\).md_\1_p'
+    rm -rf "$tmpDir"
+
+    # Add extra opsrecipes
+    # These ones are defined as aliases of `deployment-not-satisfied`:
+    echo "workload-cluster-managed-deployment-not-satisfied"
+    echo "workload-cluster-deployment-not-satisfied"
+    echo "deployment-not-satisfied-china"
+}
+
+main() {
+    local -a checkedRules
+    local -a opsRecipes
+    local -a E_extradata
+    local -a E_norecipe
+    local -a E_unexistingrecipe
+    local returncode=0
+
+    # Retrieve list of opsrecipes
+    mapfile -t opsRecipes < <(listOpsRecipes)
+
+    if [[ "$DEBUG_MODE" != "false" ]]; then
+        echo "List of opsrecipe:"
+        for recipe in "${opsRecipes[@]}"; do
+            echo " - \"$recipe\""
+        done
+    fi
+
+    # Look at each rules file
+    for rulesFile in "${RULES_FILES[@]}" ; do
+        # echo "rules file: $rulesFile"
+        prettyRulesFilename="$(basename "$rulesFile")"
+
+        # skip if rules file has already been checked
+        isInArray "$prettyRulesFilename" "${checkedRules[@]}" \
+            && continue
+
+        while read -r alertname opsrecipe overflow ; do
+
+            # Get rid of anchors
+            opsrecipe="${opsrecipe%%#*}"
+            # Opsrecipes in alerts have a trailing slash that we want to get rid of
+            opsrecipe="${opsrecipe%/}"
+
+            if [[ "$overflow" != "" ]]; then
+                local message="file: $prettyRulesFilename / alert \"$alertname\" / recipe \"$opsrecipe\": extra data \"$overflow\""
+                E_extradata+=("$message")
+                #echo "ERROR: $message"
+                continue
+            fi
+            if [[ "$opsrecipe" == "null" ]]; then
+                local message="file $prettyRulesFilename / alert \"$alertname\" has no opsrecipe"
+                E_norecipe+=("$message")
+                continue
+            fi
+
+            if ! isInArray "$opsrecipe" "${opsRecipes[@]}"; then
+                local message="file $prettyRulesFilename / alert \"$alertname\" links to unexisting opsrecipe (\"$opsrecipe\")"
+                E_unexistingrecipe+=("$message")
+                continue
+            fi
+
+            if [[ "$DEBUG_MODE" != "false" ]]; then
+                echo "file $prettyRulesFilename / alert: $alertname / recipe: $opsrecipe - OK"
+            fi
+        done < <(yq -o json "$rulesFile" | jq -j '.spec.groups[].rules[] | .alert, " ", .annotations.opsrecipe, "\n"')
+
+        checkedRules+=("$prettyRulesFilename")
+    done
+
+    if [[ "$CHECK_EXTRADATA_ERRORS" != "false" ]]; then
+        if [[ "${#E_extradata[@]}" -gt 0 ]]; then
+            echo ""
+            echo "Alerts that failed parsing: ${#E_extradata[@]}"
+            for message in "${E_extradata[@]}"; do
+                echo "$message"
+            done
+            returncode=1
+        fi
+    fi
+    if [[ "$CHECK_NORECIPE_ERRORS" != "false" ]]; then
+        if [[ "${#E_norecipe[@]}" -gt 0 ]]; then
+            echo ""
+            echo "Alerts missing recipe: ${#E_norecipe[@]}"
+            for message in "${E_norecipe[@]}"; do
+                echo "$message"
+            done
+            returncode=1
+        fi
+    fi
+    if [[ "$CHECK_UNEXISTINGRECIPE_ERRORS" != "false" ]]; then
+        if [[ "${#E_unexistingrecipe[@]}" -gt 0 ]]; then
+            echo ""
+            echo "Alerts using unexisting recipe: ${#E_unexistingrecipe[@]}"
+            for message in "${E_unexistingrecipe[@]}"; do
+                echo "$message"
+            done
+            returncode=1
+        fi
+    fi
+
+    return "$returncode"
+}
+
+main "$@"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/23638

This PR adds a script to check for opsrecipes validity in alerting rules.
For the moment it's manually triggered, until we sort out what we want to do with the missing / wrong opsrecipes.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
