### PR TITLE
Fix Kyverno recording rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change `ManagementClusterAPIServerAdmissionWebhookErrors` severity to page.
 - CAPA alerts only during business hours.
+- Fix Kyverno recording rule to ignore WorkloadCluster Apps.
 
 ## [2.109.0] - 2023-06-30
 

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -327,7 +327,7 @@ spec:
             ) by (deployment, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{namespace="giantswarm", team!="noteam"}
+              app_operator_app_info{namespace=~".*giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, deployment, app),
         "name", ",", "deployment")
@@ -349,7 +349,7 @@ spec:
             ) by (daemonset, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{team!="noteam"}
+              app_operator_app_info{namespace=~".*giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, daemonset, app),
         "name", ",", "daemonset")
@@ -371,7 +371,7 @@ spec:
             ) by (statefulset, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{team!="noteam"}
+              app_operator_app_info{namespace=~".*giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, statefulset, app),
         "name", ",", "statefulset")
@@ -393,7 +393,7 @@ spec:
             ) by (job, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{team!="noteam"}
+              app_operator_app_info{namespace=~".*giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, job, app),
         "name", ",", "job")
@@ -415,7 +415,7 @@ spec:
             ) by (cronjob, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{team!="noteam"}
+              app_operator_app_info{namespace=~".*giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, cronjob, app),
         "name", ",", "cronjob")

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -327,7 +327,7 @@ spec:
             ) by (deployment, app) 
             * on(app) group_left(team) 
             sum(
-              app_operator_app_info{team!="noteam"}
+              app_operator_app_info{namespace="giantswarm", team!="noteam"}
             ) by (app, team)
           ) by (team, deployment, app),
         "name", ",", "deployment")


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C05FZLLNXCK/p1688730483478609

This PR fixes the Kyverno recording rule when an App has multiple owners. since we are getting reports from only Management Clusters, 
we decided to look for Apps inside the `giantswarm` namespace.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
