### PR TITLE
Add non-blocking opsrecipe validation

### DIFF
--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -26,9 +26,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - name: Clone opsrecipe repo
+      - name: Clone private opsrecipe repo
         run: |
           git clone --depth 1 --single-branch -b main -q https://oauth2:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/giantswarm/giantswarm.git
+      - name: Clone public opsrecipe repo
+        run: |
+          git clone --depth 1 --single-branch -b main -q https://oauth2:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/giantswarm/handbook.git
       - name: run opsrecipe tests
         env:
           OPSRECIPES_DIR: ./giantswarm

--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -20,3 +20,16 @@ jobs:
           fetch-depth: "0"
       - name: run inhibition tests
         run: make test-inhibitions
+  opsrecipe-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+      - name: Clone opsrecipe repo
+        run: |
+          git clone --depth 1 --single-branch -b main -q https://oauth2:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/giantswarm/giantswarm.git
+      - name: run opsrecipe tests
+        env:
+          OPSRECIPES_DIR: ./giantswarm
+        run: make test-ci-opsrecipes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add non-blocking opsrecipe validation.
+
 ## [3.7.2] - 2024-04-08
 
 ### Fixed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -33,4 +33,4 @@ test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
 	bash test/hack/bin/check-opsrecipes.sh
 
 test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid in CI
-	bash OPSRECIPES_DIR=./giantswarm test/hack/bin/check-opsrecipes.sh
+	test/hack/bin/check-opsrecipes.sh --ci

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -22,6 +22,9 @@ template-chart: install-tools ## prepare the helm chart
 test-rules: install-tools template-chart ## run unit tests for alerting rules
 	bash test/hack/bin/verify-rules.sh "$(test_filter)"
 
+test-rules: install-tools template-chart ## run unit tests for alerting rules
+	bash test/hack/bin/verify-rules.sh "$(test_filter)"
+
 test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
 	bash test/hack/bin/get-inhibition.sh
 	cd test/hack/checkLabels; go run main.go

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -22,9 +22,6 @@ template-chart: install-tools ## prepare the helm chart
 test-rules: install-tools template-chart ## run unit tests for alerting rules
 	bash test/hack/bin/verify-rules.sh "$(test_filter)"
 
-test-rules: install-tools template-chart ## run unit tests for alerting rules
-	bash test/hack/bin/verify-rules.sh "$(test_filter)"
-
 test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
 	bash test/hack/bin/get-inhibition.sh
 	cd test/hack/checkLabels; go run main.go

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -6,16 +6,11 @@ clean-dry-run: ## dry run for `make clean` - print all untracked files
 clean: ## Clean the git work dir and remove all untracked files
 	# clean stage
 	git clean -xdf -- test/hack/bin test/hack/output test/hack/checkLabels
-	git checkout -- helm/prometheus-rules/Chart.yaml
-	git checkout -- helm/prometheus-rules/values.yaml
 
 ##@ Testing
 
 .PHONY: test
-test: install-tools template-chart test-rules test-inhibitions restore-chart
-
-test-rules: install-tools template-chart ## run unit tests for alerting rules
-	bash test/hack/bin/verify-rules.sh "$(test_filter)"
+test: install-tools template-chart test-rules test-inhibitions test-opsrecipes ## Run all tests
 
 install-tools:
 	./test/hack/bin/fetch-tools.sh
@@ -24,16 +19,15 @@ template-chart: install-tools ## prepare the helm chart
 	test/hack/bin/architect helm template --dir helm/prometheus-rules --dry-run
 	bash ./test/hack/bin/template-chart.sh
 
+test-rules: install-tools template-chart ## run unit tests for alerting rules
+	bash test/hack/bin/verify-rules.sh "$(test_filter)"
+
 test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
-	./test/hack/bin/get-inhibition.sh
+	bash test/hack/bin/get-inhibition.sh
 	cd test/hack/checkLabels; go run main.go
 
 test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
-	./test/hack/bin/check-opsrecipes.sh
+	bash test/hack/bin/check-opsrecipes.sh
 
-restore-chart:
-	@## Revert Chart version
-	@yq e -i '.version = "[[ .Version ]]"' helm/prometheus-rules/Chart.yaml
-	@yq e -i '.appVersion = "[[ .AppVersion ]]"' helm/prometheus-rules/Chart.yaml
-	@yq e -i '.project.branch = "[[ .Branch ]]"' helm/prometheus-rules/values.yaml
-	@yq e -i '.project.commit = "[[ .SHA ]]"' helm/prometheus-rules/values.yaml
+test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid in CI
+	bash OPSRECIPES_DIR=./giantswarm test/hack/bin/check-opsrecipes.sh

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -64,4 +64,5 @@ templates/recording-rules/gs-managed-app-deployment-status.rules.yml
 templates/recording-rules/kubernetes-mixins.rules.yml
 templates/recording-rules/service-level.rules.yml
 templates/recording-rules/mimir-mixins.rules.yml
+templates/recording-rules/tempo-mixins.rules.yml
 templates/recording-rules/loki-mixins.rules.yml

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -30,7 +30,7 @@ isInArray () {
 
 # merge_docs () merges a Hugo docs hierarchy from a source directory (first arg) into a destination directory (second arg).
 merge_docs() {
-    if [ ! -d "$1/content/docs/." ] ; then
+    if [[ ! -d "$1/content/docs/." ]] ; then
         echo "Source Hugo base directory not specified or invalid (must contain content/docs)!" >&2
     fi
     if [ ! -d "$2/content/docs/." ] ; then

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -6,9 +6,11 @@ RULES_FILES=(./test/hack/output/*/*/prometheus-rules/templates/alerting-rules/*)
 #RULES_FILES=(./test/hack/output/*/prometheus-rules/templates/alerting-rules/up*)
 
 DEBUG_MODE=false
+
 CHECK_EXTRADATA_ERRORS=true
 CHECK_NORECIPE_ERRORS=true
 CHECK_UNEXISTINGRECIPE_ERRORS=true
+OPSRECIPES_DIR=
 
 # Parameters:
 # - an element
@@ -29,13 +31,17 @@ isInArray () {
 
 
 listOpsRecipes () {
-    # find list of opsrecipes from git repo
-    tmpDir="$(mktemp -d)"
-    git clone --depth 1 --single-branch -b main -q git@github.com:giantswarm/giantswarm.git "$tmpDir"
+    # find list of opsrecipes from git repo if the OPSRECIPES_DIR is not set
+    if [ -z "$OPSRECIPES_DIR" ]; then
+        tmpDir="$(mktemp -d)"
+        git clone --depth 1 --single-branch -b main -q git@github.com:giantswarm/giantswarm.git "$tmpDir"
+        OPSRECIPES_DIR="$tmpDir"
+    fi
+
     # find all ops-recipes ".md" files, and keep only the opsrecipe name (may contain a path, like "rolling-nodes/rolling-nodes")
-    find "$tmpDir"/content/docs/support-and-ops/ops-recipes -type f -name \*.md \
-        | sed -n 's_'"$tmpDir"'/content/docs/support-and-ops/ops-recipes/\(.*\).md_\1_p'
-    rm -rf "$tmpDir"
+    find "$OPSRECIPES_DIR"/content/docs/support-and-ops/ops-recipes -type f -name \*.md \
+        | sed -n 's_'"$OPSRECIPES_DIR"'/content/docs/support-and-ops/ops-recipes/\(.*\).md_\1_p'
+    rm -rf "$OPSRECIPES_DIR"
 
     # Add extra opsrecipes
     # These ones are defined as aliases of `deployment-not-satisfied`:

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -91,7 +91,7 @@ main() {
     ########################
 
     # Retrieve list of opsrecipes
-    mapfile -t opsRecipes < <(listOpsRecipes $runInCi)
+    mapfile -t opsRecipes < <(listOpsRecipes "$runInCi")
 
     if [[ "$DEBUG_MODE" != "false" ]]; then
         echo "List of opsrecipe:"

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -45,6 +45,7 @@ listOpsRecipes () {
     local runInCi="$1" && shift
     privateOpsrecipesParentDirectory="./giantswarm"
     privateOpsrecipesHandbookParentDirectory="./handbook"
+    # CI clones git dependencies, but if we run it locally we have to do it ourselves
     if [[ "$runInCi" == false ]]; then
         tmpDir="$(mktemp -d)"
         tmpDirHandbook="$(mktemp -d)"

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -28,27 +28,13 @@ isInArray () {
     return 1
 }
 
-
-mergeInHandbook() {
-    if [ ! -d "$1/content/docs/." ]
-    then
-        echo Destination Hugo base directory not specified or invalid (must contain content/docs)! >&2
-    fi
-    tmpDirHandbook="$(mktemp -d)"
-    git clone --depth=1 https://github.com/giantswarm/handbook.git "$tmpDirHandbook" && \
-        find "$tmpDirHandbook/content/docs" -mindepth 1 -maxdepth 1 -type d | xargs cp -v -x -a -r -u -t "$1/content/docs/." | \
-            grep -o -P "(?<= -> ').*\.md" | \
-            xargs sed -s -i'' '0,/^---.*$/s//---\nsourceOrigin: handbook/'
-
-}
-
-# merge_docs() merges a Hugo docs hierarchy from a source directory (first arg) into a destination directory (second arg).
+# merge_docs () merges a Hugo docs hierarchy from a source directory (first arg) into a destination directory (second arg).
 merge_docs() {
     if [ ! -d "$1/content/docs/." ] ; then
-        echo Source Hugo base directory not specified or invalid (must contain content/docs)! >&2
+        echo "Source Hugo base directory not specified or invalid (must contain content/docs)!" >&2
     fi
     if [ ! -d "$2/content/docs/." ] ; then
-        echo Destination Hugo base directory not specified or invalid (must contain content/docs)! >&2
+        echo "Destination Hugo base directory not specified or invalid (must contain content/docs)!" >&2
     fi
     find "$1/content/docs" -mindepth 1 -maxdepth 1 -type d | xargs cp -v -x -a -r -u -t "$2/content/docs/." | \
         grep -o -P "(?<= -> ').*\.md" | \

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -33,7 +33,7 @@ merge_docs() {
     if [[ ! -d "$1/content/docs/." ]] ; then
         echo "Source Hugo base directory not specified or invalid (must contain content/docs)!" >&2
     fi
-    if [ ! -d "$2/content/docs/." ] ; then
+    if [[ ! -d "$2/content/docs/." ]] ; then
         echo "Destination Hugo base directory not specified or invalid (must contain content/docs)!" >&2
     fi
     find "$1/content/docs" -mindepth 1 -maxdepth 1 -type d | xargs cp -v -x -a -r -u -t "$2/content/docs/." | \

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 main() {
-
   local GIT_WORKDIR
   GIT_WORKDIR="$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/23638

This PR adds a non-blocking opsrecipe validation test

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
