### PR TITLE
Vpa restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add cilium BPF map monitoring.
+- Add `VpaComponentTooManyRestarts` alerting rule.
 
 ## [2.112.0] - 2023-07-13
 

--- a/helm/prometheus-rules/templates/alerting-rules/vpa-too-many-restart.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa-too-many-restart.rules.yml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: grafana.all.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: vpa
+    rules:
+    - alert: VpaComponentTooManyRestarts
+      annotations:
+        description: This pages when one of the vpa's component has restarted too much over the last 10min.
+        opsrecipe: vpa-component-too-many-restarts/
+      expr: |
+        1 - sum(increase(kube_pod_container_status_restarts_total{container=~"recommender|updater|admission-controller"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100
+          or
+        1 - sum(increase(kube_pod_container_status_restarts_total{container="vertical-pod-autoscaler-app"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100
+          < 0.98
+      for: 10m
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_scrape_timeout: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
@@ -14,10 +14,9 @@ spec:
         description: This pages when one of the vpa's component has restarted too much over the last 10min.
         opsrecipe: vpa-component-too-many-restarts/
       expr: |
-        1 - sum(increase(kube_pod_container_status_restarts_total{container=~"recommender|updater|admission-controller"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100
+        1 - sum(increase(kube_pod_container_status_restarts_total{container=~"recommender|updater|admission-controller"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100 < 0.98
           or
-        1 - sum(increase(kube_pod_container_status_restarts_total{container="vertical-pod-autoscaler-app"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100
-          < 0.98
+        1 - sum(increase(kube_pod_container_status_restarts_total{container="vertical-pod-autoscaler-app"}[10m])) by (container, cluster_id, cluster_type, customer, installation, pipeline, provider, region)/100 < 0.98
       for: 10m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
@@ -3,7 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: grafana.all.rules
+  name: vpa.all.rules
   namespace: {{ .Values.namespace }}
 spec:
   groups:

--- a/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_outside_working_hours: "false"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
         topic: observability


### PR DESCRIPTION
This PR aims to provide an alerting rule which pages when one of the VPA's component has been restarting too much over a short period of time. 

It will override the [corresponding SLO](https://github.com/giantswarm/sloth-rules/blob/main/areas/platform/teams/atlas/vertical-pod-autoscaler/slos/vpa-component-restarts.yaml) which will be replace by another, more adequate alert.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
