### PR TITLE
Add missing cluster_id label for PromAvailabilityRation alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing cluster-id label to the PrometheusAvailabilityRatio alert.
+
 ## [2.104.0] - 2023-06-21
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-availability.rules.yml
@@ -16,7 +16,7 @@ spec:
         description: '{{`Prometheus {{$labels.pod}} has availability ratio of {{ printf "%.2f" $value }} (min 0.8) over the last hour.`}}'
         opsrecipe: prometheus-resource-limit-reached/
         dashboard: promavailability/prometheus-availability
-      expr: avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[1h])) by (pod) < 0.8
+      expr: label_replace(avg(avg_over_time(kube_pod_status_ready{namespace=~"(.*)-prometheus", condition="true"}[1h])) by (pod), "cluster_id", "$1", "pod", "prometheus-(.+)-(.+)") < 0.8
       # At startup, availability starts at 0 for a few minutes. So ratio grows slowly from 0.
       for: 30m
       labels:

--- a/test/tests/providers/global/prometheus-availability.rules.test.yml
+++ b/test/tests/providers/global/prometheus-availability.rules.test.yml
@@ -35,6 +35,7 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
               pod: "prometheus-wcbad-0"
+              cluster_id: wcbad
             exp_annotations:
               description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
               opsrecipe: "prometheus-resource-limit-reached/"
@@ -54,6 +55,7 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
               pod: "prometheus-wcbad-0"
+              cluster_id: wcbad
             exp_annotations:
               description: "Prometheus prometheus-wcbad-0 has availability ratio of 0.00 (min 0.8) over the last hour."
               opsrecipe: "prometheus-resource-limit-reached/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27271

This PR adds the missing cluster id label for the PrometheusAvailabilityRation alert

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [X] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
