### PR TITLE
Add linkerd deployment alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Alert for `etcd-kubernetes-resources-count-exporter`.
+- Alert `LinkerdDeploymentNotSatisfied` for managed LinkerD deployments.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alert `LinkerdDeploymentNotSatisfied` for managed Linkerd deployments.
+
 ## [2.87.0] - 2023-04-06
 
 ### Added
 
 - Alert for `etcd-kubernetes-resources-count-exporter`.
-- Alert `LinkerdDeploymentNotSatisfied` for managed LinkerD deployments.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: linkerd.deployment.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: linkerd-deployment
+    rules:
+    - alert: LinkerdDeploymentNotSatisfied
+      annotations:
+        description: '{{`Linkerd Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: managed-app-linkerd/
+      expr: managed_app_deployment_status_replicas_unavailable{deployment=~"linkerd.*"} > 0
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: cabbage
+        topic: linkerd

--- a/test/tests/providers/global/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/linkerd.deployment.rules.test.yml
@@ -25,7 +25,6 @@ tests:
               cancel_if_outside_working_hours: "false"
               namespace: linkerd
               deployment: linkerd-destination
-              pod: kong-app-internal
               severity: page
               team: cabbage
               topic: linkerd

--- a/test/tests/providers/global/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/linkerd.deployment.rules.test.yml
@@ -6,23 +6,22 @@ tests:
   - interval: 1m
     input_series:
       - series: 'managed_app_deployment_status_replicas_unavailable{deployment="linkerd-destination", managed_app="destination", namespace="linkerd"}'
-        values: '_x5 0+0x10 1+0x20'
+        values: '_x5 0+0x10 1+0x45'
     alert_rule_test:
       - alertname: LinkerdDeploymentNotSatisfied
         eval_time: 5m
       - alertname: LinkerdDeploymentNotSatisfied
         eval_time: 15m
       - alertname: LinkerdDeploymentNotSatisfied
-        eval_time: 25m
+        eval_time: 46m
         exp_alerts:
           - exp_labels:
               alertname: LinkerdDeploymentNotSatisfied
               area: managedservices
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "false"
               namespace: linkerd
               deployment: linkerd-destination
+              managed_app: destination
               severity: page
               team: cabbage
               topic: linkerd

--- a/test/tests/providers/global/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/linkerd.deployment.rules.test.yml
@@ -5,8 +5,6 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kong_datastore_reachable{cluster_id="deu01", installation="anteater", instance="localhost:8080", namespace="kong-internal", pod="kong-app-internal"}'
-        values: '_x20 1+0x10 0+0x20'
       - series: 'managed_app_deployment_status_replicas_unavailable{deployment="linkerd-destination", managed_app="destination", namespace="linkerd"}'
         values: '_x5 0+0x10 1+0x20'
     alert_rule_test:

--- a/test/tests/providers/global/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/linkerd.deployment.rules.test.yml
@@ -1,0 +1,34 @@
+---
+rule_files:
+  - linkerd.deployment.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kong_datastore_reachable{cluster_id="deu01", installation="anteater", instance="localhost:8080", namespace="kong-internal", pod="kong-app-internal"}'
+        values: '_x20 1+0x10 0+0x20'
+      - series: 'managed_app_deployment_status_replicas_unavailable{deployment="linkerd-destination", managed_app="destination", namespace="linkerd"}'
+        values: '_x5 0+0x10 1+0x20'
+    alert_rule_test:
+      - alertname: LinkerdDeploymentNotSatisfied
+        eval_time: 5m
+      - alertname: LinkerdDeploymentNotSatisfied
+        eval_time: 15m
+      - alertname: LinkerdDeploymentNotSatisfied
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              alertname: LinkerdDeploymentNotSatisfied
+              area: managedservices
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "false"
+              namespace: linkerd
+              deployment: linkerd-destination
+              pod: kong-app-internal
+              severity: page
+              team: cabbage
+              topic: linkerd
+            exp_annotations:
+              description: "Linkerd Deployment linkerd/linkerd-destination is not satisfied."
+              opsrecipe: managed-app-linkerd/


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21041

This PR adds alerting on linkerd deployment failures

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
