### PR TITLE
add alert for vpa's recommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `VpaRecommenderTooManyRestarts` alert.
+
 ### Changed
 
 - Reduce PrometheusRuleFailures interval to 5m

--- a/helm/prometheus-rules/Chart.yaml
+++ b/helm/prometheus-rules/Chart.yaml
@@ -4,8 +4,8 @@ engine: gotpl
 home: https://github.com/giantswarm/prometheus-rules
 icon: https://s.giantswarm.io/app-icons/1/png/default-app-light.png
 name: prometheus-rules
-appVersion: '[[ .AppVersion ]]'
-version: '[[ .Version ]]'
+appVersion: '2.98.0-20b7f02eb3bbb9568e0c6e2de8ebdd6a7bc65578'
+version: '2.98.0-20b7f02eb3bbb9568e0c6e2de8ebdd6a7bc65578'
 annotations:
   application.giantswarm.io/team: "atlas"
   config.giantswarm.io/version: 1.x.x

--- a/helm/prometheus-rules/templates/alerting-rules/vpa-recommender.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa-recommender.rules.yml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: vpa-recommender.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: vpa-recommender
+    rules:
+    - alert: VpaRecommenderTooManyRestarts
+      annotations:
+        description: 'The vpa's recommender has restarted several times in the last 30min'
+      expr: sum(changes(kube_pod_container_status_restarts_total{container="recommender"}[30min])) by (container) > 3
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -2,8 +2,8 @@ name: prometheus-rules
 namespace: monitoring
 serviceType: managed
 project:
-  branch: '[[ .Branch ]]'
-  commit: '[[ .SHA ]]'
+  branch: 'master'
+  commit: '20b7f02eb3bbb9568e0c6e2de8ebdd6a7bc65578'
 managementCluster:
   name: ""
   pipeline: ""

--- a/test/tests/providers/global/vpa-recommender.rules.test.yml
+++ b/test/tests/providers/global/vpa-recommender.rules.test.yml
@@ -1,0 +1,35 @@
+---
+rule_files:
+  - vpa-recommender.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      # For the first 60min: test with 1 pod: none, up, down then pod restarts 3 times in 12min
+      - series: 'up{container="recommender"}'
+        values: "_x20 1+0x20 0+0x20 1+0x2 0+0x2 1+0x2 0+0x2 1+0x2 0+0x2 1+0x30"
+    alert_rule_test:
+      - alertname: VpaRecommenderTooManyRestarts
+        eval_time: 10m
+      - alertname: VpaRecommenderTooManyRestarts
+        eval_time: 30m
+      - alertname: VpaRecommenderTooManyRestarts
+        eval_time: 60m
+      - alertname: VpaRecommenderTooManyRestarts
+        eval_time: 80m  
+      - alertname: VpaRecommenderTooManyRestarts
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: managedservices
+              severity: page
+              team: atlas
+              topic: observability
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_scrape_timeout: "true"
+              cancel_if_outside_working_hours: "false"
+            exp_annotations:
+              description: "The vpa's recommender has restarted several times in the last 30min"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26922

This PR adds an alerting rule for the vpa's recommender so that when the recommender is restarting too often we get paged.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
