### PR TITLE
set unique names for alert groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Decrease severity for PrometheusJobScrapingFailure alerts, so they don't show in Slack.
+- set unique names for alert groups
 
 ## [2.89.0] - 2023-04-12
 

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: certificate
+  - name: certificate.all
     rules:
     - alert: KiamCertificateSecretWillExpireInLessThanTwoWeeks
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.management-cluster.rules.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: certificate
+  - name: certificate.management-cluster
     rules:
     - alert: ManagementClusterKVMCertificateWillExpireInLessThanOneMonth
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.workload-cluster.rules.yml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: certificate
+  - name: certificate.workload-cluster
     rules:
     - alert: WorkloadClusterCertificateWillExpireInLessThanAMonth
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: inhibit
+  - name: inhibit.all
     rules:
     - alert: InhibitionOutsideWorkingHours
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: inhibit
+  - name: inhibit.management-cluster
     rules:
     - alert: InhibitionClusterStatusCreating
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: network
+  - name: network.all
     rules:
     - alert: DNSErrorRateTooHigh
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/network.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.management-cluster.rules.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: network
+  - name: network.management-cluster
     rules:
     - alert: NetworkCheckErrorRateTooHigh
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/network.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.workload-cluster.rules.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: network
+  - name: network.workload-cluster
     rules:
     - alert: NetworkCheckErrorRateTooHigh
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: up
+  - name: up.all
     rules:
     - alert: ChartOperatorDown
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.management-cluster.rules.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: up
+  - name: up.management-cluster
     rules:
     - alert: AppExporterDown
       annotations:


### PR DESCRIPTION
When applying the procedure written here: https://github.com/giantswarm/giantswarm/pull/26533
it was failing because different rules groups have the same name.

So I updated them to be unique.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
