### PR TITLE
Update rules team to turtles 

### DIFF
--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -39,6 +39,10 @@ phoenix
 {{- end -}}
 {{- end -}}
 
+{{- define "lifecycleTeam" -}}
+turtles
+{{- end -}}
+
 {{- define "workingHoursOnly" -}}
 {{- if has .Values.managementCluster.provider.kind (list "openstack" "capz") -}}
 "true"

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -31,11 +31,9 @@ giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- define "providerTeam" -}}
 {{- if has .Values.managementCluster.provider.kind (list "kvm" "openstack" "cloud-director" "vsphere") -}}
 rocket
-{{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa") -}}
+{{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa" "capz") -}}
 {{- /* hydra alerts merged into phoenix business hours on-call */ -}}
 phoenix
-{{- else if eq .Values.managementCluster.provider.kind "capz" -}}
-clippy
 {{- else -}}
 phoenix
 {{- end -}}

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
@@ -28,7 +28,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster
     - alert: ManagementClusterAPIServerAdmissionWebhookErrors
       annotations:
@@ -40,7 +40,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster
     - alert: ManagementClusterWebhookDurationExceedsTimeout
       annotations:
@@ -52,5 +52,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterAPIServerAdmissionWebhookErrors
       annotations:
@@ -38,7 +38,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
 
     # Webhooks that are not explicitely owner by any team (customer owned ones).

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -40,7 +40,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterControlPlaneNodeMissingAWS
       annotations:
@@ -54,7 +54,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         control_plane_node_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterHAControlPlaneDownForTooLong
       annotations:
@@ -69,7 +69,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         control_plane_node_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterPodPendingAWS
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/azure.workload-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterCriticalPodNotRunningAzure
       annotations:
@@ -33,7 +33,7 @@ spec:
         area: kaas
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterCriticalPodMetricMissingAzure
       annotations:
@@ -45,7 +45,7 @@ spec:
         area: kaas
         cancel_if_kube_state_metrics_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: WorkloadClusterPodLimitAlmostReachedAzure
       annotations:
@@ -75,7 +75,7 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         control_plane_node_down: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
 
     - alert: WorkloadClusterAzureScheduledEventsNotRunning

--- a/helm/prometheus-rules/templates/alerting-rules/capi-kubeadmcontrolplane.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi-kubeadmcontrolplane.rules.yml
@@ -17,7 +17,7 @@ spec:
             area: kaas
             cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
             severity: notify
-            team: {{include "providerTeam" .}}
+            team: {{include "lifecycleTeam" .}}
             topic: managementcluster
           annotations:
             description: |-
@@ -31,7 +31,7 @@ spec:
             area: kaas
             cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
             severity: notify
-            team: {{include "providerTeam" .}}
+            team: {{include "lifecycleTeam" .}}
             topic: managementcluster
           annotations:
             description: |-

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-autoscaler.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: cluster-autoscaler
     - alert: ClusterAutoscalerFailedScaling
       annotations:
@@ -41,6 +41,6 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: cluster-autoscaler
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: ContainerdVolumeSpaceTooLow
       annotations:
@@ -33,7 +33,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -45,7 +45,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -57,7 +57,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -69,7 +69,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: PersistentVolumeSpaceTooLow
       annotations:
@@ -81,7 +81,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -93,7 +93,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: DataDiskPersistentVolumeSpaceTooLow
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
@@ -20,7 +20,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -32,7 +32,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -43,7 +43,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -54,7 +54,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -65,5 +65,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: storage

--- a/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.management-cluster.rules.yml
@@ -21,5 +21,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/docker.workload-cluster.rules.yml
@@ -21,5 +21,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.management-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdDBSizeTooLarge
       annotations:
@@ -33,7 +33,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
@@ -43,7 +43,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdHasNoLeader
       annotations:
@@ -55,7 +55,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: ManagementClusterEtcdMetricsMissing
       annotations:
@@ -67,6 +67,6 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: true
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
 

--- a/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcd.workload-cluster.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_control_plane_node_down: "true"
         cancel_if_kubelet_down: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: WorkloadClusterEtcdCommitDurationTooHigh
       annotations:
@@ -37,7 +37,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: WorkloadClusterEtcdDBSizeTooLarge
       annotations:
@@ -49,7 +49,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: WorkloadClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
@@ -58,7 +58,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: WorkloadClusterEtcdHasNoLeader
       annotations:
@@ -70,7 +70,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: WorkloadClusterEtcdMetricsMissing
       annotations:
@@ -82,5 +82,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: true
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd
     - alert: LatestETCDBackup1DayOld
       annotations:
@@ -36,7 +36,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd-backup
     - alert: LatestETCDBackup2DaysOld
       annotations:
@@ -51,7 +51,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd-backup
     - alert: ManagementClusterNotBackedUp24h
       annotations:
@@ -66,5 +66,5 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: etcd-backup

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -19,7 +19,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{include "providerTeam" .}}
+        team: {{include "lifecycleTeam" .}}
         topic: kubernetes
     - alert: FlowcontrolTooManyRequests
       annotations:
@@ -31,5 +31,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{include "providerTeam" .}}
+        team: {{include "lifecycleTeam" .}}
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -46,7 +46,7 @@ spec:
       labels:
         area: empowerment
         apiserver_down: "true"
-        team: phoenix
+        team: {{ include "lifecycleTeam" . }}
         topic: monitoring
     {{- if or (eq .Values.managementCluster.provider.kind "azure") (eq .Values.managementCluster.provider.kind "aws") }}
     - alert: InhibitionClusterWithoutWorkerNodes

--- a/helm/prometheus-rules/templates/alerting-rules/kubelet.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kubelet.management-cluster.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster
     - alert: KubeletDockerOperationsErrorsTooHigh
       annotations:
@@ -40,7 +40,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
@@ -55,7 +55,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
@@ -70,5 +70,5 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: managementcluster

--- a/helm/prometheus-rules/templates/alerting-rules/kubelet.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kubelet.workload-cluster.rules.yml
@@ -24,7 +24,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: KubeletDockerOperationsErrorsTooHigh
       annotations:
@@ -38,7 +38,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
@@ -52,7 +52,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
@@ -66,5 +66,5 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes

--- a/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: NodeHasConstantOOMKills
       annotations:
@@ -46,7 +46,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
@@ -58,7 +58,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: MachineEntropyTooLow
       annotations:
@@ -70,7 +70,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     - alert: MachineAllocatedFileDescriptorsTooHigh
       annotations:
@@ -82,7 +82,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     # Alert if load average is 2 times the number of CPUs.
     - alert: MachineLoadTooHigh
@@ -94,7 +94,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     - alert: MachineMemoryUsageTooHigh
       annotations:
@@ -105,5 +105,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -23,7 +23,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: AWSWorkloadClusterNodeTooManyAutoTermination
       annotations:
@@ -59,7 +59,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: NodeHasConstantOOMKills
       # Check if a core component is restarted because memory reasons
@@ -74,7 +74,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
@@ -86,7 +86,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: kubernetes
     - alert: MachineEntropyTooLow
       annotations:
@@ -98,7 +98,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     - alert: MachineAllocatedFileDescriptorsTooHigh
       annotations:
@@ -110,7 +110,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     {{- if eq .Values.managementCluster.provider.kind "aws" }}
     - alert: WorkloadClusterNodeUnexpectedTaintNodeWithImpairedVolumes

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.management-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     - alert: ManagementClusterDisabledSystemdUnitActive
       annotations:
@@ -33,5 +33,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/systemd.workload-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure
     - alert: WorkloadClusterDisabledSystemdUnitActive
       annotations:
@@ -33,5 +33,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure

--- a/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/timesync.rules.yml
@@ -20,5 +20,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: {{ include "lifecycleTeam" . }}
         topic: infrastructure


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26997

- clippy is no more, change capz providerteam to phoenix
- Initial work on changing rules ownership to turtles

Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
