### PR TITLE
Fix query for `WorkloadClusterControlPlaneNodeMissingAWS`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix query for `WorkloadClusterControlPlaneNodeMissingAWS`.
+
 ## [2.98.3] - 2023-05-24
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -46,8 +46,8 @@ spec:
       annotations:
         description: '{{`Control plane node is missing.`}}'
         opsrecipe: master-node-missing/
-      expr: count(kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
-      for: 10m
+      expr: count by (cluster_id) (kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
+      for: 30m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26804

This PR fixes the query for WorkloadClusterControlPlaneNodeMissingAWS and increases the page threshold

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
