### PR TITLE
decrease sensitivity for alerting on KVM WC critical pods from 10m to 15m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move Kyverno certificate expiry alert from KaaS to Managed Services.
+- Decrease sensitivity for alerting on KVM WC critical pods from 10m to 15m.
 
 ## [2.119.0] - 2023-07-31
 

--- a/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kvm.workload-cluster.rules.yml
@@ -17,7 +17,7 @@ spec:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
       expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
-      for: 10m
+      for: 15m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27738

this PR:

- further decreases the sensitivity when alerting on critical pods not running in KVM WCs.

### Checklist

- [x] Update CHANGELOG.md
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
