### PR TITLE
Add alerts for legacy vault's etcd backups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alerts for legacy vault's etcd backups. 
+
 ## [2.105.0] - 2023-06-22
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -98,7 +98,7 @@ spec:
         topic: vault
     - alert: VaultLatestEtcdBackupMetricsMissing
       annotations:
-        description: '{{`etcd backup metrics for vault absent on {{ $labels.installation }}.`}}'
+        description: '{{`etcd backup metrics for vault absent.`}}'
         opsrecipe: vault-backup/
       expr: absent(vault_etcd_backups_exporter_latest_successful_backup_time) == 1
       for: 120m

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -84,4 +84,29 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: vault
+    - alert: VaultLatestEtcdBackupTooOld
+      annotations:
+        description: '{{`Latest etcd backup for vault on {{ $labels.installation }} is more than 48h old.`}}'
+        opsrecipe: absent-metrics/
+      expr: (time() - vault_etcd_backups_exporter_latest_successful_backup_time) / 60 / 60 > 48
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: true
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: vault
+    - alert: VaultLatestEtcdBackupMetricsMissing
+      annotations:
+        description: '{{`etcd backup metrics for vault absent on {{ $labels.installation }}.`}}'
+        opsrecipe: absent-metrics/
+      expr: absent(vault_etcd_backups_exporter_latest_successful_backup_time) == 1
+      for: 120m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: true
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: vault
+
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vault.rules.yml
@@ -87,7 +87,7 @@ spec:
     - alert: VaultLatestEtcdBackupTooOld
       annotations:
         description: '{{`Latest etcd backup for vault on {{ $labels.installation }} is more than 48h old.`}}'
-        opsrecipe: absent-metrics/
+        opsrecipe: vault-backup/
       expr: (time() - vault_etcd_backups_exporter_latest_successful_backup_time) / 60 / 60 > 48
       for: 5m
       labels:
@@ -99,7 +99,7 @@ spec:
     - alert: VaultLatestEtcdBackupMetricsMissing
       annotations:
         description: '{{`etcd backup metrics for vault absent on {{ $labels.installation }}.`}}'
-        opsrecipe: absent-metrics/
+        opsrecipe: vault-backup/
       expr: absent(vault_etcd_backups_exporter_latest_successful_backup_time) == 1
       for: 120m
       labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27314

This PR adds an alert when etcd backup for legacy vault is too old or metrics are missing

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
