### PR TITLE
SLO notification in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
+SLO helps you both increase the quality of your monitoring and reduce the alert noise.
+
+* How to creat a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
+* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/
+
+---
 Towards: https://github.com/giantswarm/...
 
 This PR ...


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27259

This PR update the PR template in order to notify people to create SLO instead of adding alerting rules into this repository.