### PR TITLE
Increase the timewindow for `NodeConnTrackAlmostExhausted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increase the time window for `NodeConnTrackAlmostExhausted`.
 - Fix expression for KongDeploymentNotSatisfied
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
@@ -50,10 +50,10 @@ spec:
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
-        description: '{{`Node {{ $labels.node }} reports a connection usage above 90%.`}}'
+        description: '{{`Node {{ $labels.node }} reports a connection usage above 85% for the last 15 minutes.`}}'
         opsrecipe: node-conntrack-limits/
-      expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit >= 0.90
-      for: 5m
+      expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit >= 0.85
+      for: 15m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -78,10 +78,10 @@ spec:
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
-        description: '{{`Node {{ $labels.node }} reports a connection usage above 90%.`}}'
+        description: '{{`Node {{ $labels.node }} reports a connection usage above 85% for the last 15 minutes.`}}'
         opsrecipe: node-conntrack-limits/
-      expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit >= 0.90
-      for: 5m
+      expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit >= 0.85
+      for: 15m
       labels:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27926

This PR increases the timewindow for `NodeConnTrackAlmostExhausted`. We
noticed that having only a timewindow of 5 minutes is not enough,
usually conntrack table gets cleaned up and the alert is autoclosing.

Additionally we'll prepare an SLO for `NodeConnTrackAlmostExhausted`
for having a broader view on the cluster to detect widespread issues.

The alert is only within working hours.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).