### PR TITLE
Fix recording rule expression for kubelet status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.139.0] - 2023-11-07
 
+### Fixed
+
+- Fix `raw_slo_requests` recording rule expression for kubelet status.
+
 ### Added
 
 - Add KEDA alerting rules.

--- a/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/service-level.rules.yml
@@ -82,7 +82,7 @@ spec:
       record: slo_target
 
       # -- kubelet whole cluster
-    - expr: "kube_node_status_condition"
+    - expr: kube_node_status_condition{condition="Ready"}
       labels:
         class: MEDIUM
         area: kaas


### PR DESCRIPTION
Added `condition="Ready"` label to kube_node_status_condition in `raw_slo_requests` recording rule expression since we only check that condition in the errors.

Without this the `slo_error_per_request` are 1/5 of the actual value, since the condition label has 5 possible values (`Ready`, `DiskPressure`, `MemoryPressure`, `PIDPressure`, `NetworkUnavailable`).


---
Towards: https://github.com/giantswarm/giantswarm/issues/27921#issuecomment-1804147257

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
