### PR TITLE
Restructure Cabbage Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alert `LinkerdDeploymentNotSatisfied` for managed Linkerd deployments.
 - New `make test-opsrecipes` target
 - Alert `SlothDown` for Sloth app
-- Alert `KongDeploymentNotSatisfied` for managed kong deployments.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `make test-opsrecipes` target
 - Alert `SlothDown` for Sloth app
 
+### Removed
+
+- Alert `WorkloadClusterManagedDeploymentNotSatisfiedCabbage`
+
 ## [2.87.0] - 2023-04-06
 
 ### Added
@@ -81,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Splits `kyverno` certificate expiry alert & created `KyvernoCertificateSecretWillExpireInLessThanTwoDays`.
-- Tweak ETCD DB Too Large alert 
+- Tweak ETCD DB Too Large alert
 
 ## [2.82.2] - 2023-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alert `LinkerdDeploymentNotSatisfied` for managed Linkerd deployments.
 - New `make test-opsrecipes` target
 - Alert `SlothDown` for Sloth app
+- Alert `KongDeploymentNotSatisfied` for managed kong deployments.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -35,18 +35,6 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: observability
-    - alert: WorkloadClusterManagedDeploymentNotSatisfiedCabbage
-      annotations:
-        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
-        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"external-dns.*|kong.*"} > 0
-      for: 30m
-      labels:
-        area: managedservices
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: page
-        team: cabbage
-        topic: releng
     - alert: WorkloadClusterManagedDeploymentNotSatisfiedHydra
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kong.rules.yml
@@ -26,3 +26,17 @@ spec:
         severity: page
         team: cabbage
         topic: kong
+    - alert: KongDeploymentNotSatisfied
+      annotations:
+        description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} / managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} < 0.9
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: cabbage
+        topic: kong

--- a/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/gs-managed-app-deployment-status.rules.yml
@@ -21,3 +21,9 @@ spec:
               kube_deployment_labels{label_giantswarm_io_service_type="managed"},
             "managed_app", "$1", "label_app_kubernetes_io_name", "(.*)" )
       record: managed_app_deployment_status_replicas_unavailable
+    - expr: label_replace(
+              kube_deployment_spec_replicas *
+              on (namespace, deployment) group_left(label_app_kubernetes_io_name)
+              kube_deployment_labels{label_giantswarm_io_service_type="managed"},
+            "managed_app", "$1", "label_app_kubernetes_io_name", "(.*)" )
+      record: managed_app_deployment_spec_replicas


### PR DESCRIPTION
This PR 

- Removes `WorkloadClusterManagedDeploymentNotSatisfiedCabbage`. It was covering external-dns and Kong. external-dns is already covered by `ExternalDNSDown`. Kong now has its own `KongDeploymentNotSatisfied`
- Adds `KongDeploymentNotSatisfied`. This works different from the old `WorkloadClusterManagedDeploymentNotSatisfiedCabbage` as it only alerts for available replicas / desired replicas < 0.9
- Adds recording rule `managed_app_deployment_spec_replicas`

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
