### PR TITLE
Fix `AWSLoadBalancerControllerReconcileErrors` alert query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `AWSLoadBalancerControllerReconcileErrors` alert query.
+
 ## [3.0.1] - 2024-03-12
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -33,7 +33,7 @@ spec:
       annotations:
         description: '{{`AWS load balancer controller pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.cluster_id }} is throwing errors while reconciling the {{ $labels.controller }} controller.`}}'
         opsrecipe: alb-errors
-      expr: sum(increase(controller_runtime_reconcile_total{result = "error"}[20m])) by (controller,namespace,pod,cluster_id) > 0
+      expr: sum(increase(controller_runtime_reconcile_total{service="aws-load-balancer-controller", result = "error"}[20m])) by (controller,namespace,pod,cluster_id) > 0
       for: 40m
       labels:
         area: managedservices


### PR DESCRIPTION
restrict the alert query otherwise it pages for all pods in the cluster