### PR TITLE
Added missing opsrecipe to WorkloadClusterMasterMemoryUsageTooHigh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `WorkloadClusterMasterMemoryUsageTooHigh` opsrecipe.
+
 ## [3.7.2] - 2024-04-08
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -132,6 +132,7 @@ spec:
     - alert: WorkloadClusterMasterMemoryUsageTooHigh
       annotations:
         description: '{{`Machine {{ $labels.instance }} memory usage is too high (less than 10% and 2G of allocatable memory).`}}'
+        opsrecipe: master-machine-usage-too-high/
       expr: |-
         ( ( (
               ( node_memory_MemTotal_bytes{cluster_type="workload_cluster"}


### PR DESCRIPTION
This PR adds the missing opsrecipe to WorkloadClusterMasterMemoryUsageTooHigh alert.

### Checklist

- [x] Update CHANGELOG.md
