### PR TITLE
Updated 'PrometheusAvailabilityRatio' alert to set window to 1h rather than 10h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- updated `PrometheusAvailabilityRatio` alert to set window to 1h rather than 10h.
+
 ## [2.96.6] - 2023-05-03
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -12,10 +12,10 @@ spec:
     rules:
     - alert: PrometheusAvailabilityRatio
       annotations:
-        description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last 10 hours.`}}'
+        description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last hour.`}}'
         opsrecipe: prometheus-resource-limit-reached/
         dashboard: promavailability/prometheus-availability
-      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[10h])) by (pod) < 0.8
+      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[1h])) by (pod) < 0.8
       # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
       for: 30m
       labels:

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -12,16 +12,16 @@ tests:
     input_series:
       # This prometheus is up foreve - generates no alert
       - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
-        values: "1+0x600"
-      # This prometheus starts at h+2, and takes 15min to get ready - generates no alert
+        values: "1+0x120"
+      # This prometheus starts at h+1, and takes 5min to get ready - generates no alert
       - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
-        values: "_x120 0+0x15 1+0x600"
-      # This promteheus is down - generates alerts
+        values: "_x60 0+0x5 1+0x60"
+      # This prometheus is down - generates alerts
       - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
-        values: "0+0x600"
+        values: "0+0x60 1+0x60"
     alert_rule_test:
       - alertname: PrometheusAvailabilityRatio
-        eval_time: 135m
+        eval_time: 60m
         exp_alerts:
           - exp_labels:
               area: empowerment
@@ -36,11 +36,11 @@ tests:
               cancel_if_outside_working_hours: "true"
               pod: "prometheus-wcbad-0"
             exp_annotations:
-              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
               opsrecipe: "prometheus-resource-limit-reached/"
               dashboard: "promavailability/prometheus-availability"
       - alertname: PrometheusAvailabilityRatio
-        eval_time: 4h
+        eval_time: 108m
         exp_alerts:
           - exp_labels:
               area: empowerment
@@ -55,28 +55,11 @@ tests:
               cancel_if_outside_working_hours: "true"
               pod: "prometheus-wcbad-0"
             exp_annotations:
-              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
               opsrecipe: "prometheus-resource-limit-reached/"
               dashboard: "promavailability/prometheus-availability"
       - alertname: PrometheusAvailabilityRatio
-        eval_time: 15h
-        exp_alerts:
-          - exp_labels:
-              area: empowerment
-              severity: page
-              team: atlas
-              topic: observability
-              cancel_if_any_apiserver_down: "true"
-              cancel_if_cluster_has_no_workers: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "true"
-              pod: "prometheus-wcbad-0"
-            exp_annotations:
-              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last 10 hours."
-              opsrecipe: "prometheus-resource-limit-reached/"
-              dashboard: "promavailability/prometheus-availability"
+        eval_time: 140m
   # Test PrometheusJobScrapingFailure and PrometheusCriticalJobScrapingFailure
   - interval: 1h
     input_series:


### PR DESCRIPTION
towards https://gigantic.slack.com/archives/C01176DKNP4/p1683201431181329

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
