### PR TITLE
fix-nginx-ingress-controller-deployment-not-satisfied-opsrecipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `IngressControllerDeploymentNotSatisfied` opsrecipe.
+
 ## [3.7.1] - 2024-04-08
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: IngressControllerDeploymentNotSatisfied
       annotations:
         description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
-        opsrecipe: ingress-controller-deployment-not-satisfied/
+        opsrecipe: ingress-controller-down/
       expr: managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} / (managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"}) * 100 <= 50
       for: 10m
       labels:


### PR DESCRIPTION
This PR fixes the opsrecipe name

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
