### PR TITLE
Now testing recording rules as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alert `ClusterDNSZoneMissing` added for `dns-operator-azure`
 - Alert `AzureDNSOperatorAPIErrorRate` added for `dns-operator-azure`
 - Test recording rules
+- Added unit test for recording rule `helm-operations`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Alert `ClusterDNSZoneMissing` added for `dns-operator-azure`
 - Alert `AzureDNSOperatorAPIErrorRate` added for `dns-operator-azure`
+- Test recording rules
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -182,9 +182,8 @@ This is a good example of an input series for testing a `range` query.
 
 #### Limitation
 
-* The current implementation only renders alerting rules for different providers via the helm value `managementCluster.provider.kind`.
+* The current implementation only renders rules for different providers via the helm value `managementCluster.provider.kind`.
 Any other decision in the current helm chart is ignored for now (e.g. `helm/prometheus-rules/templates/alerting-rules/alertmanager-dashboard.rules.yml`)
-* Only alerting-rules are being tested, other folders (recording rules) are ignored.
 
 #### A word on the testing logic
 

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -76,7 +76,6 @@ templates/alerting-rules/up.management-cluster.rules.yml
 templates/alerting-rules/vault.rules.yml
 templates/recording-rules/cortex.rules.yml
 templates/recording-rules/gs-managed-app-deployment-status.rules.yml
-templates/recording-rules/helm-operations.rules.yml
 templates/recording-rules/kube-prometheus-mixins.rules.yml
 templates/recording-rules/kubernetes-mixins.rules.yml
 templates/recording-rules/service-level.rules.yml

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -40,7 +40,7 @@ main() {
         cd "$GIT_WORKDIR" || return 1
         # filter alerting-rules files, and remove prefix `helm/prometheus-rules/`
         git ls-files |
-            sed -En 's_^helm/prometheus-rules/(templates/alerting-rules/.*\.ya?ml)$_\1_p' || echo error
+            sed -En 's_^helm/prometheus-rules/(templates/(alerting|recording)-rules/.*\.ya?ml)$_\1_p' || echo error
     )
 
     # Get prefixes whitelisted via the failure_file
@@ -80,6 +80,9 @@ main() {
             if [[ -f "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/alerting-rules/$filename" ]]
             then
                 "$GIT_WORKDIR/$YQ" '.spec' "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/alerting-rules/$filename" > "$GIT_WORKDIR/test/tests/providers/$provider/$filename"
+            elif [[ -f "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/recording-rules/$filename" ]]
+            then
+                "$GIT_WORKDIR/$YQ" '.spec' "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/recording-rules/$filename" > "$GIT_WORKDIR/test/tests/providers/$provider/$filename"
             else
                 echo "###    Failed extracting rules file $file"
                 failing_extraction+=("$provider:$file")

--- a/test/tests/providers/global/helm-operations.rules.test.yml
+++ b/test/tests/providers/global/helm-operations.rules.test.yml
@@ -1,0 +1,15 @@
+---
+rule_files:
+  - helm-operations.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'helmclient_library_event_total{app="chart-operator", cluster_id="gauss", container="chart-operator", event="update_release_from_tarball", namespace="giantswarm", pod="chart-operator-5c7b6f8867-pr44n", release="cilium"}'
+        values: "0+1x20"
+    promql_expr_test:
+      - expr: monitoring:helm:number_of_operations_on_release
+        eval_time: 10m
+        exp_samples:
+          - labels: 'monitoring:helm:number_of_operations_on_release{cluster_id="gauss", event="update_release_from_tarball", release="cilium"}'
+            value: 10


### PR DESCRIPTION
I just thought it's now time to test recording rules as well.
- syntax check for all recording rules.
- added a unit tests for recording `helm-operations` to make sure it works.

Towards https://github.com/giantswarm/giantswarm/issues/26681

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
