### PR TITLE
Add unit tests for KSMDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unit tests for KubeStateMetricsDown
+
 ## [2.127.0] - 2023-08-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -72,7 +72,7 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         inhibit_kube_state_metrics_down: "true"
         cancel_if_kubelet_down: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "false"
         severity: page
         team: atlas
         topic: observability

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -71,7 +71,6 @@ templates/alerting-rules/systemd.workload-cluster.rules.yml
 templates/alerting-rules/tiller.all.rules.yml
 templates/alerting-rules/tiller.workload-cluster.rules.yml
 templates/alerting-rules/timesync.rules.yml
-templates/alerting-rules/up.all.rules.yml
 templates/alerting-rules/up.management-cluster.rules.yml
 templates/alerting-rules/vault.rules.yml
 templates/recording-rules/grafana-cloud.rules.yml

--- a/test/tests/providers/global/up.all.rules.test.yml
+++ b/test/tests/providers/global/up.all.rules.test.yml
@@ -1,0 +1,193 @@
+---
+rule_files:
+- up.all.rules.yml
+
+tests:
+  # KubeStateMetricsDown tests
+  # Tests to be run:
+  # - no "up" metrics
+  # - "up" metrics with servicemonitor discovery (ports 8080 and 8081)
+  #   - "up" metric for port 8080 is OK, but port 8081 is set to 0
+  #   - "up" metric for port 8080 is set to 0, but port 8080 is OK
+  # - "up" metrics with label discovery (random port)
+  # - "up" is ok, but we don't have enough metrics
+  - name: "KSMDown with servicemonitor discovery"
+    interval: 1m
+    input_series:
+      # Tests for servicemonitor discovery
+      # - 00:00 Start with no metrics
+      # - 00:30 Both ports up and enough metrics
+      # - 01:00 Port 8080 goes down
+      # - 01:30 All is up again
+      # - 02:00 Port 8081 goes down
+      # - 02:30 all is up again
+      # - 03:00 we don't have enough metrics
+      # - 03:30 all is up again
+      - series: 'up{app="kube-state-metrics", cluster_id="testinstall", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", endpoint="http", installation="testinstall", instance="192.0.2.10:8080", job="kube-state-metrics", namespace="kube-system", node="ip-10-0-1-1.eu-west-1.compute.internal", organization="giantswarm", pipeline="testing", pod="prometheus-operator-app-kube-state-metrics-d7f4ff68d-72vzx", provider="aws", region="eu-west-1", service="prometheus-operator-app-kube-state-metrics", service_priority="highest"}'
+        values: "_x30 1x30 0x30 1x30 1x30 1x30 1x30 1x30"
+      - series: 'up{app="kube-state-metrics", cluster_id="testinstall", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", endpoint="metrics", installation="testinstall", instance="192.0.2.10:8081", job="kube-state-metrics", namespace="kube-system", node="ip-10-0-1-1.eu-west-1.compute.internal", organization="giantswarm", pipeline="testing", pod="prometheus-operator-app-kube-state-metrics-d7f4ff68d-72vzx", provider="aws", region="eu-west-1", service="prometheus-operator-app-kube-state-metrics", service_priority="highest"}'
+        values: "_x30 1x30 1x30 1x30 0x30 1x30 1x30 1x30"
+      - series: 'testmetric2{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric3{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric4{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric5{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric6{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric7{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric8{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric9{app="kube-state-metrics"}'
+        values: "_x30 1x30 1x30 1x30 1x30 1x30 _x30 1x30"
+    alert_rule_test:
+      # - 00:00 Start with no metrics
+      - alertname: KubeStateMetricsDown
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: "kaas"
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_kubelet_down: "true"
+              cancel_if_outside_working_hours: "false"
+              inhibit_kube_state_metrics_down: "true"
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "KubeStateMetrics () is down."
+              opsrecipe: "kube-state-metrics-down/"
+      # - 00:30 Both ports up and enough metrics
+      - alertname: KubeStateMetricsDown
+        eval_time: 55m
+      # - 01:00 Port 8080 goes down
+      - alertname: KubeStateMetricsDown
+        eval_time: 85m
+        exp_alerts:
+          - exp_labels:
+              area: "kaas"
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_kubelet_down: "true"
+              cancel_if_outside_working_hours: "false"
+              inhibit_kube_state_metrics_down: "true"
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "KubeStateMetrics () is down."
+              opsrecipe: "kube-state-metrics-down/"
+      # - 01:30 All is up again
+      - alertname: KubeStateMetricsDown
+        eval_time: 115m
+      # - 02:00 Port 8081 goes down
+      - alertname: KubeStateMetricsDown
+        eval_time: 145m
+      # - 02:30 all is up again
+      - alertname: KubeStateMetricsDown
+        eval_time: 175m
+      # - 03:00 we don't have enough metrics
+      - alertname: KubeStateMetricsDown
+        eval_time: 205m
+        exp_alerts:
+          - exp_labels:
+              area: "kaas"
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_kubelet_down: "true"
+              cancel_if_outside_working_hours: "false"
+              inhibit_kube_state_metrics_down: "true"
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "KubeStateMetrics () is down."
+              opsrecipe: "kube-state-metrics-down/"
+      # - 03:30 all is up again
+      - alertname: KubeStateMetricsDown
+        eval_time: 235m
+
+
+  # Tests for label-discovery targets
+  - name: "KSMDown with label discovery"
+    interval: 1m
+    input_series:
+      # - 00:00 Start with no metrics
+      # - 00:30 all goes up
+      # - 01:00 up goes down
+      # - 01:30 All is up again
+      - series: 'up{app="kube-state-metrics", cluster_id="testvintage", cluster_type="workload_cluster", customer="giantswarm", installation="testinstall", instance="10.0.2.4:10301", job="test-prometheus/workload-test/0", namespace="kube-system", node="ip-10-1-0-3.eu-west-1.compute.internal", organization="giantswarm", pod="kube-state-metrics-v2-3-0-67b5fdc5d4-78mhf", provider="aws", service_priority="highest"}'
+        values: "_x30 1x30 0x30 1x30"
+      - series: 'testmetric2{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric3{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric4{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric5{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric6{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric7{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric8{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric9{app="kube-state-metrics"}'
+        values: "0x1000"
+      - series: 'testmetric10{app="kube-state-metrics"}'
+        values: "0x1000"
+    alert_rule_test:
+      # - 00:00 Start with no metrics
+      - alertname: KubeStateMetricsDown
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: "kaas"
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_kubelet_down: "true"
+              cancel_if_outside_working_hours: "false"
+              inhibit_kube_state_metrics_down: "true"
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "KubeStateMetrics () is down."
+              opsrecipe: "kube-state-metrics-down/"
+      # - 00:30 all goes up
+      - alertname: KubeStateMetricsDown
+        eval_time: 55m
+      # - 01:00 up goes down
+      - alertname: KubeStateMetricsDown
+        eval_time: 85m
+        exp_alerts:
+          - exp_labels:
+              area: "kaas"
+              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_kubelet_down: "true"
+              cancel_if_outside_working_hours: "false"
+              inhibit_kube_state_metrics_down: "true"
+              severity: "page"
+              team: "atlas"
+              topic: "observability"
+            exp_annotations:
+              description: "KubeStateMetrics () is down."
+              opsrecipe: "kube-state-metrics-down/"
+      # - 01:30 All is up again
+      - alertname: KubeStateMetricsDown
+        eval_time: 115m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27913

This PR adds unit tests to KSMDown.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
