### PR TITLE
Alert about GS certs expiring on both WCs and MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Alert `WorkloadClusterManagedDeploymentNotSatisfiedCabbage`
+- Alert `WorkloadClusterManagedDeploymentNotSatisfiedCabbage`.
+
 ### Changed
 
 - Decrease severity for PrometheusJobScrapingFailure alerts, so they don't show in Slack.
-- set unique names for alert groups
+- set unique names for alert groups.
+- Changed `GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks` alert to work for both workload clusters and management clusters.
 
 ## [2.89.0] - 2023-04-12
 

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 2 * 7 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2249

This PR changes the alert so that it will page for certificates expiring on both WCs and MCs.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
