### PR TITLE
increase alert threshold for kvm wc critical pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase alert threshold for KVM WC critical pods from 5m to 10m.
+
 ## [2.117.0] - 2023-07-27
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
-      for: 5m
+      for: 10m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27738

This PR:

- increases the time from 5m to 10m before kvm wcs alert for critical pods not running

### Checklist

- [x] Update CHANGELOG.md
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
