### PR TITLE
Improve PrometheusAgent inhibition to avoid flapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve InhibitionClusterIsNotRunningPrometheusAgent to keep paging if the kube-state-metrics metric is missing for 5 minutes (avoid flapping of inhibitions).
+
 ## [2.134.0] - 2023-09-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.prometheus-agent.rules.yml
@@ -24,15 +24,17 @@ spec:
       expr: |-
         count(
           label_replace(
-            kube_namespace_created{namespace!="{{ .Values.managementCluster.name }}-prometheus", namespace=~".+-prometheus"},
-            "cluster_id", "$1", "namespace", "(.+)-prometheus"
+            sum_over_time(
+              kube_namespace_created{namespace!="{{ .Values.managementCluster.name }}-prometheus", namespace=~".+-prometheus"}[5m]
+            ), "cluster_id", "$1", "namespace", "(.+)-prometheus"
           )
         ) by (cluster_id)
         unless
         count(
           label_replace(
-            app_operator_app_info{app="prometheus-agent"},
-            "cluster_id", "$1", "namespace", "(.*)"
+            sum_over_time(
+              app_operator_app_info{app="prometheus-agent"}[5m]
+            ), "cluster_id", "$1", "namespace", "(.*)"
           )
         ) by (cluster_id)
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -68,7 +68,7 @@ spec:
         area: "empowerment"
         cancel_if_mc_kube_state_metrics_down: "false"
         cancel_if_cluster_status_creating: "true"
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: true
         installation: {{ .Values.managementCluster.name }}
         severity: "page"
         team: "atlas"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/28288

This PR is trying to fix the PrometheusAgentNotRunning inhibition to avoid being paged for a missing `prometheus-agent` app when the source metrics are missing for less than 5 minutes which can sometimes happen

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
