### PR TITLE
Fix 'KubeStateMetricsDown' inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `KubeStateMetricsDown` inhibition.
+
 ## [2.114.0] - 2023-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- New alert `KubeStateMetricsSlow` that inhibits KSM related alerts.
+
 ### Fixed
 
 - Fix `KubeStateMetricsDown` inhibition.

--- a/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
@@ -10,10 +10,28 @@ spec:
   groups:
   - name: kube-state-metrics
     rules:
+    - alert: KubeStateMetricsSlow
+      annotations:
+        description: '{{`KubeStateMetrics ({{ $labels.instance }}) is too slow.`}}'
+        opsrecipe: kube-state-metrics-down/
+      expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{handler="metrics", job="kube-state-metrics"}[5m])) by (le, cluster_id)) > 7
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        inhibit_kube_state_metrics_down: "true"
+        cancel_if_kubelet_down: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
     - alert: KubeConfigMapCreatedMetricMissing
       annotations:
         description: '{{`kube_configmap_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_configmap_created{})
       for: 30m
       labels:
@@ -26,7 +44,7 @@ spec:
     - alert: KubeDaemonSetCreatedMetricMissing
       annotations:
         description: '{{`kube_daemonset_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_daemonset_created{})
       for: 30m
       labels:
@@ -39,7 +57,7 @@ spec:
     - alert: KubeDeploymentCreatedMetricMissing
       annotations:
         description: '{{`kube_deployment_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_deployment_created{})
       for: 30m
       labels:
@@ -52,7 +70,7 @@ spec:
     - alert: KubeEndpointCreatedMetricMissing
       annotations:
         description: '{{`kube_endpoint_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_endpoint_created{})
       for: 30m
       labels:
@@ -65,7 +83,7 @@ spec:
     - alert: KubeNamespaceCreatedMetricMissing
       annotations:
         description: '{{`kube_namespace_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_namespace_created{})
       for: 30m
       labels:
@@ -78,7 +96,7 @@ spec:
     - alert: KubeNodeCreatedMetricMissing
       annotations:
         description: '{{`kube_node_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_node_created{})
       for: 30m
       labels:
@@ -91,7 +109,7 @@ spec:
     - alert: KubePodCreatedMetricMissing
       annotations:
         description: '{{`kube_pod_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_pod_created{})
       for: 30m
       labels:
@@ -104,7 +122,7 @@ spec:
     - alert: KubeReplicaSetCreatedMetricMissing
       annotations:
         description: '{{`kube_replicaset_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_replicaset_created{})
       for: 30m
       labels:
@@ -117,7 +135,7 @@ spec:
     - alert: KubeSecretCreatedMetricMissing
       annotations:
         description: '{{`kube_secret_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_secret_created{})
       for: 30m
       labels:
@@ -130,7 +148,7 @@ spec:
     - alert: KubeServiceCreatedMetricMissing
       annotations:
         description: '{{`kube_service_created metric is missing for cluster {{ $labels.cluster_id }}.`}}'
-        opsrecipe: kube-steate-metrics-metrics-missing/
+        opsrecipe: kube-state-metrics-down/
       expr: absent(kube_service_created{})
       for: 30m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -48,7 +48,7 @@ spec:
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'
         opsrecipe: kube-state-metrics-down/
-      expr: label_replace(up{app="kube-state-metrics"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0  or absent(up{app="kube-state-metrics"} == 1)
+      expr: label_replace(up{app="kube-state-metrics", endpoint="http"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0  or absent(up{app="kube-state-metrics", endpoint="http"} == 1)
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27483


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
