### PR TITLE
remove heartbeats delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers (previous fix was not working)
 
+### Changed
+
+- Reduced delay for heartbeats from 10m to none
+
 ## [2.96.0] - 2023-04-28
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -11,7 +11,6 @@ spec:
     rules:
     - alert: "Heartbeat"
       expr: up{app="prometheus",instance!="prometheus-agent"}
-      for: 10m
       labels:
         area: "empowerment"
         installation: {{ .Values.managementCluster.name }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26770

This PR removes the delay before sending heartbeat alerts.
Means as soon as prometheus is up and ready it sends heartbeats, instead of waiting for 10 extra minutes.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
