### PR TITLE
link promtail alerts to ops-recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update ops-recipe link for promtail alerts.
+
 ## [3.11.2] - 2024-04-18
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/promtail.rules.yml
@@ -12,7 +12,7 @@ spec:
         - alert: PromtailDown
           annotations:
             description: '{{`Scraping of all promtail pods to check if one failed every 30 minutes.`}}'
-            opsrecipe: promtail-is-not-running/
+            opsrecipe: promtail/
           expr: count(up{container="promtail"} == 0) by (cluster_id, installation, provider, pipeline) > 0
           for: 30m
           labels:
@@ -28,7 +28,7 @@ spec:
         - alert: PromtailRequestsErrors
           annotations:
             description: This alert checks if that the amount of failed requests is below 10% for promtail
-            opsrecipe: promtail-requests-are-failing/
+            opsrecipe: promtail/
           expr: |
             100 * sum(rate(promtail_request_duration_seconds_count{status_code=~"5..|failed"}[2m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance) / sum(rate(promtail_request_duration_seconds_count[2m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance) > 10
           for: 15m

--- a/test/tests/providers/global/promtail.rules.test.yml
+++ b/test/tests/providers/global/promtail.rules.test.yml
@@ -36,7 +36,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Scraping of all promtail pods to check if one failed every 30 minutes."
-              opsrecipe: "promtail-is-not-running/"
+              opsrecipe: "promtail/"
       # Tests with 2 pods
       - alertname: PromtailDown
         eval_time: 111m
@@ -56,7 +56,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Scraping of all promtail pods to check if one failed every 30 minutes."
-              opsrecipe: "promtail-is-not-running/"
+              opsrecipe: "promtail/"
       - alertname: PromtailDown
         eval_time: 121m
       - alertname: PromtailDown
@@ -77,7 +77,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Scraping of all promtail pods to check if one failed every 30 minutes."
-              opsrecipe: "promtail-is-not-running/"
+              opsrecipe: "promtail/"
   - interval: 1m
     input_series:
       # Tests with multiple cases: no metrics, no requests, only status_code 204 ones, 204 ones and 500 that are less than 10% of the the total, 500 request that represent more than 10% of the total, only 500 ones
@@ -111,7 +111,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
-              opsrecipe: "promtail-requests-are-failing/"
+              opsrecipe: "promtail/"
       - alertname: PromtailRequestsErrors
         eval_time: 330m
         exp_alerts:
@@ -129,4 +129,4 @@ tests:
               topic: observability
             exp_annotations:
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
-              opsrecipe: "promtail-requests-are-failing/"
+              opsrecipe: "promtail/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30487

Update link for Promtail alerts to point to the new ops-recipe from https://github.com/giantswarm/giantswarm/pull/30564