### PR TITLE
add container-level resources recording rule for grafana cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add container-level resources recording rule for grafana cloud
+
 ### Changed
 
 - Fix expression for KongDeploymentNotSatisfied

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -321,6 +321,10 @@ spec:
       record: aggregation:node:memory_memfree_bytes_total
     - expr: sum(node_memory_MemTotal_bytes) by (cluster_type, cluster_id)
       record: aggregation:node:memory_memtotal_bytes_total
+    - expr: sum(container_memory_usage_bytes) by (namespace, container, pod)
+      record: aggregation:container:memory_usage_bytes
+    - expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (namespace, container, pod)
+      record: aggregation:container:cpu_usage_seconds_total
     - expr: sum(rate(node_network_receive_bytes_total[5m])) by (cluster_type, cluster_id)
       record: aggregation:node:network_receive_bytes_total
     - expr: sum(rate(node_network_transmit_bytes_total[5m])) by (cluster_type, cluster_id)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/2931

This PR adds 2 recording ruels for grafana cloud to retrieve container-level resources consumption.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
