### PR TITLE
Remove no worker node inhibition on azure clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Alert `WorkloadClusterManagedDeploymentNotSatisfiedCabbage`
+- Do not inhibit azure clusters without worker nodes because the source metric is missing and the inhibition is preventing real alerts to go through.
+
 ### Changed
 
 - Decrease severity for PrometheusJobScrapingFailure alerts, so they don't show in Slack.

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -57,22 +57,16 @@ spec:
         apiserver_down: "true"
         team: phoenix
         topic: monitoring
-    {{- if or (eq .Values.managementCluster.provider.kind "azure") (eq .Values.managementCluster.provider.kind "aws") }}
+    {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: InhibitionClusterWithoutWorkerNodes
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) has no worker nodes.`}}'
-      {{- if eq .Values.managementCluster.provider.kind "azure" }}
-      expr: azure_operator_cluster_worker_nodes == 0
-      {{- else if eq .Values.managementCluster.provider.kind "aws" }}
       expr: sum(aws_operator_asg_desired_count) by (cluster_id) - on(cluster_id) sum(aws_operator_asg_desired_count{asg=~".*-tccpn-.*"}) by (cluster_id) == 0
-      {{- end }}
       labels:
         area: kaas
         has_worker_nodes: "false"
         team: phoenix
         topic: status
-    {{- end }}
-    {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: InhibitionKiamErrors
       annotations:
         description: '{{`Kiam on cluster {{ $labels.cluster_id }} has increased error rate.`}}'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26616

The azure-collector is using v1alpha3 cluster api CRD which are not working in latest MCs so the source metric always return 0 worker nodes whether this is true or not. 
As it is unclear if the azure collector will be fixed, we are removing the inhibition on azure clusters as existing customers are not using empty clusters in azure and because the inhibition behing always on is blocking alerts on azure clusters.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
