### PR TITLE
Add recording rule for ingresses using the baseDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 - Add missing alert about loki containers not running to ensure we do not suffer from [extra cloud cost](https://github.com/giantswarm/giantswarm/issues/30124).
 - Add missing alert about mimir containers not running to ensure we do not suffer from [extra cloud cost](https://github.com/giantswarm/giantswarm/issues/30124).
+- Add recording rule for ingresses using the baseDomain.
 
 ## [3.5.0] - 2024-03-27
 

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -186,6 +186,10 @@ spec:
       record: aggregation:ingress:management_cluster_replicas
     - expr: sum(rate(nginx_ingress_controller_nginx_process_requests_total[5m])) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:ingress:requests_total
+    {{- with .Values.Installation.V1.Guest.Kubernetes.IngressController.BaseDomain }}
+    - expr: count(count(kube_ingress_path{host=~".*{{ . }}"}) by (ingress,cluster_id)) by (cluster_id)
+      record: aggregation:ingress:base_domain_total
+    {{- end }}
   - name: kubelet.grafana-cloud.recording
     rules:
     - expr: sum(kubelet_running_container_count or kubelet_running_containers{container_state="running"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -12,3 +12,10 @@ managementCluster:
 
 mimir:
   enabled: false
+
+Installation:
+  V1:
+    Guest:
+      Kubernetes:
+        IngressController:
+          BaseDomain: ""


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30076

This PR adds recording rule for ingresses using the baseDomain.

It's only valid for Vintage installations, as the value `.Installation.V1.Guest.Kubernetes.IngressController.BaseDomain` is only present there. We need it to get an idea of how many customers are using the base domain in their ingresses.

It should be removed once Vintage is gone.
 
### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
