### PR TITLE
Fix aggregation rules counting docker.io images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix counting of docker.io images by using the `image_spec` label instead of `image`:
+  - `aggregation:docker:containers_using_dockerhub_image`
+  - `aggregation:docker:containers_using_dockerhub_image_relative`
+
 ## [2.142.1] - 2023-11-20
 
 ### Changed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -105,9 +105,9 @@ spec:
     rules:
     - expr: sum(engine_daemon_image_actions_seconds_count) by (cluster_id, cluster_type, action)
       record: aggregation:docker:action_count
-    - expr: sum(kube_pod_container_info{image=~"docker\\.io/.*"} or kube_pod_init_container_info{image=~"docker\\.io/.*"})
+    - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"})
       record: aggregation:docker:containers_using_dockerhub_image
-    - expr: sum(kube_pod_container_info{image=~"docker\\.io/.*"} or kube_pod_init_container_info{image=~"docker\\.io/.*"}) / sum(kube_pod_container_info{} or kube_pod_init_container_info{})
+    - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) / sum(kube_pod_container_info{} or kube_pod_init_container_info{})
       record: aggregation:docker:containers_using_dockerhub_image_relative
   - name: certificates.grafana-cloud.recording
     rules:


### PR DESCRIPTION
Toward https://github.com/giantswarm/roadmap/issues/2882

This PR fixes two aggregation rules that would previously report too low numbers because they looked at the wrong label.

### Checklist

- [x] Update CHANGELOG.md
