### PR TITLE
Fix App Failed alerts on CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix AppFailed alerts on CAPI clusters.
+
 ## [2.94.0] - 2023-04-26
 
 ### Added

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -58,27 +58,15 @@ true
 {{- end -}}
 
 {{- define "isClusterServiceInstalled" -}}
-{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere" "capa" "capz") -}}
-false
-{{- else -}}
-true
-{{- end -}}
+{{ not (eq .Values.managementCluster.provider.flavor "capi") }}
 {{- end -}}
 
 {{- define "isVaultBeingMonitored" -}}
-{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere" "capa" "capz") -}}
-false
-{{- else -}}
-true
-{{- end -}}
+{{ not (eq .Values.managementCluster.provider.flavor "capi") }}
 {{- end -}}
 
 {{- define "isBastionBeingMonitored" -}}
-{{- if has .Values.managementCluster.provider.kind (list "gcp" "openstack" "cloud-director" "vsphere" "capa" "capz") -}}
-false
-{{- else -}}
-true
-{{- end -}}
+{{ not (eq .Values.managementCluster.provider.flavor "capi") }}
 {{- end -}}
 
 {{- define "namespaceNotGiantswarm" -}}

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -45,8 +45,11 @@ spec:
       annotations:
         description: '{{`Workload Cluster App {{ if $labels.exported_namespace }}{{ $labels.exported_namespace }}{{ else }}{{ $labels.namespace }}{{ end }}/{{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      # we have this Frankenstein for namespace checks because go (and prometheus) don't support negative lookaheads in regex
+      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
+      expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog~="giantswarm|cluster", team!~"^$|noteam"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
+      {{- else }}
       expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog="giantswarm", team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
+      {{- end }}
       for: 30m
       labels:
         area: managedservices
@@ -57,13 +60,16 @@ spec:
         severity: page
         sig: none
         topic: releng
-    # If apps can't be installed - only for supported apps (coming from `giantswarm` catalog)
+    # If apps can't be installed - only for supported apps
     - alert: WorkloadClusterAppNotInstalled
       annotations:
         description: '{{`Workload Cluster App {{ if $labels.exported_namespace }}{{ $labels.exported_namespace }}{{ else }}{{ $labels.namespace }}{{ end }}/{{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
-      # we have this Frankenstein for namespace checks because go (and prometheus) don't support negative lookaheads in regex
+      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
+      expr: label_replace(app_operator_app_info{status="not-installed", catalog~="giantswarm|cluster", team!~"^$|noteam"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
+      {{- else }}
       expr: label_replace(app_operator_app_info{status="not-installed", catalog="giantswarm", team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
+      {{- end }}
       for: 30m
       labels:
         area: managedservices
@@ -79,8 +85,11 @@ spec:
       annotations:
         description: 'Current version of {{`App {{ $labels.name }} is {{ $labels.deployed_version }} but it should be {{ $labels.version }}.`}}'
         opsrecipe: app-pending-update/
-      # we have this Frankenstein for namespace checks because go (and prometheus) don't support negative lookaheads in regex
+      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
+      expr: label_replace(app_operator_app_info{catalog~="giantswarm|cluster", deployed_version!="", status="deployed", version_mismatch="true" ,team!~"^$|noteam"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
+      {{- else }}
       expr: label_replace(app_operator_app_info{catalog="giantswarm", deployed_version!="", status="deployed", version_mismatch="true" ,team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
+      {{- end }}
       for: 40m
       labels:
         area: managedservices
@@ -95,8 +104,12 @@ spec:
       annotations:
         description: '{{`App {{ $labels.name }} has no team label.`}}'
         opsrecipe: app-without-team-annotation/
+      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
+      expr: label_replace(app_operator_app_info{team=~"^$|noteam"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
+      {{- else }}
       # we have this Frankenstein for namespace checks because go (and prometheus) don't support negative lookaheads in regex
       expr: label_replace(app_operator_app_info{team=~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
+      {{- end }}
       for: 40m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi.rules.yml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.managementCluster.provider.kind "openstack") (eq .Values.managementCluster.provider.kind "gcp") (eq .Values.managementCluster.provider.kind "capz") }}
+{{- if eq .Values.managementCluster.provider.flavor "capi" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -9,3 +9,4 @@ managementCluster:
   pipeline: ""
   provider:
     kind: ""
+    flavor: ""


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26173

This PR requires https://github.com/giantswarm/config/pull/1754 to be merged before

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
