### PR TITLE
Fix WorkloadClusterControlPlaneNodeMissing alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers. 
+
 ## [2.95.1] - 2023-04-27
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -42,25 +42,11 @@ spec:
         severity: page
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterControlPlaneNodeMissingAWS in this file is AWS specific and thus
-    # assigned to Team Phoenix. The alert is also defined for all the other
-    # providers with other team assignments.
-    #
-    #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
-    #     kubelet.
-    #
-    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
-    #     of all control plane node kubelets.
-    #
-    #     `unless` results in a vector consisting of the control planes for which
-    #     there are no kubelets, which we can then alert on. See
-    #     https://prometheus.io/docs/prometheus/latest/querying/operators.
-    #
     - alert: WorkloadClusterControlPlaneNodeMissingAWS
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
       for: 10m
       labels:
         area: kaas
@@ -74,7 +60,7 @@ spec:
       annotations:
         description: '{{`Control plane node in HA setup is down for a long time.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet",role=~"master|control-plane"}) by (cluster_id) == 2
+      expr: sum(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) by (cluster_id) == 2
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -61,25 +61,11 @@ spec:
         severity: notify
         team: phoenix
         topic: kubernetes
-    # WorkloadClusterControlPlaneNodeMissingPhoenix in this file is Azure specific and thus
-    # assigned to Team Phoenix. The alert is also defined for all the other
-    # providers with other team assignments.
-    #
-    #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
-    #     kubelets.
-    #
-    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
-    #     of all control plane node kubelets.
-    #
-    #     `unless` results in a vector consisting of the control planes for which
-    #     there are no control plane kubelets, which we can then alert on. See
-    #     https://prometheus.io/docs/prometheus/latest/querying/operators.
-    #
     - alert: WorkloadClusterControlPlaneNodeMissingPhoenix
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -62,7 +62,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -48,25 +48,11 @@ spec:
         severity: notify
         team: rocket
         topic: kubernetes
-    # WorkloadClusterControlPlaneNodeMissingRocket in this file is Azure specific and thus
-    # assigned to Team Rocket. The alert is also defined for all the other
-    # providers with other team assignments.
-    #
-    #     kubernetes_build_info{app="kubelet"} gives us a vector of all the
-    #     kubelets.
-    #
-    #     kubernetes_build_info{app="kubelet", role=~"master|control-plane"} gives us a vector
-    #     of all control plane node kubelets.
-    #
-    #     `unless` results in a vector consisting of the control planes for which
-    #     there are no control plane kubelets, which we can then alert on. See
-    #     https://prometheus.io/docs/prometheus/latest/querying/operators.
-    #
     - alert: WorkloadClusterControlPlaneNodeMissingRocket
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role=~"master|control-plane"}
+      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
This PR fixes alerting issues

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
