### PR TITLE
Set PromtailDown alert to not page out of business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `PromtailDown` alert to not page out of business hours
+
 ### Fixed
 
 - Fix `AWSLoadBalancerControllerReconcileErrors` alert query.

--- a/helm/prometheus-rules/templates/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/promtail.rules.yml
@@ -20,6 +20,7 @@ spec:
             severity: page
             team: "atlas"
             topic: "observability"
+            cancel_if_outside_working_hours: "true"
             cancel_if_cluster_status_creating: "true"
             cancel_if_cluster_status_deleting: "true"
             cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/promtail.rules.test.yml
+++ b/test/tests/providers/global/promtail.rules.test.yml
@@ -23,6 +23,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: empowerment
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -39,6 +40,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: empowerment
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -56,6 +58,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: empowerment
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"


### PR DESCRIPTION
This PR prevents PromtailDown from paging out of business hours.
This will allow us to take some time to tune and stabilize the alert, then we can change this back when the alert does not page that often.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
