### PR TITLE
Move to abs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
     jobs:
       - architect/push-to-app-catalog:
           context: "architect"
+          executor: app-build-suite
           name: app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"

--- a/helm/prometheus-rules/Chart.yaml
+++ b/helm/prometheus-rules/Chart.yaml
@@ -4,8 +4,8 @@ engine: gotpl
 home: https://github.com/giantswarm/prometheus-rules
 icon: https://s.giantswarm.io/app-icons/1/png/default-app-light.png
 name: prometheus-rules
-appVersion: '1.0.0'
-version: '3.1.1'
+appVersion: '0.1.0'
+version: '3.5.0'
 annotations:
   application.giantswarm.io/team: "atlas"
   config.giantswarm.io/version: 1.x.x

--- a/helm/prometheus-rules/Chart.yaml
+++ b/helm/prometheus-rules/Chart.yaml
@@ -4,8 +4,8 @@ engine: gotpl
 home: https://github.com/giantswarm/prometheus-rules
 icon: https://s.giantswarm.io/app-icons/1/png/default-app-light.png
 name: prometheus-rules
-appVersion: '[[ .AppVersion ]]'
-version: '[[ .Version ]]'
+appVersion: '1.0.0'
+version: '3.1.1'
 annotations:
   application.giantswarm.io/team: "atlas"
   config.giantswarm.io/version: 1.x.x

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -19,8 +19,6 @@ Common labels
 {{- define "labels.common" -}}
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
-application.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
-application.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -1,9 +1,6 @@
 name: prometheus-rules
 namespace: monitoring
 serviceType: managed
-project:
-  branch: '[[ .Branch ]]'
-  commit: '[[ .SHA ]]'
 managementCluster:
   customer: ""
   name: ""


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Self explanatory
### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
