### PR TITLE
Loki alerts only during working hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unit tests for KubeStateMetricsDown
 
+### Changed
+
+- Loki alerts only during working hours
+
 ## [2.127.0] - 2023-08-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_outside_working_hours: "false"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
         topic: observability
@@ -44,7 +44,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_scrape_timeout: "true"
-        cancel_if_outside_working_hours: "false"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
         topic: observability

--- a/test/tests/providers/global/loki.all.rules.test.yml
+++ b/test/tests/providers/global/loki.all.rules.test.yml
@@ -27,7 +27,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "false"
+              cancel_if_outside_working_hours: "true"
               cancel_if_scrape_timeout: "true"
               job: zj88t-prometheus/workload-zj88t/0
               namespace: loki
@@ -53,7 +53,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "false"
+              cancel_if_outside_working_hours: "true"
               cancel_if_scrape_timeout: "true"
               job: zj88t-prometheus/workload-zj88t/0
               namespace: loki


### PR DESCRIPTION
As discussed during area alerts review, Loki alerts don't need to wake up night oncall.
Let's switch it to working-hours only.


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
