### PR TITLE
 Add `DNSRequestDurationTooSlow` to catch slow DNS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `DNSRequestDurationTooSlow` to catch slow DNS.
+
+### Removed
+
+- Remove `CoreDNSLoadUnbalanced` alert.
+- Remove `CoreDNSCPUUsageTooHigh` alert.
+
 ## [2.113.0] - 2023-07-18
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -10,17 +10,6 @@ spec:
   groups:
   - name: coredns
     rules:
-    - alert: CoreDNSCPUUsageTooHigh
-      annotations:
-        description: '{{`CoreDNS CPU usage is too high.`}}'
-      expr: rate(container_cpu_user_seconds_total{pod=~"coredns-.*"}[5m]) > 0.15
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
-        team: {{ include "providerTeam" . }}
-        topic: observability
     - alert: CoreDNSDeploymentNotSatisfied
       annotations:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
@@ -46,18 +35,17 @@ spec:
         topic: dns
       annotations:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled to its maximum replica count for too long.`}}'
-    # This alert checks the percentage of the dns requests that are handled by a single pod. The result of the query should always be 0 (that means load is spread evenly between all coredns pods).
-    # If it's > 20 for 10 minutes there is something weird happening in the cluster.
-    # This is only relevant if there is a meaningful number of DNS requests happening
-    - alert: CoreDNSLoadUnbalanced
-      expr: sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) > 10 AND (sum by(cluster_id,pod) (rate(coredns_dns_requests_total[10m])) / ignoring(pod) group_left sum by (cluster_id) (rate(coredns_dns_requests_total[10m])) * 100) - ignoring(pod) group_left 100 / sum by (cluster_id) (kube_deployment_status_replicas{deployment=~"coredns|coredns-cp"}) > 20
-      for: 10m
+    - alert: DNSRequestDurationTooSlow
+      expr: histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{app="coredns"}[5m])) by (le)) > 1
+      for: 15m
       labels:
         area: kaas
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: {{ include "providerTeam" . }}
         topic: dns
       annotations:
-        description: '{{`CoreDNS Load has been unbalanced for more than 10m.`}}'
-        opsrecipe: core-dns-unbalanced/
+        description: '{{`CoreDNS requests are taking more than 1 second to be responded.`}}'
+        opsrecipe: dns-request-duration-too-slow/
+        dashboard: Yu9tkufmk/dns
+
+


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27506

add new alert that fires when 99th percentile of coredns name resolution takes more than 1s for 15m straight.

Note: we have a similar SLO alert for DNS latency, but that is BH only and we would like to have this temporary alert until we promote the other one to 24h alert