### PR TITLE
Fix container image  aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix aggregation:container:images by adding the namespace to avoid issues when one application is deployed multiple times in one cluster.
+
 ## [2.143.0] - 2023-11-21
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -476,12 +476,12 @@ spec:
     - expr: |-
         label_replace(
           label_replace(
-                count by (cluster_id, pod, image) (kube_pod_init_container_info{image=~".*giantswarm.*"})
-              * on (cluster_id, pod) group_left (label_application_giantswarm_io_team)
+                count by (cluster_id, pod, image, namespace) (kube_pod_init_container_info{image=~".*giantswarm.*"})
+              * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
                 kube_pod_labels
             or
-                count by (cluster_id, pod, image) (kube_pod_container_info{image=~".*giantswarm.*"})
-              * on (cluster_id, pod) group_left (label_application_giantswarm_io_team)
+                count by (cluster_id, pod, image, namespace) (kube_pod_container_info{image=~".*giantswarm.*"})
+              * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
                 kube_pod_labels,
             "team",
             "$2",


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
