### PR TITLE
Check creation CAPI cluster creation time on `LatestETCDBackup2DaysOld`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Check creation CAPI cluster creation time before paging `LatestETCDBackup2DaysOld`.
+
 ## [2.150.1] - 2024-01-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Check creation CAPI cluster creation time before paging `LatestETCDBackup2DaysOld`.
-=======
+
 ### Changed
 
 - Rename `dipstick` report count metric.

--- a/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/etcdbackup.rules.yml
@@ -23,11 +23,12 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd
-    - alert: LatestETCDBackup1DayOld
+{{- if eq .Values.managementCluster.provider.flavor "capi" }}
+    - alert: LatestETCDBackup2DaysOld
       annotations:
-        description: '{{`Latest successfull ETCD backup for {{ $labels.cluster_id }}/{{ $labels.tenant_cluster_id }} was more than 24h ago.`}}'
+        description: '{{`Latest successfull ETCD backup for {{ $labels.cluster_id }}/{{ $labels.tenant_cluster_id }} was more than 48h ago.`}}'
         opsrecipe: etcd-backup-failed/
-      expr: (time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) > 24 * 60 * 60 and (time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) < 48 * 60 * 60
+      expr: count(label_replace(capi_cluster_created, "tenant_cluster_id", "$1", "name", "(.*)")) by (tenant_cluster_id)  > 48 * 60 * 60 unless count((time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) > 48 * 60 * 60) by (tenant_cluster_id)
       for: 5m
       labels:
         area: kaas
@@ -35,9 +36,10 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd-backup
+{{- else }}
     - alert: LatestETCDBackup2DaysOld
       annotations:
         description: '{{`Latest successfull ETCD backup for {{ $labels.cluster_id }}/{{ $labels.tenant_cluster_id }} was more than 48h ago.`}}'
@@ -53,6 +55,7 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: etcd-backup
+{{- end }}
     - alert: ManagementClusterNotBackedUp24h
       annotations:
         description: '{{`{{ $labels.cluster_id }} management cluster''s ETCD backup was unsuccessful.`}}'


### PR DESCRIPTION
We do get from time to time pages for `LatestETCDBackup2DaysOld` when clusters don’t have a backup for more than 48h. 

It seems to happen unintended if a cluster gets deleted and get recreated.

Example you have a test cluster `foobar`, you let it run for a while. We make a backup of your cluster, you delete the cluster after some hours. After 2 days you recreating the same cluster (using the same name) and we get a page for that cluster.

This aims more to an issue of CAPI since many of us are reusing the same cluster name

**Adjustments for CAPI**

This is a Prometheus query that checks if there are any tenant clusters that have been created more than 48 hours ago but do not have a successful ETCD backup in the last 48 hours.

Additionally I dropped `LatestETCDBackup1DayOld` this was only notifying, no one looked at it