### PR TITLE
remove-WorkloadClusterManagedDeploymentNotSatisfiedPhoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Ignore `api-spec` from `AppWithoutTeamAnnotation` alert.
+- Remove `WorkloadClusterManagedDeploymentNotSatisfiedPhoenix` as `cert-manager` is no longer owned by Phoenix.
+
 
 ## [2.145.0] - 2023-11-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.workload-cluster.rules.yml
@@ -48,18 +48,6 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: observability
-    - alert: WorkloadClusterManagedDeploymentNotSatisfiedPhoenix
-      annotations:
-        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
-        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: label_join(managed_app_deployment_status_replicas_unavailable{cluster_type="workload_cluster", managed_app=~"cert-manager.*"}, "service", "/", "namespace", "deployment") > 0
-      for: 30m
-      labels:
-        area: managedservices
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: page
-        team: phoenix
-        topic: releng
     - alert: WorkloadClusterDeploymentScaledDownToZero
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled down to zero for prolonged period of time.`}}'


### PR DESCRIPTION
Team Phoenix no longer owns `cert-manager` and as this was the only app monitored by this rule I am removing the whole alert.

The alert of the app si already covered by the` ServiceLevelBurnRateTooHigh` alert and its in proper team/area.