### PR TITLE
Add two aggregations about images from Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add two aggregations to track usage of Docker Hub
+  - `aggregation:docker:containers_using_dockerhub_image`: Number of containers running iwht image from docker.io.
+  - `aggregation:docker:containers_using_dockerhub_image_relative`: Percentage of all running containers that use an image from docker.io (range 0.0 to 1.0).
+
 ## [2.141.0] - 2023-11-15
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -105,6 +105,10 @@ spec:
     rules:
     - expr: sum(engine_daemon_image_actions_seconds_count) by (cluster_id, cluster_type, action)
       record: aggregation:docker:action_count
+    - expr: sum(kube_pod_container_info{image=~"docker\\.io/.*"})
+      record: aggregation:docker:containers_using_dockerhub_image
+    - expr: sum(kube_pod_container_info{image=~"docker\\.io/.*"}) / sum(kube_pod_container_info{})
+      record: aggregation:docker:containers_using_dockerhub_image_relative
   - name: certificates.grafana-cloud.recording
     rules:
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2882

Adds two aggregations to track usage of Docker Hub:

- `aggregation:docker:containers_using_dockerhub_image`: Number of containers running with image from docker.io.
- `aggregation:docker:containers_using_dockerhub_image_relative`: Percentage of all running containers that use an image from docker.io (range 0.0 to 1.0).