### PR TITLE
Fix link for node exporter opsrecipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix link for node exporter opsrecipe
+
 ## [2.138.0] - 2023-10-05
 
 ### Fixed
@@ -409,7 +413,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.98.0] - 2023-05-10
 
-
 ### Added
 
 - Add `WorkloadClusterMasterMemoryUsageTooHigh` alert.
@@ -711,7 +714,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cortex recording rules for requests and limits
 - Upgrade inhibition labels checking script
 - inhibition script now throwing error in github-action if missing labels are detected
-
 
 ## [2.77.0] - 2023-02-03
 
@@ -1030,7 +1032,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Narrow down Flux `FluxKustomizationFailed` alert.
 
 ## [2.56.0] - 2022-11-03
-
 
 ### Added
 
@@ -1531,7 +1532,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `ManagementClusterPodPendingFor15Min` and `ManagementClusterPodPending`.
 
-
 ## [1.7.1] - 2022-03-22
 
 ### Changed
@@ -1861,7 +1861,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change `WorkloadClusterEtcdCommitDurationTooHigh` severity to paging.
-
 
 ## [0.31.3] - 2021-11-09
 

--- a/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node-exporter.all.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: NodeExporterCollectorFailed
       annotations:
         description: '{{`NodeExporter Collector {{ $labels.collector }} on {{ $labels.instance }} is failed.`}}'
-        opsrecipe: node-exporter-device-failed/
+        opsrecipe: node-exporter-device-error/
       expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme{{ if eq .Values.managementCluster.provider.kind "kvm" }}|pressure{{ end }}"} == 0
       for: 5m
       labels:

--- a/test/tests/providers/capi/capz/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/capi/capz/node-exporter.all.rules.test.yml
@@ -31,7 +31,7 @@ tests:
               topic: "observability"
             exp_annotations:
               description: "NodeExporter Collector cpu on 10.0.5.111:10300 is failed."
-              opsrecipe: "node-exporter-device-failed/"
+              opsrecipe: "node-exporter-device-error/"
       - alertname: NodeExporterCollectorFailed
         eval_time: 70m
 

--- a/test/tests/providers/capi/openstack/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/capi/openstack/node-exporter.all.rules.test.yml
@@ -31,7 +31,7 @@ tests:
               topic: "observability"
             exp_annotations:
               description: "NodeExporter Collector cpu on 10.0.5.111:10300 is failed."
-              opsrecipe: "node-exporter-device-failed/"
+              opsrecipe: "node-exporter-device-error/"
       - alertname: NodeExporterCollectorFailed
         eval_time: 70m
 

--- a/test/tests/providers/vintage/aws/node-exporter.all.rules.test.yml
+++ b/test/tests/providers/vintage/aws/node-exporter.all.rules.test.yml
@@ -31,7 +31,7 @@ tests:
               topic: "observability"
             exp_annotations:
               description: "NodeExporter Collector cpu on 10.0.5.111:10300 is failed."
-              opsrecipe: "node-exporter-device-failed/"
+              opsrecipe: "node-exporter-device-error/"
       - alertname: NodeExporterCollectorFailed
         eval_time: 70m
 


### PR DESCRIPTION
HTTP 404 for the old URL, and likely it never existed

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
