### PR TITLE
fix WorkloadClusterControlPlaneNodeMissing alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers (previous fix was not working)
+
 ## [2.96.0] - 2023-04-28
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -46,7 +46,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
+      expr: count(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -65,7 +65,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
+      expr: count(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.management-cluster.rules.yml
@@ -62,7 +62,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
+      expr: count(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -52,7 +52,7 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}
+      expr: count(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: [slack - flooded by `WorkloadClusterControlPlaneNodeMissingAWS` alerts](https://gigantic.slack.com/archives/C020E38NGTZ/p1682676716862719)

Here is one of the alerts in opsgenie: https://giantswarm.app.opsgenie.com/alert/detail/3fdbf118-00ed-47ed-88c2-151588e55723-1682677098661/details

This PR applies the proposed fix from @QuentinBisson .
Tested on a few clusters, no more false alerts with this query.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
