### PR TITLE
fix PrometheusMissingGrafanaCloud opsrecipe link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- link to `PrometheusMissingGrafanaCloud` opsrecipe
+
 ## [3.11.0] - 2024-04-15
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -31,7 +31,7 @@ spec:
     - alert: PrometheusMissingGrafanaCloud
       annotations:
         description: 'Prometheus is not sending data to Grafana Cloud.'
-        opsrecipe: tbd/
+        opsrecipe: prometheus-grafanacloud/
       {{- if .Values.mimir.enabled }}
       expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud", cluster_type="management_cluster", cluster_id="{{ .Values.managementCluster.name }}", installation="{{ .Values.managementCluster.name }}", provider="{{ .Values.managementCluster.provider.kind }}", pipeline="{{ .Values.managementCluster.pipeline }}"})
       {{- else }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30487

Fix `PrometheusMissingGrafanaCloud` opsrecipe link

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
