### PR TITLE
Add two alerts for ALB role errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add two new alerts for ALB role errors.
 - Add dashboard link to `ServiceLevelBurnRateTooHigh` alert.
 - Ship Kyverno policy enforcement status to Grafana Cloud.
 

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -1,0 +1,45 @@
+{{- if eq .Values.managementCluster.provider.kind "aws" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "workload_cluster"
+  name: aws-load-balancer-controller.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: aws-load-balancer-controller
+    rules:
+    - alert: AWSLoadBalacerAssumeRoleErrors
+      annotations:
+        description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} can not assume the role.`}}'
+        opsrecipe: alb-role-errors#assume-role-errors
+      expr: increase(aws_api_calls_total{error_code="WebIdentityErr"}[20m]) > 0
+      for: 40m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: phoenix
+        topic: alb
+    - alert: AWSLoadBalacerRolePolicyErrors
+      annotations:
+        description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has a wrong role policy.`}}'
+        opsrecipe: alb-role-errors#role-policy-errors
+      expr: increase(aws_api_calls_total{error_code="UnauthorizedOperation"}[20m]) > 0
+      for: 40m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: phoenix
+        topic: alb
+{{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -12,7 +12,7 @@ spec:
   groups:
   - name: aws-load-balancer-controller
     rules:
-    - alert: AWSLoadBalacerAssumeRoleErrors
+    - alert: AWSLoadBalancerAssumeRoleErrors
       annotations:
         description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} can not assume the role.`}}'
         opsrecipe: alb-role-errors#assume-role-errors
@@ -27,7 +27,7 @@ spec:
         severity: page
         team: phoenix
         topic: alb
-    - alert: AWSLoadBalacerRolePolicyErrors
+    - alert: AWSLoadBalancerRolePolicyErrors
       annotations:
         description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has a wrong role policy.`}}'
         opsrecipe: alb-role-errors#role-policy-errors


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27249

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
