### PR TITLE
Fix PVC alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `PersistentVolumeSpaceTooLow` to ignore the observability components and `DataDiskPersistentVolumeSpaceTooLow` to alert on the new observability stack components.
+
 ## [2.153.0] - 2024-02-27
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.management-cluster.rules.yml
@@ -71,18 +71,6 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
-    - alert: PersistentVolumeSpaceTooLow
-      annotations:
-        description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
-        opsrecipe: low-disk-space/#persistent-volume
-      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*",mountpoint!~".*prometheus/[0-9]+"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*",mountpoint!~".*prometheus/[0-9]+"}) * on (pod) group_left kube_pod_info{priority_class!="prometheus"}) < 10
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: {{ include "providerTeam" . }}
-        topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
         description: '{{`Root volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
@@ -95,11 +83,50 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: storage
+    - alert: PersistentVolumeSpaceTooLow
+      annotations:
+        description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
+        opsrecipe: low-disk-space/#persistent-volume
+      expr: |
+        100 * (
+          label_replace(
+            (
+                node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}
+              /
+                node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}
+            ),
+            "uid",
+            "$1",
+            "mountpoint",
+            "/var/lib/kubelet/pods/([^/]+).*"
+          )
+          * on (uid) group_left (affected_pod, affected_namespace)
+          label_replace(
+            label_replace(
+              kube_pod_info{pod!~"(alertmanager|loki|mimir|prometheus|pyroscope|tempo).*"},
+              "affected_pod",
+              "$1",
+              "pod",
+              "(.*)"
+            ),
+            "affected_namespace",
+            "$1",
+            "namespace",
+            "(.*)"
+          )
+        ) < 10
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: storage
     - alert: DataDiskPersistentVolumeSpaceTooLow
       annotations:
         description: '{{`The free space on the Data Disk for instance: {{ $labels.instance }} and PVC: {{ $labels.persistentvolumeclaim}} was below 10 percent for longer than 1 hour (current value {{ $value | printf "%.2f" }}).`}}'
         opsrecipe: low-disk-space/#persistent-volume
-      expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"prometheus.*|alertmanager.*"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"prometheus.*|alertmanager.*"} < 0.10
+      expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo).*"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo).*"} < 0.10
       for: 1h
       labels:
         area: empowerment


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/29004

This PR prevents kaas team from being alerted for atlas components and page atlas in for their PVs

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
