### PR TITLE
fix "service" labels for commonly firing alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move Cert-manager alerts to Cabbage
 
+### Fixed
+
+- Make `ManagementClusterContainerIsRestartingTooFrequentlyAWS` alert title include the involved pod.
+- Make `DeploymentNotSatisfiedKaas` alert title include the involved deployment.
+- Make `WorkloadClusterNonCriticalDeploymentNotSatisfiedKaas` alert title include the involved deployment.
+- Make `WorkloadClusterDeploymentNotSatisfiedKaas` alert title include the involved deployment.
+- Make `WorkloadClusterContainerIsRestartingTooFrequentlyAWS` alert title include the involved pod.
+- Make `WorkloadClusterManagedDeploymentNotSatisfiedPhoenix` alert title include the involved deployment.
+
 ## [2.120.0] - 2023-08-01
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.management-cluster.rules.yml
@@ -133,7 +133,7 @@ spec:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
       ## route53-manager is only used in China as route53 did not used to exist there
-      expr: increase(kube_pod_container_status_restarts_total{container=~"aws-admission-controller.*|aws-node.*|aws-operator.*|cluster-operator.*|route53-manager.*"}[1h]) > 6
+      expr: label_join(increase(kube_pod_container_status_restarts_total{container=~"aws-admission-controller.*|aws-node.*|aws-operator.*|cluster-operator.*|route53-manager.*"}[1h]), "service", "/", "namespace", "pod") > 6
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws.workload-cluster.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{container=~"aws-node.*|kiam-agent.*|kiam-server.*|cluster-autoscaler.*|ebs-csi-.*|aws-pod-identity-webhook.*|etcd-kubernetes-resources-count-exporter.*"}[1h]) > 10
+      expr: label_join(increase(kube_pod_container_status_restarts_total{container=~"aws-node.*|kiam-agent.*|kiam-server.*|cluster-autoscaler.*|ebs-csi-.*|aws-pod-identity-webhook.*|etcd-kubernetes-resources-count-exporter.*"}[1h]),"service","/","namespace","pod") > 10
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -101,7 +101,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator-.+|azure-admission-controller-.+|azure-operator.*|azure-collector.*|cluster-operator-.+|cluster-api-core-webhook.*|coredns-.+|event-exporter-.*|etcd-kubernetes-resources-count-exporter-.*|upgrade-schedule-operator.*|worker-.+|master-.+", cluster_id!~"argali|giraffe"} > 0
+      expr: label_join(kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"aws-admission-controller.*|aws-operator-.+|azure-admission-controller-.+|azure-operator.*|azure-collector.*|cluster-operator-.+|cluster-api-core-webhook.*|coredns-.+|event-exporter-.*|etcd-kubernetes-resources-count-exporter-.*|upgrade-schedule-operator.*|worker-.+|master-.+", cluster_id!~"argali|giraffe"}, "service", "/", "namespace", "deployment") > 0
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook.*|cluster-autoscaler|aws-load-balancer-controller"} > 0
+      expr: label_join(kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"metrics-server|vertical-pod-autoscaler-app-admission-controller|vertical-pod-autoscaler-app-recommender|vertical-pod-autoscaler-app-updater|aws-pod-identity-webhook.*|cluster-autoscaler|aws-load-balancer-controller"}, "service", "/", "namespace", "deployment") > 0
       for: 30m
       labels:
         area: kaas
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"etcd-kubernetes-resources-count-exporter"} > 0
+      expr: label_join(kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment=~"etcd-kubernetes-resources-count-exporter"}, "service", "/", "namespace", "deployment") > 0
       for: 30m
       labels:
         area: kaas
@@ -52,7 +52,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*"} > 0
+      expr: label_join(managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*"}, "service", "/", "namespace", "deployment") > 0
       for: 30m
       labels:
         area: managedservices


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27671

Goal of this PR is to change alerts from looking like this:

![Screenshot_20230802_115531](https://github.com/giantswarm/prometheus-rules/assets/868430/a391bbdb-cb3f-42d3-89af-15a718bd4d68)

to like this

![Screenshot_20230802_120548](https://github.com/giantswarm/prometheus-rules/assets/868430/0ef8094e-0845-44da-b3cb-66e5f04a3ef9)


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
