### PR TITLE
Add grafana-agent app to send rules to mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.1] - 2024-03-14
 
-
 ### Fixed
 
 - Fix teleport alerts for mimir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Grafana Agent App CR to be able to send our PrometheusRules CRs to Mimir.
+
 ### Fixed
 
 - Fix teleport alerts for mimir.

--- a/helm/prometheus-rules/templates/mimir-rules-grafana-agent.yaml
+++ b/helm/prometheus-rules/templates/mimir-rules-grafana-agent.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    {{- include "labels.common" . | nindent 4 }}
+  name: grafana-agent-rules
+  namespace: giantswarm
+spec:
+  catalog: giantswarm
+  config:
+    configMap:
+      name: grafana-agent-rules-config
+      namespace: mimir
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: grafana-agent
+  namespace: mimir
+  # used by renovate
+  # repo: giantswarm/grafana-agent-app
+  version: 0.4.1
+---
+apiVersion: v1
+data:
+  values: |
+    grafana-agent:
+      agent:
+        configMap:
+          content: |
+            mimir.rules.kubernetes "local" {
+              address = "http://mimir-ruler.mimir.svc:8080/"
+              tenant_id = "anonymous"
+            }
+      controller:
+        type: deployment
+      crds:
+        create: false
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: grafana-agent-rules-config
+  namespace: mimir
+{{- end }}


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
