### PR TITLE
Send Kyverno policy configuration status to Grafana Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add dashboard link to `ServiceLevelBurnRateTooHigh` alert
+- Add dashboard link to `ServiceLevelBurnRateTooHigh` alert.
+- Ship Kyverno policy enforcement status to Grafana Cloud.
 
 ## [2.108.0] - 2023-06-28
 

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -307,7 +307,10 @@ spec:
     # Kyverno-related resource counts by kind
     - expr: sum(etcd_kubernetes_resources_count{kind=~".*.kyverno.io|clusterpolicyreports.wgpolicyk8s.io|policyreports.wgpolicyk8s.io"}) by (cluster_id, kind)
       record: aggregation:kyverno_resource_counts
-    # Kyverno policy status by team - Deployments
+    # Kyverno policy enforcement status
+    - expr: sum(kyverno_policy) by (background, category, kind, policy, rule, type, validationFailureAction)
+      record: aggregation:kyverno_policy_status
+    # Kyverno policy workload status by team - Deployments
     - expr: |-
         label_join(
           sum(
@@ -329,7 +332,7 @@ spec:
           ) by (team, deployment, app),
         "name", ",", "deployment")
       record: aggregation:kyverno_policy_deployment_status_team
-    # Kyverno policy status by team - DaemonSets
+    # Kyverno policy workload status by team - DaemonSets
     - expr: |-
         label_join(
           sum(
@@ -351,7 +354,7 @@ spec:
           ) by (team, daemonset, app),
         "name", ",", "daemonset")
       record: aggregation:kyverno_policy_daemonset_status_team
-    # Kyverno policy status by team - StatefulSets
+    # Kyverno policy workload status by team - StatefulSets
     - expr: |-
         label_join(
           sum(
@@ -373,7 +376,7 @@ spec:
           ) by (team, statefulset, app),
         "name", ",", "statefulset")
       record: aggregation:kyverno_policy_statefulset_status_team
-    # Kyverno policy status by team - Job
+    # Kyverno policy workload status by team - Job
     - expr: |-
         label_join(
           sum(
@@ -395,7 +398,7 @@ spec:
           ) by (team, job, app),
         "name", ",", "job")
       record: aggregation:kyverno_policy_job_status_team
-    # Kyverno policy status by team - CronJob
+    # Kyverno policy workload status by team - CronJob
     - expr: |-
         label_join(
           sum(


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26857

This PR sends information about the configured state of Kyverno policies to Grafana cloud. This will enable visualizing when policies change state (e.g. from audit to enforce) and help identify gaps in the rollout or in policy coverage.

The series look like:
```
{background="true", kind="ClusterPolicy",policy="disallow-capabilities",rule="adding-capabilities",type="validation",validationFailureAction="Enforce",category="Pod Security Standards (Baseline)"}
```

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
