### PR TITLE
Add keda alerting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add KEDA alerting rules.
+
 ### Changed
 
 - Added `namespace` label to Flux helm release related alerts

--- a/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
@@ -21,8 +21,9 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        severity: page
-        team: phoenix
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: atlas
         topic: autoscaling
     - alert: KedaScaledObjectErrors
       annotations:
@@ -37,7 +38,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: phoenix
+        team: atlas
         topic: autoscaling
     - alert: KedaWebhookScaledObjectValidationErrors
       annotations:
@@ -52,7 +53,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: phoenix
+        team: atlas
         topic: autoscaling
     - alert: KedaScalerErrors
       annotations:
@@ -67,5 +68,5 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: notify
-        team: phoenix
+        team: atlas
         topic: autoscaling

--- a/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
@@ -1,0 +1,71 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: keda.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: Keda
+    rules:
+    - alert: KedaDown
+      annotations:
+        description: 'Keda is down.'
+      expr: count (up{container=~"keda-.*"} == 0) > 0
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: phoenix
+        topic: autoscaling
+    - alert: KedaScaledObjectErrors
+      annotations:
+        description: '{{`Errors detected in scaled object {{ $labels.scaledObject }} in namespace {{ $labels.namespace}}.`}}'
+      expr: increase(keda_scaled_object_errors[10m])> 0
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: phoenix
+        topic: autoscaling
+    - alert: KedaWebhookScaledObjectValidationErrors
+      annotations:
+        description: '{{`Validation errors detected in webhook for scaled object {{ $labels.scaledObject }} in namespace {{ $labels.namespace}}.`}}'
+      expr: increase(keda_webhook_scaled_object_validation_errors[10m]) > 0
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: phoenix
+        topic: autoscaling
+    - alert: KedaScalerErrors
+      annotations:
+        description: '{{`Errors detected in scaler {{ $labels.scaler }} for scaled object {{ $labels.scaledObject }} in namespace {{ $labels.namespace}}.`}}'
+      expr: increase(keda_scaler_errors[10m]) > 0
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: phoenix
+        topic: autoscaling


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/adidas/issues/1213

This PR adds keda alerting rules. They are configurés to only notify for now

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
