### PR TITLE
stable-testing pipeline only page during working hours.

### DIFF
--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -44,6 +44,8 @@ phoenix
 {{- define "workingHoursOnly" -}}
 {{- if has .Values.managementCluster.provider.kind (list "openstack" "capz" "capa") -}}
 "true"
+{{- else if .Values.managementCluster.pipeline (list "stable-testing") -}}
+"true"
 {{- else -}}
 "false"
 {{- end -}}

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -44,7 +44,7 @@ phoenix
 {{- define "workingHoursOnly" -}}
 {{- if has .Values.managementCluster.provider.kind (list "openstack" "capz" "capa") -}}
 "true"
-{{- else if .Values.managementCluster.pipeline "stable-testing" -}}
+{{- else if eq .Values.managementCluster.pipeline "stable-testing" -}}
 "true"
 {{- else -}}
 "false"

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -44,7 +44,7 @@ phoenix
 {{- define "workingHoursOnly" -}}
 {{- if has .Values.managementCluster.provider.kind (list "openstack" "capz" "capa") -}}
 "true"
-{{- else if .Values.managementCluster.pipeline (list "stable-testing") -}}
+{{- else if .Values.managementCluster.pipeline "stable-testing" -}}
 "true"
 {{- else -}}
 "false"


### PR DESCRIPTION
---
Towards: https://github.com/giantswarm/giantswarm/issues/26718

Add support for stable-testing pipeline type to only page during working hours.

Other changes related. 
- https://github.com/giantswarm/config/pull/1877
- https://github.com/giantswarm/installations/pull/2208

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
