### PR TITLE
Support overwriting apiserver_flowcontrol_request_concurrency_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Ingress Controller: Rename `IngressControllerDown` recipe. ([#793](https://github.com/giantswarm/prometheus-rules/pull/793))
+- Respect also `apiserver_flowcontrol_request_concurrency_limit_overwrite` metric for `FlowcontrolTooManyRequests` alerts.
 
 ## [2.103.0] - 2023-06-14
 

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -26,6 +26,8 @@ spec:
         description: '{{`Cluster {{ $labels.installation }}/{{ $labels.cluster_id }}: there are too many API requests for flow schema {{ $labels.flow_schema }}.`}}'
         opsrecipe: flowcontrol-rejected-requests/
       expr: sum(irate(apiserver_flowcontrol_dispatched_requests_total[1m])) by (priority_level) > (min by(priority_level) (apiserver_flowcontrol_request_concurrency_limit_overwrite) OR min by(priority_level) (apiserver_flowcontrol_request_concurrency_limit))
+      for: 15m
+      labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page

--- a/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fairness.rules.yml
@@ -25,9 +25,7 @@ spec:
       annotations:
         description: '{{`Cluster {{ $labels.installation }}/{{ $labels.cluster_id }}: there are too many API requests for flow schema {{ $labels.flow_schema }}.`}}'
         opsrecipe: flowcontrol-rejected-requests/
-      expr: sum(irate(apiserver_flowcontrol_dispatched_requests_total[1m])) by (priority_level) > min(apiserver_flowcontrol_request_concurrency_limit) by (priority_level)
-      for: 15m
-      labels:
+      expr: sum(irate(apiserver_flowcontrol_dispatched_requests_total[1m])) by (priority_level) > (min by(priority_level) (apiserver_flowcontrol_request_concurrency_limit_overwrite) OR min by(priority_level) (apiserver_flowcontrol_request_concurrency_limit))
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page


### PR DESCRIPTION
Towards:  https://github.com/giantswarm/giantswarm/issues/27281
Explanation: https://github.com/giantswarm/giantswarm/issues/27281#issuecomment-1598715483

Shortly, we want to be able to overwrite apiserver_flowcontrol_request_concurrency_limit metric in old&buggy k8s clusters for FlowcontrolTooManyRequests alerts.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
