### PR TITLE
Improve ManagementClusterAPIServerAdmissionWebhookErrors alert.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow 1 error/5 minutes for `ManagementClusterAPIServerAdmissionWebhookErrors`.
+
+### Fixed
+
+- Add webhook name in `ManagementClusterAPIServerAdmissionWebhookErrors` alert title.
+
 ## [2.121.0] - 2023-08-02
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/apiserver.management-cluster.rules.yml
@@ -34,7 +34,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="management_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 1
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27670

This PR makes the alert less sensitive by allowing some errors (1 every 5 minutes) and improves alert quality by adding webhook name in the alert's title

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
