### PR TITLE
add team in SLO alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Relabel team in `ServiceLevelBurnRateTooHigh` alert.
+
 ## [2.143.2] - 2023-11-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -16,16 +16,30 @@ spec:
         opsrecipe: service-level-burn-rate-too-high/
         dashboard: https://giantswarm.grafana.net/d/service-level/service-level?orgId=1
       expr: |
-        (
-          slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"} > on (service) group_left slo_threshold_high
-        and
-          slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"} > on (service) group_left slo_threshold_high
-        )
-        or
-        (
-          slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"} > on (service) group_left slo_threshold_low
-        and
-          slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"} > on (service) group_left slo_threshold_low
+        label_replace(
+            (
+                  slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                > on (service) group_left ()
+                  slo_threshold_high
+              and
+                  slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                > on (service) group_left ()
+                  slo_threshold_high
+            )
+          or
+            (
+                  slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                > on (service) group_left ()
+                  slo_threshold_low
+              and
+                  slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                > on (service) group_left ()
+                  slo_threshold_low
+            ),
+          "team",
+          "$1",
+          "label_application_giantswarm_io_team",
+          "(.*)"
         )
       for: 5m
       labels:
@@ -35,4 +49,4 @@ spec:
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: '{{`{{ $labels.label_application_giantswarm_io_team }}`}}'
+        team: '{{`{{ $labels.team }}`}}'


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/28751

This PR relabel the team label so alerts can be grouped by the team label in alertmanager configuration

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
