### PR TITLE
README: naming convention for inhibition labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Forward WorkloadClusterCertificateExpiring to team-teddyfriends on Slack
+- README: naming convention for inhibition labels
 
 ## [2.92.0] - 2023-04-19
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The `cancel_if_*` labels are used to inhibit alerts, they are defined in [Alertm
 
 The base principle is: if an alert is currently firing with a `source_matcher` label, then all alerts that have a `target_matcher` label are inhibited (or muted).
 
+To make inhibitions easier to read, let's try to follow this naming convention inhibition-related labels:
+* `inhibit_[something]` for `source` matchers
+* `cancel_if_[something]` for `target` matchers
+
 Official documentation for inhibit rules can be found here: https://www.prometheus.io/docs/alerting/latest/configuration/#inhibit_rule
 
 ### Recording rules


### PR DESCRIPTION
After talking with @marieroque about inhibitions for https://github.com/giantswarm/prometheus-meta-operator/pull/1271 and https://github.com/giantswarm/prometheus-rules/pull/708, I think there is something fundamentally wrong with our inhibitions: we should have a convention for source labels names rather than source alert names.

So this PR adds a note about it in the README.

Don't hesitate to discuss this idea.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
