### PR TITLE
Ship dipstick metrics to grafana cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ship `dipstick` metrics to Grafana Cloud.
+
 ## [2.148.0] - 2024-01-17
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -355,6 +355,17 @@ spec:
     rules:
     - expr: sum(increase(grafana_analytics_sessions_total[60s]) / (132 / 99)) without (user_email, user_name)
       record: aggregation:grafana_analytics_sessions_total
+  - name: dipstick.grafana-cloud.recording
+    rules:
+    # Ship dipstick policy metrics.
+    - expr: sum(dipstick_policyreport_policy_summary) by (cluster_id, policy_name, result)
+      record: aggregation:dipstick_policy_results
+    - expr: sum(dipstick_policyreport_policy_report_count) by (cluster_id)
+      record: aggregation:dipstick_policy_count
+    - expr: sum(dipstick_policyreport_last_update_duration_seconds) by (cluster_id)
+      record: aggregation:dipstick_policy_scrape_duration_seconds
+    - expr: sum(dipstick_policyreport_last_update_timestamp_seconds) by (cluster_id)
+      record: aggregation:dipstick_policy_last_scrape_timestamp_seconds
   - name: falco.grafana-cloud.recording
     rules:
     # Falco event counts


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/29351

This PR sends aggregated metrics from dipstick to grafana cloud.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
