### PR TITLE
update ops recipe link for prometheus-agent alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update ops recipe link for all prometheus-agent alerts.
+
 ## [2.147.0] - 2024-01-09
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-agent.rules.yml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: '{{`Prometheus agent remote write is failing.`}}'
         summary: Prometheus agent fails to send samples to remote write endpoint.
-        opsrecipe: prometheus-agent-remote-write-failed/
+        opsrecipe: prometheus-agent/
         dashboard: promRW001/prometheus-remote-write
       #  expr: count(absent_over_time(up{instance="prometheus-agent"}[10m]))
       expr: |-
@@ -43,7 +43,7 @@ spec:
       annotations:
         description: '{{`Prometheus agent remote write is failing.`}}'
         summary: Prometheus agent fails to send samples to remote write endpoint.
-        opsrecipe: prometheus-agent-remote-write-failed/
+        opsrecipe: prometheus-agent/
         dashboard: promRW001/prometheus-remote-write
       #  expr: count(absent_over_time(up{instance="prometheus-agent"}[10m]))
       expr: |-
@@ -70,7 +70,7 @@ spec:
       annotations:
         description: '{{`Prometheus agent is missing shards.`}}'
         summary: Prometheus agent is missing shards.
-        opsrecipe: prometheus-agent-missing-shards/
+        opsrecipe: prometheus-agent/
       expr: |-
         max_over_time(sum(
           count(
@@ -106,7 +106,7 @@ spec:
       annotations:
         description: '{{`Prometheus agent is missing shards.`}}'
         summary: Prometheus agent is missing shards.
-        opsrecipe: prometheus-agent-missing-shards/
+        opsrecipe: prometheus-agent/
       expr: |-
         max_over_time(sum(
           count(

--- a/test/tests/providers/global/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/global/prometheus-agent.rules.test.yml
@@ -25,7 +25,7 @@ tests:
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
-              opsrecipe: "prometheus-agent-remote-write-failed/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailingInhibition
         eval_time: 30m
@@ -43,7 +43,7 @@ tests:
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
-              opsrecipe: "prometheus-agent-remote-write-failed/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailing
         eval_time: 90m
@@ -64,7 +64,7 @@ tests:
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
-              opsrecipe: "prometheus-agent-remote-write-failed/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailingInhibition
         eval_time: 90m
@@ -85,7 +85,7 @@ tests:
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
-              opsrecipe: "prometheus-agent-remote-write-failed/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent fails to send samples to remote write endpoint."
       - alertname: PrometheusAgentFailing
         eval_time: 150m
@@ -124,7 +124,7 @@ tests:
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Prometheus agent is missing shards."
-              opsrecipe: "prometheus-agent-missing-shards/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent is missing shards."
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 100m
@@ -141,7 +141,7 @@ tests:
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Prometheus agent is missing shards."
-              opsrecipe: "prometheus-agent-missing-shards/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent is missing shards."
       - alertname: PrometheusAgentShardsMissing
         eval_time: 125m
@@ -158,7 +158,7 @@ tests:
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Prometheus agent is missing shards."
-              opsrecipe: "prometheus-agent-missing-shards/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent is missing shards."
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 125m
@@ -175,7 +175,7 @@ tests:
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Prometheus agent is missing shards."
-              opsrecipe: "prometheus-agent-missing-shards/"
+              opsrecipe: "prometheus-agent/"
               summary: "Prometheus agent is missing shards."
       - alertname: PrometheusAgentShardsMissing
         eval_time: 130m


### PR DESCRIPTION
This PR updates the ops recipe link for the prometheus-agent alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
