### PR TITLE
Ignore `api-spec` fromapp without team alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Ignore `api-spec` from `AppWithoutTeamAnnotation` alert.
+
 ## [2.145.0] - 2023-11-30
 
 ### Fixed
@@ -16,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - reduced sensitivity for lokiringunhealthy
-
-### Removed
-
-- Ignore `akv2k8s` and `opencost` from `AppWithoutTeamAnnotation` alert.
 
 ## [2.144.0] - 2023-11-27
 

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -105,9 +105,9 @@ spec:
         description: '{{`App {{ $labels.name }} has no team label.`}}'
         opsrecipe: app-without-team-annotation/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: label_replace(app_operator_app_info{app!~"akv2k8s|opencost", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
+      expr: label_replace(app_operator_app_info{app!~"api-spec", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}, "cluster_id", "$1", "name", "([a-zA-Z0-9]+)-.*") == 1
       {{- else }}
-      expr: label_replace(app_operator_app_info{app!~"akv2k8s|opencost", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
+      expr: label_replace(app_operator_app_info{app!~"api-spec", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       {{- end }}
       for: 40m
       labels:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/29088#issuecomment-1834067896

This PR ignores api-spec for now

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
