### PR TITLE
Add an alert that pages if etcd metrics are missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an alert that pages if etcd metrics are missing.
+
 ## [2.95.2] - 2023-04-28
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -57,3 +57,16 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd
+    - alert: ManagementClusterEtcdMetricsMissing
+      annotations:
+        description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'
+        opsrecipe: etcd-metrics-missing/
+      expr: count(up{cluster_type="management_cluster"}) by (cluster_id) unless count(etcd_server_id) by (cluster_id)
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: true
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: etcd
+

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -62,7 +62,7 @@ spec:
         description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'
         opsrecipe: etcd-metrics-missing/
       expr: count(up{cluster_type="management_cluster"}) by (cluster_id) unless count(etcd_server_id) by (cluster_id)
-      for: 5m
+      for: 1h
       labels:
         area: kaas
         cancel_if_outside_working_hours: true

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -72,3 +72,15 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd
+    - alert: WorkloadClusterEtcdMetricsMissing
+      annotations:
+        description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'
+        opsrecipe: etcd-metrics-missing/
+      expr: count(up{cluster_type="workload_cluster"}) by (cluster_id) unless count(etcd_server_id) by (cluster_id)
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: true
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: etcd

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -77,7 +77,7 @@ spec:
         description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'
         opsrecipe: etcd-metrics-missing/
       expr: count(up{cluster_type="workload_cluster"}) by (cluster_id) unless count(etcd_server_id) by (cluster_id)
-      for: 5m
+      for: 1h
       labels:
         area: kaas
         cancel_if_outside_working_hours: true


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C02HLSDH3DZ/p1682680595002609

This PR adds a new alert that pages during BH if etcd metrics are not present

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
