### PR TITLE
Switch HighNumberOfAllocatedSockets and HighNumberOfOrphanedSockets from Rocket to provider teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch `HighNumberOfAllocatedSockets` and `HighNumberOfOrphanedSockets` from Rocket to provider teams.
+
 ## [2.115.1] - 2023-07-20
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -74,7 +74,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: network
     - alert: HighNumberOfOrphanedSockets
       annotations:
@@ -87,5 +87,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: rocket
+        team: {{ include "providerTeam" . }}
         topic: network


### PR DESCRIPTION
This PR:

- assigns HighNumberOfAllocatedSockets and HighNumberOfOrphanedSockets from Rocket to provider teams variable
.
### Checklist

- [x] Update CHANGELOG.md
