### PR TITLE
Improve Alb alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new mimir.enabled property to disable the MC/WC split in alerts.
+- Add new alert for reconciling errors of `AWS load balancer controller`.
 
 ### Changed
 
 - Change ownership of `CadvisorDown` to Turtles/Phoenix.
 - Review alerting prior to Mimir migration.
 - Increase duration for fluentbit rules to avoid false alerts when a new release is deployed.
-- Improve `AWS load balancer controller` alert's query.
+- Improve `AWS load balancer controller` alert for failed AWS calls query.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change ownership of `CadvisorDown` to Turtles/Phoenix.
 - Review alerting prior to Mimir migration.
 - Increase duration for fluentbit rules to avoid false alerts when a new release is deployed.
+- Improve `AWS load balancer controller` alert's query.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -29,19 +29,19 @@ spec:
         severity: page
         team: phoenix
         topic: alb
-      - alert: AWSLoadBalancerControllerReconcileErrors
-        annotations:
-          description: '{{`AWS load balancer controller pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.cluster_id }} is throwing errors while reconciling the {{ $labels.controller }} controller.`}}'
-          opsrecipe: alb-errors
-        expr: sum(increase(controller_runtime_reconcile_total{result = "error"}[20m])) by (controller,namespace,pod,cluster_id) > 0
-        for: 40m
-        labels:
-          area: managedservices
-          cancel_if_cluster_status_creating: "true"
-          cancel_if_cluster_status_deleting: "true"
-          cancel_if_cluster_status_updating: "true"
-          cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-          severity: page
-          team: phoenix
-          topic: alb
+    - alert: AWSLoadBalancerControllerReconcileErrors
+      annotations:
+        description: '{{`AWS load balancer controller pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.cluster_id }} is throwing errors while reconciling the {{ $labels.controller }} controller.`}}'
+        opsrecipe: alb-errors
+      expr: sum(increase(controller_runtime_reconcile_total{result = "error"}[20m])) by (controller,namespace,pod,cluster_id) > 0
+      for: 40m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: phoenix
+        topic: alb
 {{- end }}

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -14,26 +14,11 @@ spec:
   groups:
   - name: aws-load-balancer-controller
     rules:
-    - alert: AWSLoadBalancerAssumeRoleErrors
+    - alert: AWSLoadBalancerControllerAWSAPIErrors
       annotations:
-        description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} can not assume the role.`}}'
-        opsrecipe: alb-role-errors#assume-role-errors
-      expr: increase(aws_api_calls_total{error_code="WebIdentityErr"}[20m]) > 0
-      for: 40m
-      labels:
-        area: managedservices
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: page
-        team: phoenix
-        topic: alb
-    - alert: AWSLoadBalancerRolePolicyErrors
-      annotations:
-        description: '{{`AWS load balancer pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has a wrong role policy.`}}'
-        opsrecipe: alb-role-errors#role-policy-errors
-      expr: increase(aws_api_calls_total{error_code="UnauthorizedOperation"}[20m]) > 0
+        description: '{{`AWS load balancer controller pod {{ $labels.namespace}}/{{ $labels.pod }} on {{ $labels.cluster_id}} is throwing {{ $labels.error_code }} errors when contacting AWS API.`}}'
+        opsrecipe: alb-errors
+      expr: sum(increase(aws_api_calls_total{error_code != ""}[20m])) by (error_code,namespace,pod,cluster_id) > 0
       for: 40m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -29,4 +29,19 @@ spec:
         severity: page
         team: phoenix
         topic: alb
+      - alert: AWSLoadBalancerControllerReconcileErrors
+        annotations:
+          description: '{{`AWS load balancer controller pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.cluster_id }} is throwing errors while reconciling the {{ $labels.controller }} controller.`}}'
+          opsrecipe: alb-errors
+        expr: sum(increase(controller_runtime_reconcile_total{result = "error"}[20m])) by (controller,namespace,pod,cluster_id) > 0
+        for: 40m
+        labels:
+          area: managedservices
+          cancel_if_cluster_status_creating: "true"
+          cancel_if_cluster_status_deleting: "true"
+          cancel_if_cluster_status_updating: "true"
+          cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+          severity: page
+          team: phoenix
+          topic: alb
 {{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30163

This PR improves ALB alerting after some experience we made operating it.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
