### PR TITLE
Fix agent alerts to take into account sharded agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Prometheus Agent alerts for sharded agents.
+
 ## [2.98.2] - 2023-05-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -19,7 +19,7 @@ spec:
     - alert: InhibitionClusterIsNotRunningPrometheusAgent
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) is not running Prometheus Agent.`}}'
-      expr: (count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (kube_statefulset_created{namespace="kube-system",statefulset="prometheus-prometheus-agent"}  > 0))
+      expr: (count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (kube_statefulset_created{namespace="kube-system",statefulset=~"prometheus-prometheus-agent.*"}  > 0))
       labels:
         cluster_is_not_running_prometheus_agent: "true"
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -18,7 +18,7 @@ spec:
         summary: Prometheus agent fails to send samples to remote write endpoint.
         opsrecipe: prometheus-agent-remote-write-failed/
         dashboard: promRW001/prometheus-remote-write
-      expr: count(absent_over_time(up{instance="prometheus-agent"}[10m])) and count((present_over_time(kube_statefulset_created{namespace="kube-system",statefulset=~"prometheus-prometheus-agent"}[10m])))
+      expr: count(absent_over_time(up{instance="prometheus-agent"}[10m])) and count((present_over_time(kube_statefulset_created{namespace="kube-system",statefulset=~"prometheus-prometheus-agent.*"}[10m])))
       for: 10m
       labels:
         area: empowerment

--- a/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
@@ -9,6 +9,8 @@ tests:
         values: "1+0x40"
       - series: 'kube_statefulset_created{namespace="kube-system",cluster_id="gauss",statefulset="prometheus-prometheus-agent"}'
         values: "1+0x20 0+0x20"
+      - series: 'kube_statefulset_created{namespace="kube-system",cluster_id="gauss",statefulset="prometheus-prometheus-agent-shard-1"}'
+        values: "1+0x20 0+0x20"
     alert_rule_test:
       - alertname: InhibitionClusterIsNotRunningPrometheusAgent
         eval_time: 1m

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -13,7 +13,7 @@ tests:
       - alertname: PrometheusAgentFailing
         eval_time: 10m
       - alertname: PrometheusAgentFailing
-        eval_time: 25m
+        eval_time: 25ms
         exp_alerts:
           - exp_labels:
               area: empowerment

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -13,7 +13,7 @@ tests:
       - alertname: PrometheusAgentFailing
         eval_time: 10m
       - alertname: PrometheusAgentFailing
-        eval_time: 25ms
+        eval_time: 25m
         exp_alerts:
           - exp_labels:
               area: empowerment


### PR DESCRIPTION
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
