### PR TITLE
Updated 'PrometheusAvailabilityRatio' to handle only our prometheis hosted on the management cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `PrometheusAvailabilityRatio` to handle only our prometheis hosted on the management cluster.
+- Updated `PrometheusAvailabilityRatio` to be executed only on MC prometheus.
 
 ## [2.97.0] - 2023-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `PrometheusAvailabilityRatio` to handle only our prometheis hosted on the management cluster.
+
 ## [2.97.0] - 2023-05-04
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     cluster_type: "management_cluster"
-  name: prometheus.rules
+  name: prometheus-availability.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: prometheus.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: prometheus
+    rules:
+    - alert: PrometheusAvailabilityRatio
+      annotations:
+        description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last hour.`}}'
+        opsrecipe: prometheus-resource-limit-reached/
+        dashboard: promavailability/prometheus-availability
+      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[1h])) by (pod) < 0.8
+      # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
+      for: 30m
+      labels:
+        area: empowerment
+        cancel_if_any_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -15,7 +15,7 @@ spec:
         description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last hour.`}}'
         opsrecipe: prometheus-resource-limit-reached/
         dashboard: promavailability/prometheus-availability
-      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[1h])) by (pod) < 0.8
+      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true", cluster_type="management_cluster"}[1h])) by (pod) < 0.8
       # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
       for: 30m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -10,25 +10,6 @@ spec:
   groups:
   - name: prometheus
     rules:
-    - alert: PrometheusAvailabilityRatio
-      annotations:
-        description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last hour.`}}'
-        opsrecipe: prometheus-resource-limit-reached/
-        dashboard: promavailability/prometheus-availability
-      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true", cluster_type="management_cluster"}[1h])) by (pod) < 0.8
-      # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
-      for: 30m
-      labels:
-        area: empowerment
-        cancel_if_any_apiserver_down: "true"
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
     - alert: PrometheusCantCommunicateWithKubernetesAPI
       annotations:
         description: '{{`Prometheus can''t communicate with Kubernetes API.`}}'

--- a/test/tests/providers/global/prometheus-availability.rules.test.yml
+++ b/test/tests/providers/global/prometheus-availability.rules.test.yml
@@ -1,0 +1,62 @@
+---
+rule_files:
+  - prometheus-availability.rules.yml
+
+# Setting evaluation interval to 1h
+# to make it faster on long test duration.
+evaluation_interval: 1h
+
+tests:
+  # Test PrometheusAvailabilityRatio
+  - interval: 1m
+    input_series:
+      # This prometheus is up foreve - generates no alert
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
+        values: "1+0x120"
+      # This prometheus starts at h+1, and takes 5min to get ready - generates no alert
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
+        values: "_x60 0+0x5 1+0x60"
+      # This prometheus is down - generates alerts
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
+        values: "0+0x60 1+0x60"
+    alert_rule_test:
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_any_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              pod: "prometheus-wcbad-0"
+            exp_annotations:
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
+              opsrecipe: "prometheus-resource-limit-reached/"
+              dashboard: "promavailability/prometheus-availability"
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 108m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_any_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              pod: "prometheus-wcbad-0"
+            exp_annotations:
+              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
+              opsrecipe: "prometheus-resource-limit-reached/"
+              dashboard: "promavailability/prometheus-availability"
+      - alertname: PrometheusAvailabilityRatio
+        eval_time: 140m

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -11,13 +11,13 @@ tests:
   - interval: 1m
     input_series:
       # This prometheus is up foreve - generates no alert
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
         values: "1+0x120"
       # This prometheus starts at h+1, and takes 5min to get ready - generates no alert
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
         values: "_x60 0+0x5 1+0x60"
       # This prometheus is down - generates alerts
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
+      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
         values: "0+0x60 1+0x60"
     alert_rule_test:
       - alertname: PrometheusAvailabilityRatio

--- a/test/tests/providers/global/prometheus.rules.test.yml
+++ b/test/tests/providers/global/prometheus.rules.test.yml
@@ -7,59 +7,6 @@ rule_files:
 evaluation_interval: 1h
 
 tests:
-  # Test PrometheusAvailabilityRatio
-  - interval: 1m
-    input_series:
-      # This prometheus is up foreve - generates no alert
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="install-prometheus", pod="prometheus-install-0"}'
-        values: "1+0x120"
-      # This prometheus starts at h+1, and takes 5min to get ready - generates no alert
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="wcok-prometheus", pod="prometheus-wcok-0"}'
-        values: "_x60 0+0x5 1+0x60"
-      # This prometheus is down - generates alerts
-      - series: 'kube_pod_status_ready{app="kube-state-metrics", condition="true", cluster_type="management_cluster", container="kube-state-metrics", namespace="wcbad-prometheus", pod="prometheus-wcbad-0"}'
-        values: "0+0x60 1+0x60"
-    alert_rule_test:
-      - alertname: PrometheusAvailabilityRatio
-        eval_time: 60m
-        exp_alerts:
-          - exp_labels:
-              area: empowerment
-              severity: page
-              team: atlas
-              topic: observability
-              cancel_if_any_apiserver_down: "true"
-              cancel_if_cluster_has_no_workers: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "true"
-              pod: "prometheus-wcbad-0"
-            exp_annotations:
-              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
-              opsrecipe: "prometheus-resource-limit-reached/"
-              dashboard: "promavailability/prometheus-availability"
-      - alertname: PrometheusAvailabilityRatio
-        eval_time: 108m
-        exp_alerts:
-          - exp_labels:
-              area: empowerment
-              severity: page
-              team: atlas
-              topic: observability
-              cancel_if_any_apiserver_down: "true"
-              cancel_if_cluster_has_no_workers: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "true"
-              pod: "prometheus-wcbad-0"
-            exp_annotations:
-              description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
-              opsrecipe: "prometheus-resource-limit-reached/"
-              dashboard: "promavailability/prometheus-availability"
-      - alertname: PrometheusAvailabilityRatio
-        eval_time: 140m
   # Test PrometheusJobScrapingFailure and PrometheusCriticalJobScrapingFailure
   - interval: 1h
     input_series:


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C01176DKNP4/p1683211078221639?thread_ts=1683201431.181329&cid=C01176DKNP4

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
