### PR TITLE
Increase duration for fluentbit rules to avoid false alerts when a ne…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change ownership of `CadvisorDown` to Turtles/Phoenix.
 - Review alerting prior to Mimir migration.
+- Increase duration for fluentbit rules to avoid false alerts when a new release is deployed.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/fluentbit.rules.yml
@@ -16,7 +16,7 @@ spec:
         opsrecipe: fluentbit-too-many-erros/
       # If we have some failures sending data, raise an alert
       expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
-      for: 10m
+      for: 20m
       labels:
         area: empowerment
         cancel_if_cluster_status_creating: "true"
@@ -32,7 +32,7 @@ spec:
         opsrecipe: fluentbit-too-many-erros/
       # Check the ratio of dropped records over the total number of records.
       expr: rate(fluentbit_output_dropped_records_total[10m]) / (rate(fluentbit_output_proc_records_total[10m]) + rate(fluentbit_output_dropped_records_total[10m])) > 0.01
-      for: 10m
+      for: 20m
       labels:
         area: empowerment
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/30187

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
