### PR TITLE
PrometheusAgentFailing does not rely on KSM metrics anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Loki alerts only during working hours
+- `PrometheusAgentFailing` does not rely on KSM metrics anymore
 
 ## [2.127.0] - 2023-08-21
 

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -18,7 +18,8 @@ spec:
         summary: Prometheus agent fails to send samples to remote write endpoint.
         opsrecipe: prometheus-agent-remote-write-failed/
         dashboard: promRW001/prometheus-remote-write
-      expr: count(absent_over_time(up{instance="prometheus-agent"}[10m])) and count((present_over_time(kube_statefulset_created{namespace="kube-system",statefulset=~"prometheus-prometheus-agent.*"}[10m])))
+      #  expr: count(absent_over_time(up{instance="prometheus-agent"}[10m]))
+      expr: up{instance="prometheus-agent"} == 0 or absent(up{instance="prometheus-agent"}) == 1
       for: 10m
       labels:
         area: empowerment

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -5,15 +5,11 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{instance="prometheus-agent",cluster_type="workload_cluster",cluster_id="gauss",installation="gauss"}'
-        values: "_x10  _x20  0+0x100 1+0x100"
-      - series: 'kube_statefulset_created{namespace="kube-system",statefulset="prometheus-prometheus-agent",cluster_id="gauss",installation="gauss"}'
-        values: "_x10 0+0x20 1+0x100 1+0x100"
+      - series: 'up{instance="prometheus-agent",cluster_type="workload_cluster",cluster_id="gauss",installation="myinstall"}'
+        values: "_x60  0+0x60 1+0x60"
     alert_rule_test:
       - alertname: PrometheusAgentFailing
-        eval_time: 10m
-      - alertname: PrometheusAgentFailing
-        eval_time: 25m
+        eval_time: 30m
         exp_alerts:
           - exp_labels:
               area: empowerment
@@ -21,6 +17,7 @@ tests:
               team: atlas
               topic: observability
               inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
@@ -31,6 +28,26 @@ tests:
               opsrecipe: "prometheus-agent-remote-write-failed/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailing
-        eval_time: 65m
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent-remote-write-failed/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailing
-        eval_time: 165m
+        eval_time: 150m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27937

This PR fixes `PrometheusAgentFailing` so that it does not rely on KSM metrics anymore.
This used to work, but now KSM target has been moved to a servicemonitor, its data goes through prometheus-agent. So if prometheus-agent is down we don't have KSM data.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
