### PR TITLE
Move DNS related alerts to cabbage

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: cabbage
         topic: network
     - alert: DNSCheckErrorRateTooHigh
       annotations:
@@ -42,7 +42,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: cabbage
         topic: network
     - alert: NetworkErrorRateTooHigh
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: rate(dns_resolve_error_total[15m]) > 0.015
       for: 15m
       labels:
-        area: kaas
+        area: empowerment
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
@@ -34,7 +34,7 @@ spec:
       expr: rate(dns_error_total[15m]) > 0.015
       for: 15m
       labels:
-        area: kaas
+        area: empowerment
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"


### PR DESCRIPTION
during our alerts session we have identified alerts that probably should land on cabbage plate - ping in channel if discussion is needed