### PR TITLE
Teleport configmap/secret rules to notify only + 120 minutes duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed severity for `TeleportJoinTokenSecret/ConfigmapMistamch` to `notify` and increased alert interval from 30m to 120m
+
 ## [3.3.0] - 2024-03-18
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -27,14 +27,14 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 30m
+      for: 120m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: bigmac
         topic: teleport
     - alert: TeleportKubeAgentConfigMapMismatch
@@ -54,13 +54,13 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 30m
+      for: 120m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: bigmac
         topic: teleport

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -27,7 +27,7 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 120m
+      for: 2h
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
@@ -54,7 +54,7 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 120m
+      for: 2h
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/teleport.rules.yml
@@ -27,7 +27,7 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 2h
+      for: 120m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"
@@ -54,7 +54,7 @@ spec:
             "(.*)"
           )
         ) by (cluster_id, installation)
-      for: 2h
+      for: 120m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -6,17 +6,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="grizzly-teleport-join-token"}'
-        values: "1+0x130 1+0x130"
+        values: "1+0x40 1+0x40"
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="test-teleport-join-token"}'
-        values: "_x130   1+0x130"
+        values: "_x40   1+0x40"
       - series: 'capi_cluster_status_phase{name="my-cluster", installation="golem", phase="Provisioned"}'
-        values: "1+0x130 1+0x130"
+        values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportJoinTokenSecretMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportJoinTokenSecretMismatch
-        eval_time: 140m
+        eval_time: 2h10m
         exp_alerts:
           - exp_labels:
               alertname: TeleportJoinTokenSecretMismatch
@@ -27,7 +27,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: my-cluster
               installation: golem
-              severity: page
+              severity: notify
               team: bigmac
               topic: teleport
             exp_annotations:
@@ -35,17 +35,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="grizzly-teleport-kube-agent-config"}'
-        values: "1+0x130 1+0x130"
+        values: "1+0x40 1+0x40"
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="test-teleport-kube-agent-config"}'
-        values: "_x130   1+0x130"
+        values: "_x40   1+0x40"
       - series: 'capi_cluster_status_phase{phase="Provisioned", name="my-cluster", installation="grizzly"}'
-        values: "1+0x130 1+0x130"
+        values: "1+0x40 1+0x40"
     alert_rule_test:
       - alertname: TeleportKubeAgentConfigMapMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportKubeAgentConfigMapMismatch
-        eval_time: 140m
+        eval_time: 2h10m
         exp_alerts:
           - exp_labels:
               alertname: TeleportKubeAgentConfigMapMismatch
@@ -56,7 +56,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: my-cluster
               installation: grizzly
-              severity: page
+              severity: notify
               team: bigmac
               topic: teleport
             exp_annotations:

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -6,17 +6,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="grizzly-teleport-join-token"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x130 1+0x130"
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="test-teleport-join-token"}'
-        values: "_x40   1+0x40"
+        values: "_x130   1+0x130"
       - series: 'capi_cluster_status_phase{name="my-cluster", installation="golem", phase="Provisioned"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x130 1+0x130"
     alert_rule_test:
       - alertname: TeleportJoinTokenSecretMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportJoinTokenSecretMismatch
-        eval_time: 130m
+        eval_time: 140m
         exp_alerts:
           - exp_labels:
               alertname: TeleportJoinTokenSecretMismatch
@@ -35,17 +35,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="grizzly-teleport-kube-agent-config"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x130 1+0x130"
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="test-teleport-kube-agent-config"}'
-        values: "_x40   1+0x40"
+        values: "_x130   1+0x130"
       - series: 'capi_cluster_status_phase{phase="Provisioned", name="my-cluster", installation="grizzly"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x130 1+0x130"
     alert_rule_test:
       - alertname: TeleportKubeAgentConfigMapMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportKubeAgentConfigMapMismatch
-        eval_time: 130m
+        eval_time: 140m
         exp_alerts:
           - exp_labels:
               alertname: TeleportKubeAgentConfigMapMismatch

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -16,7 +16,7 @@ tests:
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportJoinTokenSecretMismatch
-        eval_time: 2h10m
+        eval_time: 130m
         exp_alerts:
           - exp_labels:
               alertname: TeleportJoinTokenSecretMismatch
@@ -45,7 +45,7 @@ tests:
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportKubeAgentConfigMapMismatch
-        eval_time: 2h10m
+        eval_time: 130m
         exp_alerts:
           - exp_labels:
               alertname: TeleportKubeAgentConfigMapMismatch

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -16,7 +16,7 @@ tests:
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportJoinTokenSecretMismatch
-        eval_time: 70m
+        eval_time: 130m
         exp_alerts:
           - exp_labels:
               alertname: TeleportJoinTokenSecretMismatch
@@ -45,7 +45,7 @@ tests:
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportKubeAgentConfigMapMismatch
-        eval_time: 70m
+        eval_time: 130m
         exp_alerts:
           - exp_labels:
               alertname: TeleportKubeAgentConfigMapMismatch

--- a/test/tests/providers/capi/capz/teleport.rules.test.yml
+++ b/test/tests/providers/capi/capz/teleport.rules.test.yml
@@ -6,17 +6,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="grizzly-teleport-join-token"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x150"
       - series: 'kube_secret_created{cluster_id="my-cluster", installation="golem", secret="test-teleport-join-token"}'
-        values: "_x40   1+0x40"
+        values: "0+0x150"
       - series: 'capi_cluster_status_phase{name="my-cluster", installation="golem", phase="Provisioned"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x150"
     alert_rule_test:
       - alertname: TeleportJoinTokenSecretMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportJoinTokenSecretMismatch
-        eval_time: 130m
+        eval_time: 140m
         exp_alerts:
           - exp_labels:
               alertname: TeleportJoinTokenSecretMismatch
@@ -35,17 +35,17 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="grizzly-teleport-kube-agent-config"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x150"
       - series: 'kube_configmap_info{app="kube-state-metrics", cluster_id="my-cluster", installation="grizzly", configmap="test-teleport-kube-agent-config"}'
-        values: "_x40   1+0x40"
+        values: "0+0x150"
       - series: 'capi_cluster_status_phase{phase="Provisioned", name="my-cluster", installation="grizzly"}'
-        values: "1+0x40 1+0x40"
+        values: "1+0x150"
     alert_rule_test:
       - alertname: TeleportKubeAgentConfigMapMismatch
         eval_time: 30m
         exp_alerts: []
       - alertname: TeleportKubeAgentConfigMapMismatch
-        eval_time: 130m
+        eval_time: 140m
         exp_alerts:
           - exp_labels:
               alertname: TeleportKubeAgentConfigMapMismatch


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30299

This PR changes teleport configmap/secret rules to notify only + 120 minutes duration as they are not actionable in the most cases and they get auto resolved after a while.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
