### PR TITLE
Change all `hydra` alerts to point to team `phoenix` since we merge the business hours on-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `make test-opsrecipes` target
 - Alert `SlothDown` for Sloth app
 
+### Changed
+
+- Change all `hydra` alerts to point to team `phoenix` since we merge the business hours on-call
+
 ## [2.87.0] - 2023-04-06
 
 ### Added
@@ -81,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Splits `kyverno` certificate expiry alert & created `KyvernoCertificateSecretWillExpireInLessThanTwoDays`.
-- Tweak ETCD DB Too Large alert 
+- Tweak ETCD DB Too Large alert
 
 ## [2.82.2] - 2023-03-03
 

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -32,7 +32,8 @@ giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- if has .Values.managementCluster.provider.kind (list "kvm" "openstack" "cloud-director" "vsphere") -}}
 rocket
 {{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa") -}}
-hydra
+{{- /* hydra alerts merged into phoenix business hours on-call */ -}}
+phoenix
 {{- else if eq .Values.managementCluster.provider.kind "capz" -}}
 clippy
 {{- else -}}

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -47,7 +47,7 @@ spec:
         severity: page
         team: cabbage
         topic: releng
-    - alert: WorkloadClusterManagedDeploymentNotSatisfiedHydra
+    - alert: WorkloadClusterManagedDeploymentNotSatisfiedPhoenix
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
@@ -57,7 +57,7 @@ spec:
         area: managedservices
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: hydra
+        team: phoenix
         topic: releng
     - alert: WorkloadClusterDeploymentScaledDownToZero
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: managementcluster
     - alert: ManagementClusterContainerIsRestartingTooFrequentlyGCP
       annotations:
@@ -41,7 +41,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: kubernetes
     - alert: ManagementClusterDeploymentMissingGCP
       annotations:
@@ -56,6 +56,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: kubernetes
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.workload-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: kubernetes
     - alert: WorkloadClusterCriticalPodNotRunningGCP
       annotations:
@@ -41,7 +41,7 @@ spec:
         cancel_if_kube_state_metrics_down: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: kubernetes
     - alert: WorkloadClusterPodPendingGCP
       annotations:
@@ -58,6 +58,6 @@ spec:
         cancel_if_kube_state_metrics_down: "true"
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: hydra
+        team: phoenix
         topic: kubernetes
 {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1884

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
