### PR TITLE
Reduced sensitivity for lokiringunhealthy alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- reduced sensitivity for lokiringunhealthy
+
 ## [2.143.2] - 2023-11-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.all.rules.yml
@@ -53,7 +53,7 @@ spec:
         description: '{{`Loki pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) sees {{ $value }} unhealthy ring members`}}'
         opsrecipe: loki/
       expr: |
-        sum (min_over_time(cortex_ring_members{state="Unhealthy"}[10m])) by (app, cluster_id, container, customer, installation, name, namespace, organization, pod) > 0
+        sum (min_over_time(cortex_ring_members{state="Unhealthy"}[30m])) by (app, cluster_id, container, customer, installation, name, namespace, organization, pod) > 0
       labels:
         area: managedservices
         cancel_if_apiserver_down: "true"

--- a/test/tests/providers/global/loki.all.rules.test.yml
+++ b/test/tests/providers/global/loki.all.rules.test.yml
@@ -72,7 +72,7 @@ tests:
         eval_time: 25m  # after 25 minutes we have an unhealthy member, but we want to filter too short events. So no alert yet.
         exp_alerts:
       - alertname: LokiRingUnhealthy
-        eval_time: 40m  # now the event has been there for 20 minutes, we should have an alert.
+        eval_time: 60m  # now the event has been there for 20 minutes, we should have an alert.
         exp_alerts:
           - exp_labels:
               app: loki-compactor


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28842
This PR reduces sensitivity for lokiringunhealthy alerts, so we get less "false" alerts when ring fixes itself.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
