### PR TITLE
added PrometheusAvailabilityRatio alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers (previous fix was not working)
 
+### Added
+
+- added `PrometheusAvailabilityRatio` alert
+
 ## [2.96.0] - 2023-04-28
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -10,6 +10,25 @@ spec:
   groups:
   - name: prometheus
     rules:
+    - alert: PrometheusAvailabilityRatio
+      annotations:
+        description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last 10 hours.`}}'
+        opsrecipe: prometheus-resource-limit-reached/
+      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[10h])) by (pod) < 0.8
+      # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
+      for: 30m
+      labels:
+        area: empowerment
+        cancel_if_any_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        cancel_if_outside_working_hours: "true"
+        dashboard: promavailability/prometheus-availability
+        severity: page
+        team: atlas
+        topic: observability
     - alert: PrometheusCantCommunicateWithKubernetesAPI
       annotations:
         description: '{{`Prometheus can''t communicate with Kubernetes API.`}}'
@@ -23,7 +42,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: atlas
         topic: observability

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -7,6 +7,77 @@ rule_files:
 evaluation_interval: 1h
 
 tests:
+  # Test PrometheusAvailabilityRatio
+  - interval: 1m
+    input_series:
+      # This prometheus is up foreve - generates no alert
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
+        values: "1+0x600"
+      # This prometheus starts at h+2, and takes 15min to get ready - generates no alert
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
+        values: "_x120 0+0x15 1+0x600"
+      # This promteheus is down - generates alerts
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
+        values: "0+0x600"
+    alert_rule_test:
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 135m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_any_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              dashboard: "promavailability/prometheus-availability"
+              pod: "prometheus-wcbad-0"
+            exp_annotations:
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
+              opsrecipe: "prometheus-resource-limit-reached/"
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 4h
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_any_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              dashboard: "promavailability/prometheus-availability"
+              pod: "prometheus-wcbad-0"
+            exp_annotations:
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
+              opsrecipe: "prometheus-resource-limit-reached/"
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 15h
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_any_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              dashboard: "promavailability/prometheus-availability"
+              pod: "prometheus-wcbad-0"
+            exp_annotations:
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
+              opsrecipe: "prometheus-resource-limit-reached/"
+  # Test PrometheusJobScrapingFailure and PrometheusCriticalJobScrapingFailure
   - interval: 1h
     input_series:
       - series: 'up{app="kubernetes",installation="gauss",cluster_id="gauss",job="gauss-prometheus/kubernetes-apiserver-gauss/0"}'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26770
Related: https://github.com/giantswarm/prometheus-rules/pull/729

This PR creates a new alert, `PrometheusAvailabilityRatio`, that pages during working hours when prometheus was up for less than 80% time in the past 10 hours.

Good to know: The alert is generated from MC prometheus, so if it's dead we have no visibility over it.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
