### PR TITLE
focus only on `Provisioned` clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed teleport alerts to take into accont only `Provisioned` clusters
+
 ## [2.148.0] - 2024-01-17
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: TeleportJoinTokenSecretMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-join-token secrets and clusters`}}'
-      expr: count(kube_secret_created{secret=~".*-teleport-join-token"}) != count(capi_cluster_info{control_plane_reference_kind="KubeadmControlPlane"})
+      expr: count(kube_secret_created{secret=~".*-teleport-join-token"}) != sum(capi_cluster_status_phase{phase="Provisioned"})
       for: 30m
       labels:
         area: kaas
@@ -27,7 +27,7 @@ spec:
     - alert: TeleportKubeAgentConfigMapMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-kube-agent-config secrets and clusters`}}'
-      expr: count(kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}) != count(capi_cluster_info{control_plane_reference_kind="KubeadmControlPlane"})
+      expr: count(kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}) != sum(capi_cluster_status_phase{phase="Provisioned"})
       for: 30m
       labels:
         area: kaas

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -9,7 +9,7 @@ tests:
         values: "1+0x40 1+0x40"
       - series: 'kube_secret_created{secret="test-teleport-join-token"}'
         values: "_x40   1+0x40"
-      - series: 'capi_cluster_info{control_plane_reference_kind="KubeadmControlPlane"}'
+      - series: 'capi_cluster_status_phase{phase="Provisioned"}'
         values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportJoinTokenSecretMismatch
@@ -36,7 +36,7 @@ tests:
         values: "1+0x40 1+0x40"
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="grizzly", configmap="test-teleport-kube-agent-config"}'
         values: "_x40   1+0x40"
-      - series: 'capi_cluster_info{cluster_id="grizzly", control_plane_reference_kind="KubeadmControlPlane"}'
+      - series: 'capi_cluster_status_phase{phase="Provisioned",name="grizzly"}'
         values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportKubeAgentConfigMapMismatch


### PR DESCRIPTION
Towards: [Thread](https://gigantic.slack.com/archives/C053JHJC99Q/p1705500007611519)

This PR fixes the issue where alerts on Teleport resources were being triggered, when a cluster was getting deleted and the cluster resource was left on `Deleting` state for while, when the secret and the configmap had already been deleted.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
