### PR TITLE
Fix ksm down alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix KubeStateMetricsDown inhibition.
+
 ## [2.96.1] - 2023-05-02
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -28,15 +28,6 @@ spec:
         topic: kubernetes
       annotations:
         description: '{{`Kubelet ({{ $labels.instance }}) is down.`}}'
-    - alert: InhibitionKubeStateMetricsDown
-      annotations:
-        description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'
-      expr: up{app="kube-state-metrics"} == 0 or absent(up{app="kube-state-metrics"} == 1)
-      labels:
-        area: kaas
-        kube_state_metrics_down: "true"
-        team: phoenix
-        topic: status
     # TODO: fix with real expr 
     - alert: ScrapeTimeout
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
@@ -14,11 +14,12 @@ spec:
       annotations:
         description: '{{`kube_configmap_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_configmap_created{}) by (cluster_id))
+      expr: absent(kube_configmap_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -26,11 +27,12 @@ spec:
       annotations:
         description: '{{`kube_daemonset_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_daemonset_created{}) by (cluster_id))
+      expr: absent(kube_daemonset_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -38,11 +40,12 @@ spec:
       annotations:
         description: '{{`kube_deployment_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_deployment_created{}) by (cluster_id))
+      expr: absent(kube_deployment_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -50,11 +53,12 @@ spec:
       annotations:
         description: '{{`kube_endpoint_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_endpoint_created{}) by (cluster_id))
+      expr: absent(kube_endpoint_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -62,11 +66,12 @@ spec:
       annotations:
         description: '{{`kube_namespace_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_namespace_created{}) by (cluster_id))
+      expr: absent(kube_namespace_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -74,11 +79,12 @@ spec:
       annotations:
         description: '{{`kube_node_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_node_created{}) by (cluster_id))
+      expr: absent(kube_node_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -86,11 +92,12 @@ spec:
       annotations:
         description: '{{`kube_pod_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_pod_created{}) by (cluster_id))
+      expr: absent(kube_pod_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -98,11 +105,12 @@ spec:
       annotations:
         description: '{{`kube_replicaset_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_replicaset_created{}) by (cluster_id))
+      expr: absent(kube_replicaset_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -110,11 +118,12 @@ spec:
       annotations:
         description: '{{`kube_secret_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_secret_created{}) by (cluster_id))
+      expr: absent(kube_secret_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes
@@ -122,11 +131,12 @@ spec:
       annotations:
         description: '{{`kube_service_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: kube-steate-metrics-metrics-missing/
-      expr: (count(up{app="kube-state-metrics"} == 1) by (cluster_id)) unless (count(kube_service_created{}) by (cluster_id))
+      expr: absent(kube_service_created{})
       for: 30m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
         severity: page
         team: atlas
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -56,6 +56,8 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_has_no_workers: "true"
+        kube_state_metrics_down: "true"
+        inhibit_kube_state_metrics_down: "true"
         cancel_if_kubelet_down: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page


### PR DESCRIPTION
This PR fixes the ksm down alert and inhibition

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
