### PR TITLE
Use `exported_namespace` for certificate expiration alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `raw_slo_requests` recording rule expression for kubelet status.
+- Use `exported_namespace` for certificate expiration alerts.
 
 ## [2.140.0] - 2023-11-13
 

--- a/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/certificate.all.rules.yml
@@ -60,7 +60,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",namespace=~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",exported_namespace=~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
@@ -71,7 +71,7 @@ spec:
       annotations:
         description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
-      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",namespace!~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
+      expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",exported_namespace!~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"

--- a/test/tests/providers/capi/capz/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/capz/certificate.all.rules.test.yml
@@ -21,6 +21,7 @@ tests:
               cluster_type: management_cluster
               container: cert-exporter
               customer: giantswarm
+              exported_namespace: giantswarm
               instance: 10.0.0.0:1234
               job: gollem-prometheus/workload-gollem/0
               namespace: giantswarm
@@ -64,6 +65,7 @@ tests:
               cluster_type: workload_cluster
               container: cert-exporter
               customer: giantswarm
+              exported_namespace: kube-system
               instance: 10.0.0.0:1234
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system

--- a/test/tests/providers/capi/capz/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/capz/certificate.all.rules.test.yml
@@ -6,7 +6,7 @@ tests:
   # CertificateSecretWillExpireInLessThanTwoWeeks within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
@@ -41,7 +41,7 @@ tests:
   # CertificateSecretWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
@@ -49,7 +49,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
@@ -85,7 +85,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks

--- a/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
@@ -21,6 +21,7 @@ tests:
               cluster_type: management_cluster
               container: cert-exporter
               customer: giantswarm
+              exported_namespace: giantswarm
               instance: 10.0.0.0:1234
               job: gollem-prometheus/workload-gollem/0
               namespace: giantswarm
@@ -64,6 +65,7 @@ tests:
               cluster_type: workload_cluster
               container: cert-exporter
               customer: giantswarm
+              exported_namespace: kube-system
               instance: 10.0.0.0:1234
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system

--- a/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
@@ -6,7 +6,7 @@ tests:
   # CertificateSecretWillExpireInLessThanTwoWeeks within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
@@ -41,7 +41,7 @@ tests:
   # CertificateSecretWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
+      - series: 'cert_exporter_secret_not_after{app="cert-exporter-deployment", cluster_id="gollem", cluster_type="management_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", job="gollem-prometheus/workload-gollem/0", name="athena-certs-secret", namespace="giantswarm", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-5c47b4c55c-49wt9", provider="kvm", secretkey="tls.crt", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: CertificateSecretWillExpireInLessThanTwoWeeks
@@ -49,7 +49,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
@@ -85,7 +85,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="giantswarm", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="kvm", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks

--- a/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
+++ b/test/tests/providers/capi/openstack/certificate.all.rules.test.yml
@@ -65,7 +65,7 @@ tests:
               cluster_type: workload_cluster
               container: cert-exporter
               customer: giantswarm
-              exported_namespace: kube-system
+              exported_namespace: giantswarm
               instance: 10.0.0.0:1234
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system

--- a/test/tests/providers/vintage/aws/certificate.all.rules.test.yml
+++ b/test/tests/providers/vintage/aws/certificate.all.rules.test.yml
@@ -49,7 +49,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="aws", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="aws", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
@@ -85,7 +85,7 @@ tests:
   # GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks not within 2 weeks of expiration
   - interval: 1d
     input_series:
-      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="aws", service_priority="highest"}'
+      - series: 'cert_exporter_certificate_cr_not_after{app="cert-exporter-deployment", cluster_id="12345", cluster_type="workload_cluster", container="cert-exporter", customer="giantswarm", installation="gollem", instance="10.0.0.0:1234", issuer_ref="kiam-ca-issuer", job="12345-prometheus/workload-12345/0", managed_issuer="true", name="kiam-agent", namespace="kube-system", exported_namespace="hello", node="10.0.0.0", organization="giantswarm", pod="cert-exporter-deployment-57bbbfd856-8r8dr", provider="aws", service_priority="highest"}'
         values: "2678400x60"
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks

--- a/test/tests/providers/vintage/aws/certificate.all.rules.test.yml
+++ b/test/tests/providers/vintage/aws/certificate.all.rules.test.yml
@@ -64,6 +64,7 @@ tests:
               cluster_type: workload_cluster
               container: cert-exporter
               customer: giantswarm
+              exported_namespace: kube-system
               instance: 10.0.0.0:1234
               job: 12345-prometheus/workload-12345/0
               namespace: kube-system


### PR DESCRIPTION
The `CustomerManagedCertificateCRWillExpireInLessThanTwoWeeks` and `GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks` use the `namespace` label to check whom a certificate belongs to, but the metrics have that information in the `exported_namespace` field instead:

![Screenshot_20231113_113506](https://github.com/giantswarm/prometheus-rules/assets/868430/8a6919e7-8aec-4f84-bfec-608d4f975e37)


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
