### PR TITLE
Deprecate master role in favor of control-plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deprecate `role=master` in favor of `role=control-plane`.
+- Rename alerts containing `Master` with `ControlPlane`
+
 ## [2.94.0] - 2023-04-26
 
 ### Added
@@ -861,7 +866,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Split mixin recording rules into 2 files (kubernetes, kube-prometheus).
 
-
 ## [2.25.0] - 2022-05-26
 
 ### Fixed
@@ -1291,7 +1295,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change ManagementClusterHasLessThanThreeNodes alert to use a metrics with reliable `role` label.
 
 ## [0.40.2] - 2021-12-03
-
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -42,46 +42,46 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingAWS in this file is AWS specific and thus
+    # WorkloadClusterControlPlaneNodeMissingAWS in this file is AWS specific and thus
     # assigned to Team Phoenix. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelet.
     #
-    #     kubernetes_build_info{app="kubelet", role="master"} gives us a vector
-    #     of all master node kubelets.
+    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     of all control plane node kubelets.
     #
-    #     `unless` results in a vector consisting of the masters for which
+    #     `unless` results in a vector consisting of the control planes for which
     #     there are no kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingAWS
+    - alert: WorkloadClusterControlPlaneNodeMissingAWS
       annotations:
-        description: '{{`Master node is missing.`}}'
+        description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
       for: 10m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
-        master_node_down: "true"
+        control_plane_node_down: "true"
         severity: page
         team: phoenix
         topic: kubernetes
-    - alert: WorkloadClusterHAMasterDownForTooLong
+    - alert: WorkloadClusterHAControlPlaneDownForTooLong
       annotations:
-        description: '{{`Master node in HA setup is down for a long time.`}}'
+        description: '{{`Control plane node in HA setup is down for a long time.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet", role="master"}) by (cluster_id) == 2
+      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet",role="control-plane"}) by (cluster_id) == 2
       for: 30m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: "true"
-        master_node_down: "true"
+        control_plane_node_down: "true"
         severity: page
         team: phoenix
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -61,25 +61,25 @@ spec:
         severity: notify
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingPhoenix in this file is Azure specific and thus
+    # WorkloadClusterControlPlaneNodeMissingPhoenix in this file is Azure specific and thus
     # assigned to Team Phoenix. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelets.
     #
-    #     kubernetes_build_info{app="kubelet", role="master"} gives us a vector
-    #     of all master node kubelets.
+    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     of all control plane node kubelets.
     #
-    #     `unless` results in a vector consisting of the masters for which
-    #     there are no master kubelets, which we can then alert on. See
+    #     `unless` results in a vector consisting of the control planes for which
+    #     there are no control plane kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingPhoenix
+    - alert: WorkloadClusterControlPlaneNodeMissingPhoenix
       annotations:
-        description: '{{`Master node is missing.`}}'
+        description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
       for: 10m
       labels:
         area: kaas
@@ -87,7 +87,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_has_no_workers: "true"
-        master_node_down: "true"
+        control_plane_node_down: "true"
         severity: page
         team: phoenix
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -49,7 +49,7 @@ spec:
       annotations:
         description: '{{`Etcd has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
-      expr: etcd_server_has_leader{role="master", cluster_type="management_cluster"} == 0
+      expr: etcd_server_has_leader{role="control-plane", cluster_type="management_cluster"} == 0
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -22,7 +22,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        cancel_if_master_node_down: "true"
+        cancel_if_control_plane_node_down: "true"
         cancel_if_kubelet_down: "true"
         severity: page
         team: {{ include "providerTeam" . }}

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -58,18 +58,18 @@ spec:
         severity: notify
         team: rocket
         topic: kubernetes
-    - alert: ManagementClusterMasterNodeMissingRocket
+    - alert: ManagementClusterControlPlaneNodeMissingRocket
       annotations:
-        description: '{{`Master node is missing.`}}'
+        description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
       for: 10m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        master_node_down: "true"
+        control_plane_node_down: "true"
         severity: page
         team: rocket
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -48,32 +48,32 @@ spec:
         severity: notify
         team: rocket
         topic: kubernetes
-    # WorkloadClusterMasterNodeMissingRocket in this file is Azure specific and thus
+    # WorkloadClusterControlPlaneNodeMissingRocket in this file is Azure specific and thus
     # assigned to Team Rocket. The alert is also defined for all the other
     # providers with other team assignments.
     #
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelets.
     #
-    #     kubernetes_build_info{app="kubelet", role="master"} gives us a vector
-    #     of all master node kubelets.
+    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     of all control plane node kubelets.
     #
-    #     `unless` results in a vector consisting of the masters for which
-    #     there are no master kubelets, which we can then alert on. See
+    #     `unless` results in a vector consisting of the control planes for which
+    #     there are no control plane kubelets, which we can then alert on. See
     #     https://prometheus.io/docs/prometheus/latest/querying/operators.
     #
-    - alert: WorkloadClusterMasterNodeMissingRocket
+    - alert: WorkloadClusterControlPlaneNodeMissingRocket
       annotations:
-        description: '{{`Master node is missing.`}}'
+        description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
       for: 10m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        master_node_down: "true"
+        control_plane_node_down: "true"
         severity: page
         team: rocket
         topic: kubernetes


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2389

This PR deprecates master role in favor of control-plane

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
