### PR TITLE
add alerting rule for dns-operator-azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `make help` shows test targets again
+
+### Added
+
+- Alert `ClusterDNSZoneMissing` added for `dns-operator-azure`
+
 ## [2.91.0] - 2023-04-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Alert `ClusterDNSZoneMissing` added for `dns-operator-azure`
+- Alert `AzureDNSOperatorAPIErrorRate` added for `dns-operator-azure`
 
 ### Changed
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -14,25 +14,21 @@ clean: ## Clean the git work dir and remove all untracked files
 .PHONY: test
 test: install-tools template-chart test-rules test-inhibitions restore-chart
 
-test-rules: install-tools template-chart
-	# run unit tests for alerting rules
+test-rules: install-tools template-chart ## run unit tests for alerting rules
 	bash test/hack/bin/verify-rules.sh "$(test_filter)"
 
 install-tools:
 	./test/hack/bin/fetch-tools.sh
 
-template-chart: install-tools
-	# prepare the helm chart
+template-chart: install-tools ## prepare the helm chart
 	test/hack/bin/architect helm template --dir helm/prometheus-rules --dry-run
 	bash ./test/hack/bin/template-chart.sh
 
-test-inhibitions: install-tools template-chart
-	# test whether inhibition labels are well defined
+test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
 	./test/hack/bin/get-inhibition.sh
 	cd test/hack/checkLabels; go run main.go
 
-test-opsrecipes: install-tools template-chart
-	# Check if opsrecipes are valid
+test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
 	./test/hack/bin/check-opsrecipes.sh
 
 restore-chart:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ There are 2 kinds of tests on rules:
 
 1. remove the rules file you would like to test from `test/conf/promtool_ignore`
 1. create a new test file in [unit testing rules] format either globally in `test/tests/providers/global/` or provider-specific in `test/tests/providers/<provider>/`
-1. by running `make test-rules` you can validate the your testing rules.
+1. by running `make test-rules` you can validate your testing rules.
    Output should look like the follows:
 
    ```

--- a/helm/prometheus-rules/templates/alerting-rules/dns-operator-azure.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dns-operator-azure.rules.yml
@@ -25,4 +25,18 @@ spec:
             severity: notify
             team: {{include "providerTeam" .}}
             topic: managementcluster
+        - alert: AzureDNSOperatorAPIErrorRate
+          annotations:
+            description: |-
+              {{`Error rate for {{ $labels.method }} is high. Check dns-operator-azure logs in installation/{{ $labels.installation }}.`}}
+            opsrecipe: dns-operator-azure/
+          expr: |-
+            sum by (method,installation) (rate(dns_operator_azure_api_request_errors_total[5m])) > 0
+          for: 15m
+          labels:
+            area: kaas
+            cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
+            severity: notify
+            team: {{include "providerTeam" .}}
+            topic: managementcluster
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/dns-operator-azure.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dns-operator-azure.rules.yml
@@ -1,0 +1,28 @@
+{{- if (eq .Values.managementCluster.provider.kind "capz") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels: {{- include "labels.common" . | nindent 4}}
+  name: dns-operator-azure.rules
+  namespace: {{.Values.namespace}}
+spec:
+  groups:
+    - name: dns-operator-azure
+      rules:
+        - alert: ClusterDNSZoneMissing
+          annotations:
+            description: |-
+              {{`No DNS-zone for cluster {{ $labels.exported_namespace}}/{{ $labels.name }} got created yet. Check dns-operator-azure logs in installation/{{ $labels.installation}}.`}}
+            opsrecipe: dns-operator-azure/
+          expr: |-
+            capi_cluster_status_phase{phase="Provisioned"}
+            unless on (name)
+            label_replace(dns_operator_azure_zone_info, "name", "$1", "resource_group", "(.+)")
+          for: 30m
+          labels:
+            area: kaas
+            cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
+            severity: notify
+            team: {{include "providerTeam" .}}
+            topic: managementcluster
+{{- end }}

--- a/test/tests/providers/capz/dns-operator-azure.rules.test.yml
+++ b/test/tests/providers/capz/dns-operator-azure.rules.test.yml
@@ -1,0 +1,33 @@
+rule_files:
+  - dns-operator-azure.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'dns_operator_azure_zone_info{controller="dns-operator-azure",resource_group="425bdf54",subscription_id="09be0ac8-38d9-4fe1-aa72-4ce2e8a084d2",tenant_id="4e4e320b-cf45-4fd4-9dd3-ec0046779035",zone="425bdf54.azuretest.gigantic.io",installation="puppy"}'
+        values: "1+0x60"
+      - series: 'capi_cluster_status_phase{name="425bdf54", exported_namespace="org-83dd715d", phase="Provisioned", installation="puppy"}'
+        values: "1+0x60"
+      - series: 'capi_cluster_status_phase{name="8e8225b5", exported_namespace="org-31f75bf9", phase="Provisioned", installation="puppy"}'
+        values: "1+0x60"
+      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="recordSets.CreateOrUpdate"}'
+        values: "0+0x10 1+1x50"
+      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="zones.Get"}'
+        values: "0+0x10 1+1x50"
+    alert_rule_test:
+      - alertname: ClusterDNSZoneMissing
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              phase: Provisioned
+              exported_namespace: org-31f75bf9
+              installation: puppy
+              name: 8e8225b5
+            exp_annotations:
+              description: "No DNS-zone for cluster org-31f75bf9/8e8225b5 got created yet. Check dns-operator-azure logs in installation/puppy."
+              opsrecipe: dns-operator-azure/

--- a/test/tests/providers/capz/dns-operator-azure.rules.test.yml
+++ b/test/tests/providers/capz/dns-operator-azure.rules.test.yml
@@ -10,10 +10,10 @@ tests:
         values: "1+0x60"
       - series: 'capi_cluster_status_phase{name="8e8225b5", exported_namespace="org-31f75bf9", phase="Provisioned", installation="puppy"}'
         values: "1+0x60"
-      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="recordSets.CreateOrUpdate"}'
-        values: "0+0x10 1+1x50"
-      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="zones.Get"}'
-        values: "0+0x10 1+1x50"
+      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="recordSets.CreateOrUpdate",installation="puppy"}'
+        values: "0+0x10 1+1x20"
+      - series: 'dns_operator_azure_api_request_errors_total{controller="dns-operator-azure",method="zones.Get",installation="puppy"}'
+        values: "0+0x10 1+1x10 0+0x10"
     alert_rule_test:
       - alertname: ClusterDNSZoneMissing
         eval_time: 30m
@@ -30,4 +30,18 @@ tests:
               name: 8e8225b5
             exp_annotations:
               description: "No DNS-zone for cluster org-31f75bf9/8e8225b5 got created yet. Check dns-operator-azure logs in installation/puppy."
+              opsrecipe: dns-operator-azure/
+      - alertname: AzureDNSOperatorAPIErrorRate
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: clippy
+              topic: managementcluster
+              installation: puppy
+              method: recordSets.CreateOrUpdate
+            exp_annotations:
+              description: "Error rate for recordSets.CreateOrUpdate is high. Check dns-operator-azure logs in installation/puppy."
               opsrecipe: dns-operator-azure/


### PR DESCRIPTION
to discover possible issues with the running operator

Towards: https://github.com/giantswarm/roadmap/issues/1976

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
