### PR TITLE
Assign clippy alerts to phoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Assign `clippy` rules to `phoenix`.
+
 ## [2.116.0] - 2023-07-20
 
 ### Fixed

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -31,11 +31,9 @@ giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- define "providerTeam" -}}
 {{- if has .Values.managementCluster.provider.kind (list "kvm" "openstack" "cloud-director" "vsphere") -}}
 rocket
-{{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa") -}}
+{{- else if has .Values.managementCluster.provider.kind (list "gcp" "capa" "capz") -}}
 {{- /* hydra alerts merged into phoenix business hours on-call */ -}}
 phoenix
-{{- else if eq .Values.managementCluster.provider.kind "capz" -}}
-clippy
 {{- else -}}
 phoenix
 {{- end -}}

--- a/test/tests/providers/capi/capz/capi-cluster.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-cluster.rules.test.yml
@@ -22,7 +22,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               name: clippaxy
               exported_namespace: giantswarm
@@ -37,7 +37,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               name: grumpy
               exported_namespace: giantswarm
@@ -53,7 +53,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               name: grumpy
               exported_namespace: giantswarm

--- a/test/tests/providers/capi/capz/capi-kubeadmcontrolplane.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-kubeadmcontrolplane.rules.test.yml
@@ -22,7 +22,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-72jzy
@@ -37,7 +37,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: grumpy
               name: grumpy-72r5c

--- a/test/tests/providers/capi/capz/capi-machine.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machine.rules.test.yml
@@ -18,7 +18,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-72jq5
@@ -34,7 +34,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: grumpy
               name: grumpy-72r5c

--- a/test/tests/providers/capi/capz/capi-machinedeployment.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machinedeployment.rules.test.yml
@@ -22,7 +22,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-def99
@@ -37,7 +37,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: grumpy
               name: grumpy-def99

--- a/test/tests/providers/capi/capz/capi-machinepool.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machinepool.rules.test.yml
@@ -22,7 +22,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-def99
@@ -37,7 +37,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: grumpy
               name: grumpy-72r5c

--- a/test/tests/providers/capi/capz/capi-machineset.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machineset.rules.test.yml
@@ -14,7 +14,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: grumpy
               name: grumpy-def99

--- a/test/tests/providers/capi/capz/capi.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi.rules.test.yml
@@ -16,7 +16,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-72jq5
@@ -42,7 +42,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-def99
@@ -67,7 +67,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-def99
@@ -92,7 +92,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               cluster_name: clippaxy
               name: clippaxy-72jzy
@@ -113,7 +113,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               name: clippaxy
               exported_namespace: giantswarm

--- a/test/tests/providers/capi/capz/cert-manager.rules.test.yml
+++ b/test/tests/providers/capi/capz/cert-manager.rules.test.yml
@@ -34,7 +34,7 @@ tests:
               installation: gollem
               service_priority: highest
               severity: page
-              team: clippy
+              team: phoenix
               topic: cert-manager
             exp_annotations:
               description: "cert-manager in namespace kube-system is down."

--- a/test/tests/providers/capi/capz/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/capz/certificate.all.rules.test.yml
@@ -33,7 +33,7 @@ tests:
               service_priority: highest
               severity: page
               secretkey: tls.crt
-              team: clippy
+              team: phoenix
               topic: cert-manager
             exp_annotations:
               description: "Certificate stored in Secret giantswarm/athena-certs-secret on gollem will expire in less than two weeks."
@@ -75,7 +75,7 @@ tests:
               installation: gollem
               service_priority: highest
               severity: page
-              team: clippy
+              team: phoenix
               topic: cert-manager
               issuer_ref: kiam-ca-issuer
               managed_issuer: true

--- a/test/tests/providers/capi/capz/dns-operator-azure.rules.test.yml
+++ b/test/tests/providers/capi/capz/dns-operator-azure.rules.test.yml
@@ -22,7 +22,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               phase: Provisioned
               exported_namespace: org-31f75bf9
@@ -38,7 +38,7 @@ tests:
               area: kaas
               cancel_if_outside_working_hours: "true"
               severity: notify
-              team: clippy
+              team: phoenix
               topic: managementcluster
               installation: puppy
               method: recordSets.CreateOrUpdate

--- a/test/tests/providers/capi/capz/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/capi/capz/node-exporter.all.rules.test.yml
@@ -27,7 +27,7 @@ tests:
               collector: "cpu"
               instance: "10.0.5.111:10300"
               severity: "page"
-              team: "clippy"
+              team: "phoenix"
               topic: "observability"
             exp_annotations:
               description: "NodeExporter Collector cpu on 10.0.5.111:10300 is failed."
@@ -60,7 +60,7 @@ tests:
               instance: "10.0.5.111:10300"
               mountpoint: "/var/lib/kubelet"
               severity: "page"
-              team: "clippy"
+              team: "phoenix"
               topic: "observability"
             exp_annotations:
               description: "NodeExporter Mountpoint /var/lib/kubelet on device /dev/mapper/usr on 10.0.5.111:10300 is erroring."


### PR DESCRIPTION
### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
