### PR TITLE
Fix MatchingNumberOfPrometheusAndCluster alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `MatchingNumberOfPrometheusAndCluster` alert.
+
 ## [3.10.0] - 2024-04-10
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-meta-operator.rules.yml
@@ -30,7 +30,7 @@ spec:
         (
           sum by(cluster_id, installation, provider, pipeline) (
             {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status", status!="Deleting"}
-          ) unless sum by(cluster_id, installation, provider, pipeline) (
+          ) > 0 unless sum by(cluster_id, installation, provider, pipeline) (
             label_replace(
               kube_pod_container_status_running{container="prometheus", namespace!="{{ .Values.managementCluster.name }}-prometheus", namespace=~".*-prometheus"},
               "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
towards to that alert https://giantswarm.app.opsgenie.com/alert/detail/fc24e952-2990-4d76-9fee-4ab03bd1e0e9-1712913366637/details

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
