### PR TITLE
Update dipstick metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `dipstick` report count metric.
+
 ## [2.150.1] - 2024-01-24
 
 ### Fixed

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -361,7 +361,7 @@ spec:
     - expr: sum(dipstick_policyreport_policy_summary) by (cluster_id, policy_name, result)
       record: aggregation:dipstick_policy_results
     - expr: sum(dipstick_policyreport_policy_report_count) by (cluster_id)
-      record: aggregation:dipstick_policy_count
+      record: aggregation:dipstick_policy_report_count
     - expr: sum(dipstick_policyreport_last_update_duration_seconds) by (cluster_id)
       record: aggregation:dipstick_policy_scrape_duration_seconds
     - expr: sum(dipstick_policyreport_last_update_timestamp_seconds) by (cluster_id)


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/29351

This PR renames a metric sent to grafana cloud to a more correct name.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
