### PR TITLE
Decrease severity for PrometheusJobScrapingFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Decrease severity for PrometheusJobScrapingFailure alerts, so they don't show in Slack.
+
 ## [2.89.0] - 2023-04-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -75,7 +75,7 @@ spec:
       for: 1d
       labels:
         area: empowerment
-        severity: notify
+        severity: none
         team: atlas
         topic: observability
         cancel_if_outside_working_hours: "true"

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -41,7 +41,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: empowerment
-              severity: notify
+              severity: none
               team: atlas
               topic: observability
               cancel_if_outside_working_hours: "true"
@@ -54,7 +54,7 @@ tests:
               description: "Prometheus gauss/gauss has failed to scrape all targets in gauss-prometheus/kubernetes-controller-manager-gauss/0 job."
           - exp_labels:
               area: empowerment
-              severity: notify
+              severity: none
               team: atlas
               topic: observability
               cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Decrease severity for PrometheusJobScrapingFailure alerts, so they don't show in Slack.
 
Towards: https://github.com/giantswarm/giantswarm/issues/26608
Related: https://github.com/giantswarm/prometheus-meta-operator/pull/1265

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
