### PR TITLE
Add an aggregation for getting information of how many pods / apps are using PSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new `aggregated metric` to list apps for which pods are annotated with a PSP , this will help us build a list of APPs that need fixing for 1.24 -> 1.25 upgrade
+
 ## [2.100.1] - 2023-06-06
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -371,3 +371,6 @@ spec:
       record: aggregation:container:memory_usage_bytes
     - expr: sum(rate(container_cpu_usage_seconds_total{cluster_type="management_cluster"}[2m])) by (container)
       record: aggregation:container:cpu_usage_cores
+    # PSP Aggregation for monitoring which APPS are using PSP ( exclude some pods that do not have the app.kubernetes.io/name label)
+    - expr: sum by (annotation_kubernetes_io_psp,label_app_kubernetes_io_name, namespace) (kube_pod_annotations{annotation_kubernetes_io_psp=~".+", pod!~"(etcd|kube-apiserver|kube-controller-manager|kube-scheduler|prometheus-operator-app-operator).+"} * on(pod) group_left(label_app_kubernetes_io_name) kube_pod_labels{})
+      record: aggregation:kubernetes:pods_with_psp_annotation


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2533

Requires https://github.com/giantswarm/prometheus-operator-app/pull/298

This PR adds a recording rule to account for pods using ( being annotated ) PSP so we can make sure we address all of those APPs in helm for `conditional rendering` of PSP based on kubernetes version

![image](https://github.com/giantswarm/prometheus-rules/assets/2085772/f90bfe20-b806-470d-ba43-f50d430650d5)


### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
