### PR TITLE
reduce PrometheusRuleFailures interval to 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce PrometheusRuleFailures interval to 5m
+
 ## [2.98.0] - 2023-05-10
 
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -58,7 +58,7 @@ spec:
         description: {{`Prometheus {{$labels.installation}}/{{$labels.cluster_id}} has failed to evaluate rule(s) {{ printf "%.2f" $value }} time(s).`}}
         summary: Prometheus is failing rule evaluations.
         opsrecipe: prometheus-rule-failures/
-      expr: rate(prometheus_rule_evaluation_failures_total[30m]) > 0
+      expr: rate(prometheus_rule_evaluation_failures_total[5m]) > 0
       for: 1h
       labels:
         area: empowerment


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26932

This PR changes the range interval from 30m to 5m in PrometheusRuleFailures alert.

This has 2 implications :

- Quicker aler resolution, has alert will resolve/close 5m after the issue is gone.
- Less noise:
    As 30m range query with for:1h means we get paged whenever there are at least 1 error every 30minutes for 1h. (very sensitive)
    As 5m range query with for:1h means we get paged whenever there are at least 1 error every 5mn for 1h.

### Checklist

- [x] Update CHANGELOG.md