### PR TITLE
Ignore `prometheus` PVCs in `PersistentVolumeSpaceTooLow` alert (they…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore `prometheus` PVCs in `PersistentVolumeSpaceTooLow` alert (they have a dedicated alert).
+
 ## [2.122.0] - 2023-08-02
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
@@ -75,7 +75,7 @@ spec:
       annotations:
         description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         opsrecipe: low-disk-space/#persistent-volume
-      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod) group_left kube_pod_info{priority_class!="prometheus"}) < 10
+      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*",mountpoint!~".*prometheus/[0-9]+"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*",mountpoint!~".*prometheus/[0-9]+"}) * on (pod) group_left kube_pod_info{priority_class!="prometheus"}) < 10
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
… have a dedicated alert).

towards: https://github.com/giantswarm/giantswarm/issues/27187

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
