### PR TITLE
Only page during business hours if `etcd-kubernetes-resources-count-e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only page during business hours if `etcd-kubernetes-resources-count-exporter` deployment is not satisfied.
+
 ## [2.88.0] - 2023-04-11
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -27,11 +27,23 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook.*|cluster-autoscaler|etcd-kubernetes-resources-count-exporter"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook.*|cluster-autoscaler"} > 0
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: observability
+    - alert: WorkloadClusterNonCriticalDeploymentNotSatisfiedKaas
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"etcd-kubernetes-resources-count-exporter"} > 0
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: true
         severity: page
         team: {{ include "providerTeam" . }}
         topic: observability


### PR DESCRIPTION
…xporter` deployment is not satisfied.

Towards: https://github.com/giantswarm/giantswarm/issues/26562

This PR makes the page a BH only one

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
