### PR TITLE
Add silence-operator reconcile error alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert on Silence operator reconciliation errors.
+
 ## [2.98.4] - 2023-05-25
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/silence-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/silence-operator.rules.yml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: silence-operator
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: silences
+    rules:
+    - alert: "SilenceOperatorReconcileErrors"
+      annotations:
+        description: '{{`silence-operator controller {{ $labels.controller }} too many reconcile errors.`}}'
+        opsrecipe: "silence-operator-reconcile-errors/"
+      expr: |
+        avg_over_time(operatorkit_controller_errors_total{app="silence-operator"}[20m]) > 0
+      for: 1h
+      labels:
+        area: "empowerment"
+        cancel_if_outside_working_hours: "true"
+        installation: {{ .Values.managementCluster.name }}
+        severity: "page"
+        team: "atlas"
+        topic: "observability"

--- a/test/tests/providers/global/silence-operator.rules.test.yml
+++ b/test/tests/providers/global/silence-operator.rules.test.yml
@@ -1,0 +1,28 @@
+---
+rule_files:
+- silence-operator.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'operatorkit_controller_errors_total{app="silence-operator", controller="silence-controller"}'
+        values: "0x30 1+0x20 20x45 20-1x20 0x100"
+    alert_rule_test:
+      - alertname: SilenceOperatorReconcileErrors
+        eval_time: 60m
+      - alertname: SilenceOperatorReconcileErrors
+        eval_time: 95m
+        exp_alerts:
+          - exp_labels:
+              app: silence-operator
+              area: "empowerment"
+              cancel_if_outside_working_hours: "true"
+              controller: silence-controller
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "silence-operator controller silence-controller too many reconcile errors."
+              opsrecipe: "silence-operator-reconcile-errors/"
+      - alertname: SilenceOperatorReconcileErrors
+        eval_time: 215m


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2497

This PR adds a new alert when the silence operator is not able to reconcile silences.

This PR means we need an ops-recipe for the alert

This is missing a test that I will try to add tomorrow

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
