### PR TITLE
Fix missing slos to add the service back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `for` setting of `WorkloadClusterCriticalPodNotRunningAWS` to 20 minutes.
+- Remove duplicate workload_name label in favor of existing daemonset|statefulset|deployment labels.
 
 ## [2.107.0] - 2023-06-26
 

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -146,7 +146,7 @@ spec:
         topic: kubernetes
     - alert: ManagementClusterDeploymentMissingAWS
       annotations:
-        description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
+        description: '{{`Deployment {{ $labels.deployment }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/
       expr: absent(kube_deployment_status_condition{namespace="giantswarm", condition="Available", deployment="aws-admission-controller"})
       for: 5m

--- a/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/gcp.management-cluster.rules.yml
@@ -45,7 +45,7 @@ spec:
         topic: kubernetes
     - alert: ManagementClusterDeploymentMissingGCP
       annotations:
-        description: '{{`Deployment {{ $labels.workload_name }} is missing.`}}'
+        description: '{{`Deployment {{ $labels.deployment }} is missing.`}}'
         opsrecipe: management-cluster-deployment-is-missing/
       expr: absent(kube_deployment_status_condition{namespace=~"giantswarm|kube-system", condition="Available", deployment=~"capi-controller-manager.*|capg-controller-manager.*|capi-kubeadm-bootstrap-controller-manager.*|capi-kubeadm-control-plane-controller-manager.*|dns-operator-gcp.*|.*workload-identity-operator-gcp.*"})
       for: 5m

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -275,13 +275,6 @@ spec:
       record: aggregation:prometheus:memory_percentage
     - expr: sum(label_replace(container_memory_working_set_bytes{container='prometheus', namespace=~'.*-prometheus'}, "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)")) by (cluster_type , cluster_id)
       record: aggregation:prometheus:memory_usage
-  - name: managed-apps.grafana-cloud.recording
-    rules:
-    # Managed apps basic SLI metrics
-    - expr: sum(monitoring:managed_apps:service_level:primary:error_budget_used) by (cluster_type, cluster_id,workload_name,workload_type) >= 1
-      record: aggregation:managed_apps:service_level:basic:error_budget_depleted
-    - expr: sum(monitoring:managed_apps:service_level:primary:error_budget_used) by (cluster_type, cluster_id,workload_name,workload_type) >= 0.75
-      record: aggregation:managed_apps:service_level:basic:error_budget_low
   - name: dex.grafana-cloud.recording
     rules:    
     # Dex activity and status based on ingress controller data

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -42,7 +42,7 @@ spec:
     - expr: |
         label_replace(
           kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|kiam-server|kiam-agent|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node|cilium"},
-        "service", "$1", "workload_name", "(.*)" )
+        "service", "$1", "daemonset", "(.*)" )
       labels:
         class: MEDIUM
         area: kaas
@@ -55,11 +55,11 @@ spec:
           (
             label_replace(
               kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|kiam-server|kiam-agent|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node|cilium"},
-              "service", "$1", "workload_name", "(.*)" ) > 0
+              "service", "$1", "daemonset", "(.*)" ) > 0
             and on (daemonset, node)
             label_replace(
               kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|kiam-server|kiam-agent|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node|cilium"} offset 10m,
-              "service", "$1", "workload_name", "(.*)" ) > 0
+              "service", "$1", "daemonset", "(.*)" ) > 0
           )
           and
           on (node) kube_node_spec_unschedulable == 0
@@ -164,9 +164,9 @@ spec:
         kube_daemonset_labels * on (daemonset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_daemonset_status_number_unavailable
-            and on(daemonset,cluster_id,cluster_type,namespace,workload_name)
+            and on(daemonset,cluster_id,cluster_type,namespace)
             kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "daemonset", "(.*)" )
         )
       labels:
         class: MEDIUM
@@ -177,9 +177,9 @@ spec:
         kube_deployment_labels * on (deployment, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_deployment_status_replicas_unavailable
-            and on(deployment,cluster_id,cluster_type,namespace, workload_name)
+            and on(deployment,cluster_id,cluster_type,namespace)
             kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "deployment", "(.*)" )
         )
       labels:
         class: MEDIUM
@@ -190,9 +190,9 @@ spec:
         kube_statefulset_labels * on (statefulset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_statefulset_status_replicas - kube_statefulset_status_replicas_current
-            and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
+            and on(statefulset,cluster_id,cluster_type,namespace)
             kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "statefulset", "(.*)" )
         )
       labels:
         class: MEDIUM
@@ -203,9 +203,9 @@ spec:
         kube_daemonset_labels * on (daemonset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_daemonset_status_desired_number_scheduled
-            and on(daemonset,cluster_id,cluster_type,namespace, workload_name)
+            and on(daemonset,cluster_id,cluster_type,namespace)
             kube_daemonset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "daemonset", "(.*)" )
         )
       labels:
         class: MEDIUM
@@ -215,9 +215,9 @@ spec:
         kube_deployment_labels * on (deployment, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_deployment_status_replicas
-            and on(deployment,cluster_id,cluster_type,namespace, workload_name)
+            and on(deployment,cluster_id,cluster_type,namespace)
             kube_deployment_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "deployment", "(.*)" )
         )
       labels:
         class: MEDIUM
@@ -227,9 +227,9 @@ spec:
         kube_statefulset_labels * on (statefulset, namespace) group_right(label_application_giantswarm_io_team) (
           label_replace(
             kube_statefulset_status_replicas
-            and on(statefulset,cluster_id,cluster_type,namespace, workload_name)
+            and on(statefulset,cluster_id,cluster_type,namespace)
             kube_statefulset_labels{label_giantswarm_io_monitoring_basic_sli='true'},
-          "service", "$1", "workload_name", "(.*)" )
+          "service", "$1", "statefulset", "(.*)" )
         )
       labels:
         class: MEDIUM

--- a/test/tests/providers/global/crossplane.rules.test.yml
+++ b/test/tests/providers/global/crossplane.rules.test.yml
@@ -5,7 +5,7 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="crossplane", installation="gauss", instance="100.64.5.122:8080", job="gauss-prometheus/workload-gauss/0", namespace="crossplane", node="ip-10-0-5-119.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-95bbb4bd7-v6hvh", provider="aws", service_priority="highest", workload_name="crossplane", workload_type="deployment"}'
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="crossplane", installation="gauss", instance="100.64.5.122:8080", job="gauss-prometheus/workload-gauss/0", namespace="crossplane", node="ip-10-0-5-119.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-95bbb4bd7-v6hvh", provider="aws", service_priority="highest"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
       - alertname: DeploymentNotSatisfiedCrossplane
@@ -36,14 +36,12 @@ tests:
               severity: page
               team: honeybadger
               topic: managementcluster
-              workload_name: crossplane
-              workload_type: deployment
             exp_annotations:
               description: "Crossplane related deployment crossplane/crossplane is not satisfied."
               opsrecipe: "deployment-not-satisfied/"
   - interval: 1m
     input_series:
-      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="caicloud-event-exporter", installation="gauss", instance="100.64.5.122:8080", job="gauss-prometheus/workload-gauss/0", namespace="crossplane", node="ip-10-0-5-119.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-95bbb4bd7-v6hvh", provider="aws", service_priority="highest", workload_name="caicloud-event-exporter", workload_type="deployment"}'
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="caicloud-event-exporter", installation="gauss", instance="100.64.5.122:8080", job="gauss-prometheus/workload-gauss/0", namespace="crossplane", node="ip-10-0-5-119.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-95bbb4bd7-v6hvh", provider="aws", service_priority="highest"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
       - alertname: DeploymentNotSatisfiedCrossplane
@@ -74,8 +72,6 @@ tests:
               severity: page
               team: honeybadger
               topic: managementcluster
-              workload_name: caicloud-event-exporter
-              workload_type: deployment
             exp_annotations:
               description: "Crossplane related deployment crossplane/caicloud-event-exporter is not satisfied."
               opsrecipe: "deployment-not-satisfied/"

--- a/test/tests/providers/global/external-secrets.rules.test.yml
+++ b/test/tests/providers/global/external-secrets.rules.test.yml
@@ -5,7 +5,7 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets", workload_type="deployment"}'
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
       - alertname: DeploymentNotSatisfiedExternalSecrets
@@ -36,14 +36,12 @@ tests:
               severity: page
               team: honeybadger
               topic: managementcluster
-              workload_name: external-secrets
-              workload_type: deployment
             exp_annotations:
               description: "ExternalSecrets related deployment external-secrets/external-secrets is not satisfied."
               opsrecipe: "deployment-not-satisfied/"
   - interval: 1m
     input_series:
-      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-cert-controller", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-cert-controller", workload_type="deployment"}'
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-cert-controller", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
       - alertname: DeploymentNotSatisfiedExternalSecrets
@@ -74,14 +72,12 @@ tests:
               severity: page
               team: honeybadger
               topic: managementcluster
-              workload_name: external-secrets-cert-controller
-              workload_type: deployment
             exp_annotations:
               description: "ExternalSecrets related deployment external-secrets/external-secrets-cert-controller is not satisfied."
               opsrecipe: "deployment-not-satisfied/"
   - interval: 1m
     input_series:
-      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-webhook", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest", workload_name="external-secrets-webhook", workload_type="deployment"}'
+      - series: 'kube_deployment_status_replicas_unavailable{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", deployment="external-secrets-webhook", installation="gauss", instance="100.64.6.226:8080", job="gauss-prometheus/workload-gauss/0", namespace="external-secrets", node="ip-10-0-5-161.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-fd99568b6-fnhdv", provider="aws", service_priority="highest"}'
         values: "0+0x20 1+0x100"
     alert_rule_test:
       - alertname: DeploymentNotSatisfiedExternalSecrets
@@ -112,8 +108,6 @@ tests:
               severity: page
               team: honeybadger
               topic: managementcluster
-              workload_name: external-secrets-webhook
-              workload_type: deployment
             exp_annotations:
               description: "ExternalSecrets related deployment external-secrets/external-secrets-webhook is not satisfied."
               opsrecipe: "deployment-not-satisfied/"


### PR DESCRIPTION
This PR fixes the legacy slo framework as the service label is currently missing because the originally used labels are not added correctly by KSM https://giantswarm.app.opsgenie.com/alert/detail/757d8fcf-819a-437e-ba1a-45ecd323edad-1687870348973/details

See https://gigantic.slack.com/archives/C01176DKNP4/p1687872689152039

As the workload_name and workload_type labels are actually unused outside of the slo framework nowadays, this PR also removes them

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
