### PR TITLE
change machine health status related alerts to page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `dipstick` report count metric.
+- Changed `MachinePoolReplicasMismatch` and `MachineUnhealthyPhase` to page.
 
 ## [2.150.1] - 2024-01-24
 

--- a/helm/prometheus-rules/templates/alerting-rules/capi-machine.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi-machine.rules.yml
@@ -19,7 +19,7 @@ spec:
           labels:
             area: kaas
             cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
-            severity: notify
+            severity: page
             team: {{include "providerTeam" .}}
             topic: managementcluster
 

--- a/helm/prometheus-rules/templates/alerting-rules/capi-machinepool.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/capi-machinepool.rules.yml
@@ -15,7 +15,7 @@ spec:
           labels:
             area: kaas
             cancel_if_outside_working_hours: {{include "workingHoursOnly" .}}
-            severity: notify
+            severity: page
             team: {{include "providerTeam" .}}
             topic: managementcluster
           annotations:

--- a/test/tests/providers/capi/capz/capi-machine.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machine.rules.test.yml
@@ -17,7 +17,7 @@ tests:
           - exp_labels:
               area: kaas
               cancel_if_outside_working_hours: "false"
-              severity: notify
+              severity: page
               team: phoenix
               topic: managementcluster
               cluster_name: clippaxy

--- a/test/tests/providers/capi/capz/capi-machinepool.rules.test.yml
+++ b/test/tests/providers/capi/capz/capi-machinepool.rules.test.yml
@@ -21,7 +21,7 @@ tests:
           - exp_labels:
               area: kaas
               cancel_if_outside_working_hours: "false"
-              severity: notify
+              severity: page
               team: phoenix
               topic: managementcluster
               cluster_name: clippaxy


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29204

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
