### PR TITLE
Add cluster-info recording rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rules to list all clusters.
+
 ## [2.138.1] - 2023-10-11
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -58,6 +58,40 @@ spec:
       record: aggregation:giantswarm:app_upgrade_available
   - name: clusters.grafana-cloud.recording
     rules:
+    # This recording rule is used to list all clusters. The last expression is used to list vintage MCs
+    - expr: |-
+        avg by (cluster_id, customer, installation) (
+          label_replace(
+            capi_cluster_info,
+            "cluster_id",
+            "$1",
+            "name",
+            "(.*)"
+          ) >= 1
+          or cluster_operator_cluster_status >= 1
+          or cluster_service_cluster_info >= 1
+          or
+            label_replace(
+              label_replace(
+                label_replace(
+                  vector(1),
+                  "cluster_id",
+                  {{ .Values.managementCluster.name | quote }},
+                  "",
+                  ""
+                ),
+                "customer",
+                {{ .Values.managementCluster.customer | quote }},
+                "",
+                ""
+              ),
+              "installation",
+              {{ .Values.managementCluster.name | quote }},
+              "",
+              ""
+            )
+        )
+      record: aggregation:giantswarm:cluster_info
     - expr: sum(label_replace(azure_operator_cluster_release{release_version!=""}, "cluster_id", "$1", "exported_cluster_id", "(.*)")) by (release_version, cluster_id) or sum(cluster_service_cluster_info) by (release_version, cluster_id) / 2 or sum(cluster_operator_cluster_status{release_version!=""}) by (release_version, cluster_id)
       record: aggregation:giantswarm:cluster_release_version
     - expr: avg_over_time(cluster_operator_cluster_create_transition[1w]) or avg_over_time(azure_operator_cluster_create_transition[1w])

--- a/helm/prometheus-rules/values.schema.json
+++ b/helm/prometheus-rules/values.schema.json
@@ -5,6 +5,9 @@
         "managementCluster": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -14,6 +17,9 @@
                 "provider": {
                     "type": "object",
                     "properties": {
+                        "flavor": {
+                            "type": "string"
+                        },
                         "kind": {
                             "type": "string"
                         }

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -5,6 +5,7 @@ project:
   branch: '[[ .Branch ]]'
   commit: '[[ .SHA ]]'
 managementCluster:
+  customer: ""
   name: ""
   pipeline: ""
   provider:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/28268

This PR adds a recording rule to be able to list all clusters to be used in join with absent functions

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
