### PR TITLE
fix some broken opsrecipe links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- some broken opsrecipe links
+
 ## [2.86.1] - 2023-03-28
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/falco.rules.yml
@@ -16,7 +16,7 @@ spec:
         description: |-
           {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
           {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
-        opsrecipe: falco-alerts/
+        opsrecipe: falco-alert/
       expr: increase(falco_events{priority=~"0|1|2|3"}[10m] ) > 0
       labels:
         area: kaas
@@ -32,7 +32,7 @@ spec:
         description: |-
           {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
           {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
-        opsrecipe: falco-alerts/
+        opsrecipe: falco-alert/
       expr: increase(falco_events{priority=~"4|5"}[10m] ) > 0
       labels:
         area: kaas
@@ -47,7 +47,7 @@ spec:
         description: |-
           {{`{{ if eq $labels.k8s_pod_name "<NA>" }}The Falco rule {{ $labels.rule }} was triggered on the node {{ $labels.node }}.
           {{else}}Pod {{ $labels.k8s_ns_name }}/{{ $labels.k8s_pod_name }} triggered the Falco rule {{ $labels.rule }} on the node {{ $labels.node }}.{{ end }}`}}
-        opsrecipe: falco-alerts/
+        opsrecipe: falco-alert/
       expr: increase(falco_events{priority="6"}[10m] ) > 0
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/managed-logging.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: ManagedLoggingElasticsearchDataNodesNotSatisfied
       annotations:
         description: '{{`Number of data nodes of Elastic Search on {{ $labels.cluster_id }} is not satified.`}}'
-        opsrecipe: managed-logging-create/
+        opsrecipe: managed-app-efk-stack/
       expr: sum(elasticsearch_cluster_health_number_of_data_nodes) by (cluster_id) < 3
       for: 15m
       labels:
@@ -26,7 +26,7 @@ spec:
     - alert: ManagedLoggingElasticsearchClusterDown
       annotations:
         description: '{{`Elastich Search cluster health on {{ $labels.cluster_id }} is not green.`}}'
-        opsrecipe: managed-logging-create/
+        opsrecipe: managed-app-efk-stack/
       expr: sum(elasticsearch_cluster_health_up) by (cluster_id) < 1
       for: 5m
       labels:


### PR DESCRIPTION
When writing [opsrecipe validity tests](https://github.com/giantswarm/prometheus-rules/pull/682) I've tried to fix these opsrecipe links.

There's more failing, but these ones seemed rather easy to fix.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
