### PR TITLE
exclude token handler from dex error rate high alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Exclude `/token` handler from `DexErrorRateHigh` alert.
 - Reduce PrometheusRuleFailures interval to 5m
 - Reduce CertificateWillExpireInLessThanTwoWeeks period from 14 days to 13
   days. This accounts for a [bug in cert-manager](https://github.com/cert-manager/cert-manager/issues/5851) and gives

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -15,7 +15,7 @@ spec:
       annotations:
         description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
         opsrecipe: dex-error-rate-high/
-      expr: sum(increase(http_requests_total{app="dex", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
+      expr: sum(increase(http_requests_total{app="dex", handler!="/token", code=~"^[4]..$|[5]..$"}[5m])) by (cluster_id) > 10
       for: 30m
       labels:
         area: managedapps


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2239

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
