### PR TITLE
Add Shield deployments to WorkloadClusterDeploymentScaledDownToZeroShield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `WorkloadClusterDeploymentScaledDownToZeroShield` for Shield deployments on WCs.
+
 ### Fixed
 
 - Add port 8081 for the `instance` label in `KubeStateMetricsDown` alert.

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -71,3 +71,14 @@ spec:
         severity: notify
         team: honeybadger
         topic: releng
+    - alert: WorkloadClusterDeploymentScaledDownToZeroShield
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled down to zero for prolonged period of time.`}}'
+      expr: kube_deployment_spec_replicas{cluster_type="workload_cluster", deployment=~"trivy-operator|starboard-exporter|jiralert"} == 0
+      for: 4h
+      labels:
+        area: managedservices
+        cancel_if_outside_working_hours: true
+        severity: notify
+        team: shield
+        topic: releng


### PR DESCRIPTION
Related: https://github.com/giantswarm/giantswarm/issues/27834


Adds Shield deployments to the WorkloadClusterDeploymentScaledDownToZeroShield alert for WCs. This does not include Kyverno that will have its own alert.