### PR TITLE
Remove `KiamDaemonsetNotCleanedUp`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `KiamDaemonsetNotCleanedUp`.
+
 ## [2.101.0] - 2023-06-12
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kiam.rules.yml
@@ -27,19 +27,4 @@ spec:
         severity: page
         team: phoenix
         topic: kiam
-    - alert: KiamDaemonsetNotCleanedUp
-      annotations:
-        description: '{{`Kiam daemonset kube-system/{{ $labels.daemonset }} on {{ $labels.installation}}/{{ $labels.cluster_id }} was not deleted after app was removed.`}}'
-        opsrecipe: kiam-daemonset-not-cleaned-up/
-      expr: count(kube_daemonset_created{daemonset=~"kiam-agent|kiam-server|kiam-watchdog"})  by (cluster_id,daemonset,installation) unless on (installation,cluster_id) label_replace(aggregation:giantswarm:app_info{name=~"kiam|kiam-app"}, "cluster_id", "$1", "namespace", "(.*)")
-      for: 60m
-      labels:
-        area: managedservices
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: phoenix
-        topic: kiam
 {{- end }}


### PR DESCRIPTION
For that alert to work, we'd need info from both the MC prometheus ("is the kiam app installed?") and the workload cluster ("is there a kiam-server or kiam-agent daemonset").
This is not possible with our current setup so alerting is impossible.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
