### PR TITLE
PrometheusCantCommunicateWithKubernetesAPI inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added dashboard to `PrometheusFailsToCommunicateWithRemoteStorageAPI` alert
 - updated kube mixins to 0.12
+- `PrometheusCantCommunicateWithKubernetesAPI` : added `cancel_if_cluster_has_no_workers`
 
 ## [2.86.1] - 2023-03-28
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -22,6 +22,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: atlas


### PR DESCRIPTION
- `PrometheusCantCommunicateWithKubernetesAPI` : added `cancel_if_cluster_has_no_workers`

Towards: https://github.com/giantswarm/giantswarm/issues/26494

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
