### PR TITLE
Fix description for alert to use the actual label for cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ClusterStatusNotRead` description is missing the cluster name
+
 ## [2.103.0] - 2023-06-14
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/capi-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi-cluster.rules.yml
@@ -34,7 +34,7 @@ spec:
             topic: managementcluster
           annotations:
             description: |-
-              {{`Cluster {{$labels.exported_namespace}}/{{$labels.cluster_name}} is not ready.`}}
+              {{`Cluster {{$labels.exported_namespace}}/{{$labels.name}} is not ready.`}}
             opsrecipe: capi-cluster/
 
         - alert: ClusterPaused

--- a/test/tests/providers/capi/capz/capi-cluster.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-cluster.rules.test.yml
@@ -39,7 +39,7 @@ tests:
               severity: notify
               team: clippy
               topic: managementcluster
-              cluster_name: grumpy
+              name: grumpy
               exported_namespace: giantswarm
               status: "False"
               type: Ready


### PR DESCRIPTION
Right now we are missing the cluste rname into the alert

![image](https://github.com/giantswarm/prometheus-rules/assets/2085772/ab9b2275-8777-4a21-991b-3ffe46674c12)


because the label is `name` and not `cluster_name`

![image](https://github.com/giantswarm/prometheus-rules/assets/2085772/d2d0c7a3-3236-4cfe-b3ed-149603cfe37d)


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
