### PR TITLE
Add new alert that fires if etcd backup metrics are missing for 12h.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert that fires if etcd backup metrics are missing for 12h.
+
 ## [2.139.0] - 2023-11-07
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -71,7 +71,7 @@ spec:
     - alert: ETCDBackupMetricsMissing
       annotations:
         description: '{{`ETCD backup metrics are missing`}}'
-        opsrecipe: etcd-backup-failed/
+        opsrecipe: etcd-backup-metrics-missing/
       expr: absent(etcd_backup_latest_attempt)
       for: 12h
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -68,3 +68,15 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd-backup
+    - alert: ETCDBackupMetricsMissing
+      annotations:
+        description: '{{`ETCD backup metrics are missing on {{ $labels.cluster_id }}`}}'
+        opsrecipe: etcd-backup-failed/
+      expr: absent(etcd_backup_latest_attempt)
+      for: 12h
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: etcd-backup

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -70,7 +70,7 @@ spec:
         topic: etcd-backup
     - alert: ETCDBackupMetricsMissing
       annotations:
-        description: '{{`ETCD backup metrics are missing on {{ $labels.cluster_id }}`}}'
+        description: '{{`ETCD backup metrics are missing`}}'
         opsrecipe: etcd-backup-failed/
       expr: absent(etcd_backup_latest_attempt)
       for: 12h


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28783

This PR adds a new alert that pages if etcd backup operator metrics are not present in a MC

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
