### PR TITLE
Make aggregation:container:images an aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `aggregation:container:images` an aggregation to avoid sending too much data to Grafana Cloud.
+
 ## [2.143.1] - 2023-11-21
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -109,6 +109,29 @@ spec:
       record: aggregation:docker:containers_using_dockerhub_image
     - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) / sum(kube_pod_container_info{} or kube_pod_init_container_info{})
       record: aggregation:docker:containers_using_dockerhub_image_relative
+    - expr: |-
+        count by (image, team) (
+          label_replace(
+            label_replace(
+                  count by (cluster_id, pod, image, namespace) (kube_pod_init_container_info{image=~".*giantswarm.*"})
+                * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
+                  kube_pod_labels
+              or
+                  count by (cluster_id, pod, image, namespace) (kube_pod_container_info{image=~".*giantswarm.*"})
+                * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
+                  kube_pod_labels,
+              "team",
+              "$2",
+              "label_application_giantswarm_io_team",
+              "(team-)?(.*)"
+            ),
+            "label_application_giantswarm_io_team",
+            "",
+            "label_application_giantswarm_io_team",
+            ".*"
+          )
+        )
+      record: aggregation:container:images
   - name: certificates.grafana-cloud.recording
     rules:
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)
@@ -473,24 +496,3 @@ spec:
       record: aggregation:container:memory_usage_bytes
     - expr: sum(rate(container_cpu_usage_seconds_total{cluster_type="management_cluster"}[2m])) by (container)
       record: aggregation:container:cpu_usage_cores
-    - expr: |-
-        label_replace(
-          label_replace(
-                count by (cluster_id, pod, image, namespace) (kube_pod_init_container_info{image=~".*giantswarm.*"})
-              * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
-                kube_pod_labels
-            or
-                count by (cluster_id, pod, image, namespace) (kube_pod_container_info{image=~".*giantswarm.*"})
-              * on (cluster_id, pod, namespace) group_left (label_application_giantswarm_io_team)
-                kube_pod_labels,
-            "team",
-            "$2",
-            "label_application_giantswarm_io_team",
-            "(team-)?(.*)"
-          ),
-          "label_application_giantswarm_io_team",
-          "",
-          "label_application_giantswarm_io_team",
-          ".*"
-        )
-      record: aggregation:container:images


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR makes the the  aggregation:container:images an aggregation

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
