### PR TITLE
fix-teleport-alerts-for-mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix teleport alerts for mimir.
+
 ## [3.1.0] - 2024-03-13
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -13,7 +13,20 @@ spec:
     - alert: TeleportJoinTokenSecretMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-join-token secrets and clusters`}}'
-      expr: count(kube_secret_created{secret=~".*-teleport-join-token"}) by (cluster_id, installation) != sum(capi_cluster_status_phase{phase="Provisioned"}) by (cluster_id, installation)
+      expr: |
+        count (
+          kube_secret_created{secret=~".*-teleport-join-token"}
+        ) by (cluster_id, installation)
+        !=
+        sum (
+          label_replace(
+            capi_cluster_status_phase{phase="Provisioned"},
+            "cluster_id",
+            "$1",
+            "name",
+            "(.*)"
+          )
+        ) by (cluster_id, installation)
       for: 30m
       labels:
         area: kaas
@@ -27,7 +40,20 @@ spec:
     - alert: TeleportKubeAgentConfigMapMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-kube-agent-config secrets and clusters`}}'
-      expr: count(kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}) by (cluster_id, installation) != sum(capi_cluster_status_phase{phase="Provisioned"}) by (cluster_id, installation)
+      expr: |
+        count (
+          kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}
+        ) by (cluster_id, installation)
+        !=
+        sum (
+          label_replace(
+            capi_cluster_status_phase{phase="Provisioned"},
+            "cluster_id",
+            "$1",
+            "name",
+            "(.*)"
+          )
+        ) by (cluster_id, installation)
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: TeleportJoinTokenSecretMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-join-token secrets and clusters`}}'
-      expr: count(kube_secret_created{secret=~".*-teleport-join-token"}) != sum(capi_cluster_status_phase{phase="Provisioned"})
+      expr: count(kube_secret_created{secret=~".*-teleport-join-token"}) by (cluster_id, installation) != sum(capi_cluster_status_phase{phase="Provisioned"}) by (cluster_id, installation)
       for: 30m
       labels:
         area: kaas
@@ -27,7 +27,7 @@ spec:
     - alert: TeleportKubeAgentConfigMapMismatch
       annotations:
         description: '{{`Mismatch in number of teleport-kube-agent-config secrets and clusters`}}'
-      expr: count(kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}) != sum(capi_cluster_status_phase{phase="Provisioned"})
+      expr: count(kube_configmap_info{configmap=~".*-teleport-kube-agent-config"}) by (cluster_id, installation) != sum(capi_cluster_status_phase{phase="Provisioned"}) by (cluster_id, installation)
       for: 30m
       labels:
         area: kaas

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -5,11 +5,11 @@ rule_files:
 tests:
   - interval: 1m
     input_series:
-      - series: 'kube_secret_created{secret="grizzly-teleport-join-token"}'
+      - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="grizzly-teleport-join-token"}'
         values: "1+0x40 1+0x40"
-      - series: 'kube_secret_created{secret="test-teleport-join-token"}'
+      - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="test-teleport-join-token"}'
         values: "_x40   1+0x40"
-      - series: 'capi_cluster_status_phase{phase="Provisioned"}'
+      - series: 'capi_cluster_status_phase{name="my-cluster", installation="golem", phase="Provisioned"}'
         values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportJoinTokenSecretMismatch
@@ -25,6 +25,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "true"
+              cluster_id: my-cluster
+              installation: golem
               severity: page
               team: bigmac
               topic: teleport
@@ -32,11 +34,11 @@ tests:
               description: "Mismatch in number of teleport-join-token secrets and clusters"
   - interval: 1m
     input_series:
-      - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="grizzly", configmap="grizzly-teleport-kube-agent-config"}'
+      - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="grizzly-teleport-kube-agent-config"}'
         values: "1+0x40 1+0x40"
-      - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="grizzly", configmap="test-teleport-kube-agent-config"}'
+      - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="test-teleport-kube-agent-config"}'
         values: "_x40   1+0x40"
-      - series: 'capi_cluster_status_phase{phase="Provisioned",name="grizzly"}'
+      - series: 'capi_cluster_status_phase{phase="Provisioned", name="my-cluster", installation="grizzly"}'
         values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportKubeAgentConfigMapMismatch
@@ -52,6 +54,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "true"
+              cluster_id: my-cluster
+              installation: grizzly
               severity: page
               team: bigmac
               topic: teleport


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes missing labels https://giantswarm.app.opsgenie.com/alert/detail/f6383a3f-6084-4b9c-a652-33df85b539b2-1710336351839/details

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
