### PR TITLE
Fix cluster_type label for vintage clusters in `aggregation:giantswar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix cluster_type label for vintage clusters in `aggregation:giantswarm:cluster_info` recording query.
+
 ## [3.8.0] - 2024-04-08
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/grafana-cloud.rules.yml
@@ -72,8 +72,8 @@ spec:
             "(.*)"
           ) >= 1
           {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-          or cluster_operator_cluster_status >= 1
-          or cluster_service_cluster_info >= 1
+          or label_replace(cluster_operator_cluster_status, "cluster_type", "workload_cluster", "", "") >= 1
+          or label_replace(cluster_service_cluster_info, "cluster_type", "workload_cluster", "", "") >= 1
           or
             label_replace(
               label_replace( 


### PR DESCRIPTION
…m:cluster_info` recording query.

Without the change in this PR, all vintage WCs have a `cluster_type: management_cluster` label:

![Schermata_20240409_155343](https://github.com/giantswarm/prometheus-rules/assets/868430/b13c743c-b16d-420f-aeda-d351db8aa5e7)
