### PR TITLE
Fix control-plane-node-down inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix control-plane-node-down inhibition.
+
 ## [2.95.0] - 2023-04-27
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -49,7 +49,7 @@ spec:
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelet.
     #
-    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
     #     of all control plane node kubelets.
     #
     #     `unless` results in a vector consisting of the control planes for which
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
       for: 10m
       labels:
         area: kaas
@@ -74,7 +74,7 @@ spec:
       annotations:
         description: '{{`Control plane node in HA setup is down for a long time.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet",role="control-plane"}) by (cluster_id) == 2
+      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet",role=~"master|control-plane"}) by (cluster_id) == 2
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -68,7 +68,7 @@ spec:
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelets.
     #
-    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
     #     of all control plane node kubelets.
     #
     #     `unless` results in a vector consisting of the control planes for which
@@ -79,7 +79,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -49,7 +49,7 @@ spec:
       annotations:
         description: '{{`Etcd has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
-      expr: etcd_server_has_leader{role="control-plane", cluster_type="management_cluster"} == 0
+      expr: etcd_server_has_leader{role=~"master|control-plane", cluster_type="management_cluster"} == 0
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -62,7 +62,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -55,7 +55,7 @@ spec:
     #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
     #     kubelets.
     #
-    #     kubernetes_build_info{app="kubelet", role="control-plane"} gives us a vector
+    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
     #     of all control plane node kubelets.
     #
     #     `unless` results in a vector consisting of the control planes for which
@@ -66,7 +66,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/...

This PR fixes the control plane node down inhibition for old clusters

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
