### PR TITLE
Make `CoreDNSLatencyTooHigh` alert page rather than notify.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `ManagementClusterAPIServerAdmissionWebhookErrors` severity to page.
 - CAPA alerts only during business hours.
 - Fix Kyverno recording rule to ignore WorkloadCluster Apps.
+- Make `CoreDNSLatencyTooHigh` alert page rather than notify.
 
 ## [2.109.0] - 2023-06-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -53,7 +53,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
+        severity: page
         team: {{ include "providerTeam" . }}
         topic: dns
     - alert: CoreDNSDeploymentNotSatisfied


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27506

This PR make the CoreDNSLatencyTooHigh page rather than just notifìy

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
