### PR TITLE
add basic alerting for mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alert `MimirDown` for Mimir app
+
 ## [2.93.0] - 2023-04-24
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: mimir.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: mimir
+    rules:
+    - alert: MimirComponentDown
+      annotations:
+        description: 'A Mimir component is down.'
+      expr: count(up{app="mimir"} == 0) by (service) > 0
+      for: 5m
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: atlas
+        topic: observability

--- a/test/tests/providers/global/mimir.rules.test.yml
+++ b/test/tests/providers/global/mimir.rules.test.yml
@@ -1,0 +1,31 @@
+---
+rule_files:
+  - mimir.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      # For the first 60min: test with 1 pod: none, up, down
+      - series: 'up{app="mimir",cluster_type="management_cluster", cluster_id="gauss", installation="gauss", service="mimir-ingester"}'
+        values: "_x20 1+0x20 0+0x20"
+    alert_rule_test:
+      - alertname:  MimirComponentDown
+        eval_time: 10m
+      - alertname:  MimirComponentDown
+        eval_time: 30m
+      - alertname:  MimirComponentDown
+        eval_time: 50m
+        exp_alerts:
+          - exp_labels:
+              area: managedservices
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_scrape_timeout: "true"
+              cancel_if_outside_working_hours: "false"
+            exp_annotations:
+              description: "A Mimir component is down."


### PR DESCRIPTION
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
