### PR TITLE
Add KarpenterDeploymentNotSatisfied as notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alert for `karpenter` deployment not satisfied.
+
 ### Removed
 
 - Ignore `api-spec` from `AppWithoutTeamAnnotation` alert.

--- a/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         dashboard: e8ea41bb-55a8-48c5-a070-262551ad3722/karpenter
         description: '{{`Karpenter Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
-      expr: managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} / managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} < 0.9
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"karpenter.*"}) < 0.9
       for: 30m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
@@ -12,8 +12,8 @@ spec:
     rules:
     - alert: KarpenterDeploymentNotSatisfied
       annotations:
+        dashboard: e8ea41bb-55a8-48c5-a070-262551ad3722/karpenter
         description: '{{`Karpenter Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
-        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
       expr: managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} / managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} < 0.9
       for: 30m
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/karpenter.workload-cluster.rules.yml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: karpenter.workload-cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: karpenter
+    rules:
+    - alert: KarpenterDeploymentNotSatisfied
+      annotations:
+        description: '{{`Karpenter Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} / managed_app_deployment_status_replicas_available{managed_app=~"karpenter.*"} < 0.9
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_outside_working_hours: "false"
+        severity: notify
+        team: phoenix
+        topic: kubernetes


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27850 _(Create alerts for Karpenter being down (i.e. pods not up&running))_

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
