### PR TITLE
KubeStateMetricsDown also triggers when KSM does not show enough data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- `KubeStateMetricsDown` also triggers when KSM does not show enough data (less than 10 metrics)
+
 ## [2.124.0] - 2023-08-08
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -58,6 +58,11 @@ spec:
           # vintage clusters without servicemonitor
           label_replace(up{app="kube-state-metrics",container=""}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0 or absent(up{app="kube-state-metrics",container=""} == 1)
         )
+        or
+        (
+          # When it looks up but we don't have metrics
+          count({app="kube-state-metrics"}) < 10
+        )
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION

Towards: https://github.com/giantswarm/giantswarm/issues/27849

This PR increases the scope of KSMDown alert: it now also checks the amount of metrics scraped form KSM.

This is to raise an alert and inhibition when:

- KSM is deployed
- it has no servicemonitor or servicemonitor is broken
- it is discovered by labels
- but all data is dropped by alertmanager config because cluster should use servicemonitor

Tested on `bandicoot`: raises an alert for `p2i6x` cluster as expected, and inhibits all `kubeXxxMetricMissing` alerts.


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
