### PR TITLE
keep agent alerts for 5min after it's solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `PrometheusAgentFailing` and `PrometheusAgentShardsMissing`: keep alerts for 5min after it's solved
+
 ## [2.131.0] - 2023-09-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -46,19 +46,24 @@ spec:
         summary: Prometheus agent is missing shards.
         opsrecipe: prometheus-agent-missing-shards/
       expr: |-
-        max_over_time(sum(count(
-          ## number of remotes that are not mimir or grafana-cloud
-          prometheus_remote_storage_metadata_total{remote_name!~"grafana-cloud|mimir"}
-        ) != sum(
-          ## number of shards defined in the Prometheus CR
-          prometheus_operator_spec_shards{controller="prometheus",name="prometheus-agent"}
-          or (
-            # if there is only 1 shard, there is no shard metric so we use the replicas metric
-            absent(prometheus_operator_spec_shards{controller="prometheus",name="prometheus-agent"})
-            and on(controller, name)
-            prometheus_operator_spec_replicas{controller="prometheus",name="prometheus-agent"}
+        max_over_time(sum(
+          count(
+            ## number of remotes that are not mimir or grafana-cloud
+            prometheus_remote_storage_metadata_total{remote_name!~"grafana-cloud|mimir"}
           )
-        ))[5m:1m])
+          !=
+          sum(
+            ## number of shards defined in the Prometheus CR
+            prometheus_operator_spec_shards{controller="prometheus",name="prometheus-agent"}
+            or
+            (
+              # if there is only 1 shard, there is no shard metric so we use the replicas metric
+              absent(prometheus_operator_spec_shards{controller="prometheus",name="prometheus-agent"})
+              and on(controller, name)
+              prometheus_operator_spec_replicas{controller="prometheus",name="prometheus-agent"}
+            )
+          )
+        )[5m:1m])
       for: 10m
       labels:
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -26,7 +26,7 @@ spec:
             up{instance="prometheus-agent"} == 0
             or
             absent(up{instance="prometheus-agent"}) == 1
-          )[5m:30s]
+          )[5m:]
         )
       for: 10m
       labels:
@@ -63,7 +63,7 @@ spec:
               prometheus_operator_spec_replicas{controller="prometheus",name="prometheus-agent"}
             )
           )
-        )[5m:1m])
+        )[5m:])
       for: 10m
       labels:
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -19,7 +19,15 @@ spec:
         opsrecipe: prometheus-agent-remote-write-failed/
         dashboard: promRW001/prometheus-remote-write
       #  expr: count(absent_over_time(up{instance="prometheus-agent"}[10m]))
-      expr: up{instance="prometheus-agent"} == 0 or absent(up{instance="prometheus-agent"}) == 1
+      expr: |-
+        max_over_time(
+          sum by (cluster_type, cluster_id, installation, instance, service)
+          (
+            up{instance="prometheus-agent"} == 0
+            or
+            absent(up{instance="prometheus-agent"}) == 1
+          )[5m:30s]
+        )
       for: 10m
       labels:
         area: empowerment
@@ -38,7 +46,7 @@ spec:
         summary: Prometheus agent is missing shards.
         opsrecipe: prometheus-agent-missing-shards/
       expr: |-
-        count(
+        max_over_time(sum(count(
           ## number of remotes that are not mimir or grafana-cloud
           prometheus_remote_storage_metadata_total{remote_name!~"grafana-cloud|mimir"}
         ) != sum(
@@ -50,7 +58,7 @@ spec:
             and on(controller, name)
             prometheus_operator_spec_replicas{controller="prometheus",name="prometheus-agent"}
           )
-        )
+        ))[5m:1m])
       for: 10m
       labels:
         area: empowerment

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -55,8 +55,6 @@ tests:
   # Tests for `PrometheusAgentShardsMissing` alert
   - interval: 1m
     input_series:
-      - series: 'up{instance="prometheus-agent", cluster_type="workload_cluster", cluster_id="gauss",installation="myinstall", team="atlas"}'
-        values: "_x60  0+0x60 1+0x60 0x60"
       - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
         values: "10000+0x180"
       - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -56,17 +56,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{instance="prometheus-agent", cluster_type="workload_cluster", cluster_id="gauss",installation="myinstall", team="atlas"}'
-        values: "_x60  0+0x60 1+0x60"
+        values: "_x60  0+0x60 1+0x60 0x60"
       - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
-        values: "10000+0x120"
+        values: "10000+0x180"
       - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
-        values: "10000+0x120"
+        values: "10000+0x180"
       - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
-        values: "10000+0x120"
+        values: "10000+0x180"
       - series: 'prometheus_operator_spec_shards{cluster_id="test01", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
-        values: '3+0x60 5+0x60'
+        values: '3+0x60 5+0x60 3+0x60'
       - series: 'prometheus_operator_spec_replicas{cluster_id="test01", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
-        values: '1+0x120'
+        values: '1+0x180'
     alert_rule_test:
       - alertname: PrometheusAgentShardsMissing
         eval_time: 40m
@@ -87,3 +87,22 @@ tests:
               description: "Prometheus agent is missing shards."
               opsrecipe: "prometheus-agent-missing-shards/"
               summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent-missing-shards/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27937

This PR keeps `PrometheusAgentFailing` and `PrometheusAgentShardsMissing`: keep alerts for 5min after their metrics are back to normal.
This is to keep inhibitions until dependent metrics (like KSM) are back.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
