### PR TITLE
send dex alerts to team bigmac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Send `dex` alerts to team bigmac.
+
 ### Fixed
 
 - Fix Prometheus Agent alerts for sharded agents.

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: managedapps
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: rainbow
+        team: bigmac
         topic: dex
     - alert: DexSecretExpired
       annotations:
@@ -33,7 +33,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: rainbow
+        team: bigmac
         topic: dex
     - alert: ManagementClusterDexAppMissing
       annotations:
@@ -45,5 +45,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: rainbow
+        team: bigmac
         topic: dex


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26583

Rainbow on-call ends by the end of this week so let's route the dex related alerts to bigmac from now on.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
