### PR TITLE
Add tempo rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Recording rules for Tempo
+
 ## [2.138.2] - 2023-10-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ Official documentation for inhibit rules can be found here: https://www.promethe
 
 The recording rules are located `helm/prometheus-rules/templates/recording-rules`
 
-
 ### Mixin
 
-#### kubermetes-mixins
+#### kubernetes-mixins
 
 To Update `kubernetes-mixins` recording rules:
 
@@ -113,6 +112,10 @@ Come as-is from https://github.com/grafana/mimir/tree/main/operations/mimir-mixi
 #### loki-mixins
 
 Come as-is from https://github.com/grafana/loki/tree/main/production/loki-mixin-compiled-ssd ; just added helm headers (metadata, spec...)
+
+#### tempo-mixins
+
+Come as-is from https://github.com/grafana/tempo/tree/main/operations/tempo-mixin-compiled ; just added helm headers (metadata, spec...)
 
 ### Testing
 

--- a/helm/prometheus-rules/templates/recording-rules/tempo-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/tempo-mixins.rules.yml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: tempo.recording.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: tempo_rules
+    rules:
+    - expr: "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route))"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds:99quantile"
+    - expr: "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route))"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds:50quantile"
+    - expr: "sum(rate(tempo_request_duration_seconds_sum[1m])) by (cluster, namespace, job, route) / sum(rate(tempo_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds:avg"
+    - expr: "sum(rate(tempo_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route)"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds_bucket:sum_rate"
+    - expr: "sum(rate(tempo_request_duration_seconds_sum[1m])) by (cluster, namespace, job, route)"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds_sum:sum_rate"
+    - expr: "sum(rate(tempo_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)"
+      record: "cluster_namespace_job_route:tempo_request_duration_seconds_count:sum_rate"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR adds the Tempo recording rules.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
