### PR TITLE
update Flux workqueue length to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Flux work queue limit to 1h from previous 30 min.
+
 ## [2.97.1] - 2023-05-05
 
 ### Changed
@@ -75,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers. 
+- Fix `WorkloadClusterControlPlaneNodeMissing` alerts for all providers.
 
 ## [2.95.1] - 2023-04-27
 

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -251,7 +251,7 @@ spec:
     - alert: FluxWorkqueueTooLong
       annotations:
         description: |-
-          {{`Flux artifacts are stuck in work queue for over 30 minutes and are not being reconciled.`}}
+          {{`Flux artifacts are stuck in work queue for over 1 hour and are not being reconciled.`}}
         opsrecipe: fluxcd-workqueue-too-long/
       expr: |
         sum by (name, namespace) (workqueue_unfinished_work_seconds{namespace=~"flux-giantswarm|flux-system"}) > 3600.0

--- a/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/flux.rules.yml
@@ -254,7 +254,7 @@ spec:
           {{`Flux artifacts are stuck in work queue for over 30 minutes and are not being reconciled.`}}
         opsrecipe: fluxcd-workqueue-too-long/
       expr: |
-        sum by (name, namespace) (workqueue_unfinished_work_seconds{namespace=~"flux-giantswarm|flux-system"}) > 1800.0
+        sum by (name, namespace) (workqueue_unfinished_work_seconds{namespace=~"flux-giantswarm|flux-system"}) > 3600.0
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
