### PR TITLE
Prometheus-agent inhibition rework, run on the MC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Loki alerts only during working hours
 - `PrometheusAgentFailing` does not rely on KSM metrics anymore
+- Prometheus-agent inhibition rework, run on the MC
 
 ## [2.127.0] - 2023-08-21
 

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -12,14 +12,29 @@ spec:
   - name: inhibit.prometheus-agent
     rules:
     # this inhibition fires when a cluster is not running prometheus-agent.
-    # If we have prometheus-agent statefulset, it means prometheus-agent is installed on this cluster
-    # so, raise an inhibition unless prometheus-agent runs on the cluster 
+    # we retrieve the list of existing cluster IDs from `kube_namespace_created`
+    #   excluding the MC's one, because it's always using prometheus-agent and namespace is not named after cluster name
+    # then compare it with the list of deployed prometheus-agents from `app_operator_app_info`
     # 
-    # Will produce data (and inhibitions) on MC/WC.
+    # Will only produce data (and inhibitions) on MC because it's where app_operator is running
+    # but that's enough to have the inhibitions on the installation-global alertmanager
     - alert: InhibitionClusterIsNotRunningPrometheusAgent
       annotations:
         description: '{{`Cluster ({{ $labels.cluster_id }}) is not running Prometheus Agent.`}}'
-      expr: (count by (cluster_id) (prometheus_build_info{app="prometheus"}) unless count by (cluster_id) (kube_statefulset_created{namespace="kube-system",statefulset=~"prometheus-prometheus-agent.*"}  > 0))
+      expr: |-
+        count(
+          label_replace(
+            kube_namespace_created{namespace!="{{ .Values.managementCluster.name }}-prometheus", namespace=~".+-prometheus"},
+            "cluster_id", "$1", "namespace", "(.+)-prometheus"
+          )
+        ) by (cluster_id)
+        unless
+        count(
+          label_replace(
+            app_operator_app_info{app="prometheus-agent"},
+            "cluster_id", "$1", "namespace", "(.*)"
+          )
+        ) by (cluster_id)
       labels:
         cluster_is_not_running_prometheus_agent: "true"
         area: empowerment

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -17,6 +17,7 @@ main() {
       "$GIT_WORKDIR"/helm/prometheus-rules \
       --set="managementCluster.provider.flavor=${BASH_REMATCH[1]}" \
       --set="managementCluster.provider.kind=${BASH_REMATCH[2]}" \
+      --set="managementCluster.name=myinstall" \
       --output-dir "$GIT_WORKDIR"/test/hack/output/"$provider"
   done
 }

--- a/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/inhibit.prometheus-agent.rules.test.yml
@@ -5,24 +5,29 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'prometheus_build_info{app="prometheus",cluster_id="gauss",instance="localhost:9090"}'
+      # - cluster 1: "clu01"
+      - series: 'kube_namespace_created{app="kube-state-metrics", cluster_id="myinstall", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", endpoint="http", installation="myinstall", instance="100.64.25.34:8080", job="kube-state-metrics", namespace="clu01-prometheus", node="ip-10-0-5-14.eu-central-1.compute.internal", organization="giantswarm", pipeline="testing", pod="prometheus-operator-app-kube-state-metrics-f7b868f49-ngvr8", service="prometheus-operator-app-kube-state-metrics"}'
+        values: '1671707388+0x40'
+      # - cluster 2: "clu02"
+      - series: 'kube_namespace_created{app="kube-state-metrics", cluster_id="myinstall", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", endpoint="http", installation="myinstall", instance="100.64.25.34:8080", job="kube-state-metrics", namespace="clu02-prometheus", node="ip-10-0-5-14.eu-central-1.compute.internal", organization="giantswarm", pipeline="stable", pod="prometheus-operator-app-kube-state-metrics-f7b868f49-ngvr8", service="prometheus-operator-app-kube-state-metrics"}'
+        values: '1671707388+0x40'
+      # - cluster 3: "myinstall", the install name
+      - series: 'kube_namespace_created{app="kube-state-metrics", cluster_id="myinstall", cluster_type="management_cluster", container="kube-state-metrics", customer="giantswarm", endpoint="http", installation="myinstall", instance="100.64.25.34:8080", job="kube-state-metrics", namespace="myinstall-prometheus", node="ip-10-0-5-14.eu-central-1.compute.internal", organization="giantswarm", pipeline="stable", pod="prometheus-operator-app-kube-state-metrics-f7b868f49-ngvr8", service="prometheus-operator-app-kube-state-metrics"}'
+        values: "1671707388+0x40"
+      # prometheus-agent app info for "clu01"
+      - series: 'app_operator_app_info{app="prometheus-agent", app_version="2.40.5", catalog="giantswarm-playground", cluster_id="myinstall", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.1.7", endpoint="web", installation="myinstall", instance="app-exporter", job="app-exporter", name="prometheus-agent", namespace="clu01", node="ip-10-0-5-141.eu-central-1.compute.internal", organization="giantswarm", pipeline="stable", pod="app-exporter-6865c9c648-sg5vg", service="app-exporter", status="deployed", team="atlas", upgrade_available="false", version="0.1.7", version_mismatch="false"}'
         values: "1+0x40"
-      - series: 'kube_statefulset_created{namespace="kube-system",cluster_id="gauss",statefulset="prometheus-prometheus-agent"}'
-        values: "1+0x20 0+0x20"
-      - series: 'kube_statefulset_created{namespace="kube-system",cluster_id="gauss",statefulset="prometheus-prometheus-agent-shard-1"}'
-        values: "1+0x20 0+0x20"
     alert_rule_test:
+      #- alertname: InhibitionClusterIsNotRunningPrometheusAgent
+      #  eval_time: 1m
       - alertname: InhibitionClusterIsNotRunningPrometheusAgent
-        eval_time: 1m
-      - alertname: InhibitionClusterIsNotRunningPrometheusAgent
-        eval_time: 22m
+        eval_time: 10m
         exp_alerts:
           - exp_labels:
               area: empowerment
               team: atlas
               topic: monitoring
               cluster_is_not_running_prometheus_agent: "true"
-              cluster_id: "gauss"
+              cluster_id: "clu02"
             exp_annotations:
-              description: "Cluster (gauss) is not running Prometheus Agent."
-
+              description: "Cluster (clu02) is not running Prometheus Agent."

--- a/test/tests/providers/global/silence-operator.rules.test.yml
+++ b/test/tests/providers/global/silence-operator.rules.test.yml
@@ -18,6 +18,7 @@ tests:
               area: "empowerment"
               cancel_if_outside_working_hours: "true"
               controller: silence-controller
+              installation: "myinstall"
               severity: "page"
               team: "atlas"
               topic: "observability"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27937

This PR goes back to the initial idea of having the inhibition run on the MC, based on installed apps.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
