### PR TITLE
Fixed CHANGELOG.md moving unreleased change in the proper section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `raw_slo_requests` recording rule expression for kubelet status.
+
 ## [2.140.0] - 2023-11-13
 
 ### Added
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new alert that fires if etcd backup metrics are missing for 12h.
 
 ## [2.139.0] - 2023-11-07
-
-### Fixed
-
-- Fix `raw_slo_requests` recording rule expression for kubelet status.
 
 ### Added
 


### PR DESCRIPTION
### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
