### PR TITLE
add recording rules for Loki from mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Alert `ClusterDNSZoneMissing` added for `dns-operator-azure`
 - Alert `AzureDNSOperatorAPIErrorRate` added for `dns-operator-azure`
+- Recording rules for Loki
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ To Update `kubernetes-mixin` recording rules:
 * Run `./scripts/sync-kube-mixin.sh (?my-fancy-branch-or-tag)` to updated the `helm/prometheus-rules/templates/recording-rules/kubernetes-mixins.rules.yml` folder.
 * make sure to update [grafana dashboards](https://github.com/giantswarm/dashboards/tree/master/helm/dashboards/dashboards/mixin)
 
+#### loki-mixins
+
+Come as-is from https://github.com/grafana/loki/tree/main/production/loki-mixin-compiled-ssd ; just added helm headers (metadata, spec...)
 
 ### Testing
 
@@ -163,9 +166,9 @@ tests:
   - interval: 1m
     input_series:
       - series: '<prometheus_timeseries>'
-        values: "_x20 1+0x20 0+0x20" 
+        values: "_x20 1+0x20 0+0x20"
       - series: '<prometheus_timeseries>'
-        values: "0+600x40 24000+400x40" 
+        values: "0+600x40 24000+400x40"
 [...]
 ```
 

--- a/helm/prometheus-rules/templates/recording-rules/loki-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/loki-mixins.rules.yml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: kube-mixins.recording.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: loki_rules
+    rules:
+    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, job))
+      record: cluster_job:loki_request_duration_seconds:99quantile
+    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, job))
+      record: cluster_job:loki_request_duration_seconds:50quantile
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job) / sum(rate(loki_request_duration_seconds_count[1m]))
+        by (cluster, job)
+      record: cluster_job:loki_request_duration_seconds:avg
+    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job)
+      record: cluster_job:loki_request_duration_seconds_bucket:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job)
+      record: cluster_job:loki_request_duration_seconds_sum:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job)
+      record: cluster_job:loki_request_duration_seconds_count:sum_rate
+    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, job, route))
+      record: cluster_job_route:loki_request_duration_seconds:99quantile
+    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, job, route))
+      record: cluster_job_route:loki_request_duration_seconds:50quantile
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job, route)
+        / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
+      record: cluster_job_route:loki_request_duration_seconds:avg
+    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job,
+        route)
+      record: cluster_job_route:loki_request_duration_seconds_bucket:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job, route)
+      record: cluster_job_route:loki_request_duration_seconds_sum:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
+      record: cluster_job_route:loki_request_duration_seconds_count:sum_rate
+    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, namespace, job, route))
+      record: cluster_namespace_job_route:loki_request_duration_seconds:99quantile
+    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
+        by (le, cluster, namespace, job, route))
+      record: cluster_namespace_job_route:loki_request_duration_seconds:50quantile
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, namespace,
+        job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster,
+        namespace, job, route)
+      record: cluster_namespace_job_route:loki_request_duration_seconds:avg
+    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, namespace,
+        job, route)
+      record: cluster_namespace_job_route:loki_request_duration_seconds_bucket:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, namespace,
+        job, route)
+      record: cluster_namespace_job_route:loki_request_duration_seconds_sum:sum_rate
+    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, namespace,
+        job, route)
+      record: cluster_namespace_job_route:loki_request_duration_seconds_count:sum_rate

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -80,3 +80,4 @@ templates/recording-rules/helm-operations.rules.yml
 templates/recording-rules/kube-prometheus-mixins.rules.yml
 templates/recording-rules/kubernetes-mixins.rules.yml
 templates/recording-rules/service-level.rules.yml
+templates/recording-rules/loki-mixins.rules.yml


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2182

Not directly related to costs, but will be needed for mixin dashboards.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
