### PR TITLE
Add loki not running alert to avoid high cloud costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add missing alert about loki statefulsets not running to ensure we do not suffer from (extra cloud cost)[https://github.com/giantswarm/giantswarm/issues/30124].
+- Add missing alert about loki containers not running to ensure we do not suffer from [extra cloud cost](https://github.com/giantswarm/giantswarm/issues/30124).
 
 ## [3.5.0] - 2024-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add missing alert about loki statefulsets not running to ensure we do not suffer from (extra cloud cost)[https://github.com/giantswarm/giantswarm/issues/30124].
+
 ## [3.5.0] - 2024-03-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Any Alert includes:
    - `cancel_if_.*`
 
 
+### Specific alert labels
+
+- `all_pipelines: true`: When adding this label to an alert, you are sure the alert will be send to opsgenie, even if the installation is not a stable installation.
+
 #### Routing
 
 Alertmanager does the routing based on the labels menitoned above.

--- a/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
@@ -10,18 +10,17 @@ spec:
   - name: loki
     rules:
     # Coming from https://github.com/giantswarm/giantswarm/issues/30124
-    # This alert ensures Loki statefulsets (loki-write and loki-backend) are running as expected.
+    # This alert ensures Loki containers are not restarting too often (flappiness).
     # If it is not the the case, this can incur high costs by cloud providers (s3 api calls are quite expensive).
-    - alert: LokiStatefulsetNotRunning
+    - alert: LokiRestartingTooOften
       annotations:
-        description: '{{`Loki statefulsets are not running.`}}'
+        description: '{{`Loki containers are restarting too often.`}}'
         opsrecipe: loki/
       expr: |
-        kube_statefulset_status_replicas{cluster_type="management_cluster", namespace="loki"}
-        - 
-        kube_statefulset_status_replicas_available{cluster_type="management_cluster", namespace="loki"}
-        > 0
-      for: 30m
+        increase(
+          kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="loki"}[1h]
+        ) > 5
+      for: 5m
       labels:
         area: managedservices
         # This label is used to ensure the alert go through even for non-stable installations

--- a/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
@@ -3,12 +3,33 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: grafana.all.rules
+  name: loki.rules
   namespace: {{ .Values.namespace }}
 spec:
   groups:
   - name: loki
     rules:
+    # Coming from https://github.com/giantswarm/giantswarm/issues/30124
+    # This alert ensures Loki statefulsets (loki-write and loki-backend) are running as expected.
+    # If it is not the the case, this can incur high costs by cloud providers (s3 api calls are quite expensive).
+    - alert: LokiStatefulsetNotRunning
+      annotations:
+        description: '{{`Loki statefulsets are not running.`}}'
+        opsrecipe: loki/
+      expr: |
+        kube_statefulset_status_replicas{cluster_type="management_cluster", namespace="loki"}
+        - 
+        kube_statefulset_status_replicas_available{cluster_type="management_cluster", namespace="loki"}
+        > 0
+      for: 30m
+      labels:
+        area: managedservices
+        # This label is used to ensure the alert go through even for non-stable installations
+        all_pipelines: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
     # Rules inspired from loki-mixins - https://github.com/grafana/loki/blob/main/production/loki-mixin-compiled/alerts.yaml
     - alert: LokiRequestErrors
       annotations:

--- a/test/tests/providers/global/loki.rules.test.yml
+++ b/test/tests/providers/global/loki.rules.test.yml
@@ -100,16 +100,14 @@ tests:
               opsrecipe: "loki/"
   - interval: 1m
     input_series:
-      - series: 'kube_statefulset_status_replicas{cluster_type="management_cluster", namespace="loki"}'
-        values: "2+0x20 2+0x160"  # 1 unhealthy value after 20 minutes
-      - series: 'kube_statefulset_status_replicas_available{cluster_type="management_cluster", namespace="loki"}'
-        values: "0+0x20 1+0x60 2+0x100"  # 1 pod stop working after 20 minutes then come back up after 60 minutes
+      - series: 'kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="loki"}'
+        values: "0+0x20 0+100x20 0+0x120"  # 0 restarts after 20 minutes then we ramp up to 100 restarts in 20 minutes and then back to 0
     alert_rule_test:
-      - alertname: LokiStatefulsetNotRunning
+      - alertname: LokiRestartingTooOften
         eval_time: 15m  # should be OK after 15 minutes
         exp_alerts:
-      - alertname: LokiStatefulsetNotRunning
-        eval_time: 60m  # After 60 minutes, should fire an alert for the t+60 error
+      - alertname: LokiRestartingTooOften
+        eval_time: 85m  # After 85 minutes, should fire an alert for the t+85 error
         exp_alerts:
           - exp_labels:
               all_pipelines: true
@@ -121,8 +119,8 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              description: Loki statefulsets are not running.
+              description: Loki containers are restarting too often.
               opsrecipe: loki/
-      - alertname: LokiStatefulsetNotRunning
-        eval_time: 120m  # After 120m minutes, all should be back to normal
+      - alertname: LokiRestartingTooOften
+        eval_time: 140m  # After 140m minutes, all should be back to normal
         exp_alerts:

--- a/test/tests/providers/global/loki.rules.test.yml
+++ b/test/tests/providers/global/loki.rules.test.yml
@@ -1,6 +1,6 @@
 ---
 rule_files:
-  - loki.all.rules.yml
+  - loki.rules.yml
 
 tests:
   - interval: 1m
@@ -98,3 +98,31 @@ tests:
             exp_annotations:
               description: "Loki pod loki-compactor-676b8c897b-rq298 (namespace loki) sees 1 unhealthy ring members"
               opsrecipe: "loki/"
+  - interval: 1m
+    input_series:
+      - series: 'kube_statefulset_status_replicas{cluster_type="management_cluster", namespace="loki"}'
+        values: "2+0x20 2+0x160"  # 1 unhealthy value after 20 minutes
+      - series: 'kube_statefulset_status_replicas_available{cluster_type="management_cluster", namespace="loki"}'
+        values: "0+0x20 1+0x60 2+0x100"  # 1 pod stop working after 20 minutes then come back up after 60 minutes
+    alert_rule_test:
+      - alertname: LokiStatefulsetNotRunning
+        eval_time: 15m  # should be OK after 15 minutes
+        exp_alerts:
+      - alertname: LokiStatefulsetNotRunning
+        eval_time: 60m  # After 60 minutes, should fire an alert for the t+60 error
+        exp_alerts:
+          - exp_labels:
+              all_pipelines: true
+              area: managedservices
+              cancel_if_outside_working_hours: "true"
+              cluster_type: management_cluster
+              namespace: loki
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: Loki statefulsets are not running.
+              opsrecipe: loki/
+      - alertname: LokiStatefulsetNotRunning
+        eval_time: 120m  # After 120m minutes, all should be back to normal
+        exp_alerts:

--- a/test/tests/providers/global/loki.rules.test.yml
+++ b/test/tests/providers/global/loki.rules.test.yml
@@ -101,7 +101,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="loki"}'
-        values: "0+0x20 0+100x20 0+0x120"  # 0 restarts after 20 minutes then we ramp up to 100 restarts in 20 minutes and then back to 0
+        values: "0+0x20 0+5x20 100+0x120"  # 0 restarts after 20 minutes then we ramp up to 100 restarts in 20 minutes and then back to 0
     alert_rule_test:
       - alertname: LokiRestartingTooOften
         eval_time: 15m  # should be OK after 15 minutes

--- a/test/tests/providers/global/loki.rules.test.yml
+++ b/test/tests/providers/global/loki.rules.test.yml
@@ -101,7 +101,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="loki"}'
-        values: "0+0x20 0+5x20 100+0x120"  # 0 restarts after 20 minutes then we ramp up to 100 restarts in 20 minutes and then back to 0
+        values: "0+0x20 0+5x20 100+0x140" # 0 restarts after 20 minutes then we restart 5 times per minute for 20 minutes then we stop restarting for 140 minutes
     alert_rule_test:
       - alertname: LokiRestartingTooOften
         eval_time: 15m  # should be OK after 15 minutes


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30124 and https://github.com/giantswarm/giantswarm/issues/30381

This PR adds a new alerts that will `transcend all pipelines` to make sure atlas is paged (during business hours) for loki statefulsets not running to prevent high cloud costs due to loki hammering the object storage api if it is crashlooping for any reasons.

We only care about the statefulsets as those are the only components that are accessing S3 but maybe we need the same alert for the loki deployments.

I initially experimented with `increase(loki_s3_request_duration_seconds_count{status_code=~"5.*"}[5m]` but this metric gets reset and rate did not work either so I settled on the statefulset not running alert for 30m

Unit tests are on the way but I wanted eyes first

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
