### PR TITLE
split azure service principal expiry alert to page bigmac for dex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split `AzureServicePrincipalExpires` alert to page team bigmac in case of dex related service principals.
+
 ## [2.98.3] - 2023-05-24
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
@@ -190,7 +190,7 @@ spec:
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} will expire in less than one month.`}}'
         opsrecipe: azure-service-principals/
-      expr: min(azure_operator_service_principal_token_expiration - time()) by (application_name,subscription_id) < 60*60*24*30
+      expr: min(azure_operator_service_principal_token_expiration{application_name!~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*30
       for: 10m
       labels:
         area: kaas
@@ -202,7 +202,7 @@ spec:
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} is about to expire.`}}'
         opsrecipe: azure-service-principals/
-      expr: min(azure_operator_service_principal_token_expiration - time()) by (application_name,subscription_id) < 60*60*24*7
+      expr: min(azure_operator_service_principal_token_expiration{application_name=!~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.management-cluster.rules.yml
@@ -190,7 +190,7 @@ spec:
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} will expire in less than one month.`}}'
         opsrecipe: azure-service-principals/
-      expr: min(azure_operator_service_principal_token_expiration{application_name!~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*30
+      expr: min(azure_operator_service_principal_token_expiration{application_name!~"dex-operator.*|.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*30
       for: 10m
       labels:
         area: kaas
@@ -202,7 +202,7 @@ spec:
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} is about to expire.`}}'
         opsrecipe: azure-service-principals/
-      expr: min(azure_operator_service_principal_token_expiration{application_name=!~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
+      expr: min(azure_operator_service_principal_token_expiration{application_name!~"dex-operator.*|.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -51,7 +51,7 @@ spec:
       annotations:
         description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} is about to expire.`}}'
         opsrecipe: dex-operator/
-      expr: min(azure_operator_service_principal_token_expiration{application_name=~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
+      expr: min(azure_operator_service_principal_token_expiration{application_name=~"dex-operator.*|.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/dex.rules.yml
@@ -47,3 +47,15 @@ spec:
         severity: page
         team: bigmac
         topic: dex
+    - alert: DexAzureServicePrincipalExpiresInOneWeek
+      annotations:
+        description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} is about to expire.`}}'
+        opsrecipe: dex-operator/
+      expr: min(azure_operator_service_principal_token_expiration{application_name=~"dex-operator.*||.*dex-app"} - time()) by (application_name,subscription_id) < 60*60*24*7
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: bigmac
+        topic: dex


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27066

This PR ensure that phoenix is not paged with expiring service principals for dex (operator) and instead those alerts go to team bigmac

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
