### PR TITLE
Add mimir mixins with correct cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add mimir recording rules from upstream mixins.
 - Add recording rules to show prometheus scraping job memory usage.
 - Add `cluster_control_plane_unhealthy` inhibition.
 - Add inhibitions expressions for CAPI clusters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add mimir recording rules from upstream mixins.
+- Add mimir and loki recording rules from upstream mixins.
 - Add recording rules to show prometheus scraping job memory usage.
 - Add `cluster_control_plane_unhealthy` inhibition.
 - Add inhibitions expressions for CAPI clusters.

--- a/README.md
+++ b/README.md
@@ -122,15 +122,17 @@ To Update `kubernetes-mixins` recording rules:
 
 #### mimir-mixins
 
-Come as-is from https://github.com/grafana/mimir/tree/main/operations/mimir-mixin-compiled ; just added helm headers (metadata, spec...)
+To update `mimir-mixins` recording rules:
+
+* Run `./mimir/update.sh`
+* make sure to update [grafana dashboards](https://github.com/giantswarm/dashboards)
 
 #### loki-mixins
 
-Come as-is from https://github.com/grafana/loki/tree/main/production/loki-mixin-compiled-ssd ; just added helm headers (metadata, spec...)
+To update `loki-mixins` recording rules:
 
-#### tempo-mixins
-
-Come as-is from https://github.com/grafana/tempo/tree/main/operations/tempo-mixin-compiled ; just added helm headers (metadata, spec...)
+* Run `./loki/update.sh`
+* make sure to update [grafana dashboards](https://github.com/giantswarm/dashboards)
 
 ### Testing
 

--- a/helm/prometheus-rules/templates/recording-rules/loki-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/loki-mixins.rules.yml
@@ -7,55 +7,41 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: loki_rules
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:loki_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:loki_request_duration_seconds:50quantile
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job) / sum(rate(loki_request_duration_seconds_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:loki_request_duration_seconds:avg
-    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:loki_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:loki_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:loki_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:loki_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:loki_request_duration_seconds:50quantile
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-        / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:loki_request_duration_seconds:avg
-    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job,
-        route)
-      record: cluster_job_route:loki_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:loki_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:loki_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:loki_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:loki_request_duration_seconds:50quantile
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster,
-        namespace, job, route)
-      record: cluster_namespace_job_route:loki_request_duration_seconds:avg
-    - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:loki_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:loki_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:loki_request_duration_seconds_count:sum_rate
+    - name: loki_rules
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
+          record: cluster_id_job:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
+          record: cluster_id_job:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
+          record: cluster_id_job:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
+          record: cluster_id_job:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
+          record: cluster_id_job:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
+          record: cluster_id_job:loki_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
+          record: cluster_id_job_route:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
+          record: cluster_id_job_route:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
+          record: cluster_id_job_route:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route)
+          record: cluster_id_job_route:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route)
+          record: cluster_id_job_route:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
+          record: cluster_id_job_route:loki_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route)
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
+          record: cluster_id_namespace_job_route:loki_request_duration_seconds_count:sum_rate

--- a/helm/prometheus-rules/templates/recording-rules/mimir-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/mimir-mixins.rules.yml
@@ -10,199 +10,199 @@ spec:
   groups:
     - name: mimir_api_1
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_request_duration_seconds:avg
-        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_request_duration_seconds_count:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_request_duration_seconds:sum_rate
     - name: mimir_api_2
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
           record: cluster_id_job_route:cortex_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
           record: cluster_id_job_route:cortex_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_request_duration_seconds:avg
-        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_request_duration_seconds_count:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_request_duration_seconds:sum_rate
     - name: mimir_api_3
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds:avg
-        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
-        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_request_duration_seconds:sum_rate
     - name: mimir_querier_api
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_querier_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_querier_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_querier_request_duration_seconds:avg
-        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_querier_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_querier_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_querier_request_duration_seconds_count:sum_rate
-        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
           record: cluster_id_job_route:cortex_querier_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route))
           record: cluster_id_job_route:cortex_querier_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_querier_request_duration_seconds:avg
-        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job, route)
           record: cluster_id_job_route:cortex_querier_request_duration_seconds_count:sum_rate
-        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route))
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:avg
-        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, namespace, job, route)
           record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_count:sum_rate
     - name: mimir_storage
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_kv_request_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_kv_request_duration_seconds:50quantile
-        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_kv_request_duration_seconds:avg
-        - expr: sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_kv_request_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_kv_request_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_kv_request_duration_seconds_count:sum_rate
     - name: mimir_queries
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_query_frontend_retries:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_query_frontend_retries:50quantile
-        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, job) / sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_retries:avg
-        - expr: sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_retries_bucket:sum_rate
-        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_retries_sum:sum_rate
-        - expr: sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_retries_count:sum_rate
-        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:50quantile
-        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:avg
-        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_bucket:sum_rate
-        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_sum:sum_rate
-        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
     - name: mimir_ingester_queries
       rules:
-        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_series:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_series:50quantile
-        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_series:avg
-        - expr: sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_series_bucket:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_series_sum:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_series_count:sum_rate
-        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_samples:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_samples:50quantile
-        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_samples:avg
-        - expr: sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_samples_bucket:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_samples_sum:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_samples_count:sum_rate
-        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_exemplars:99quantile
-        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job))
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job))
           record: cluster_id_job:cortex_ingester_queried_exemplars:50quantile
-        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, installation, pipeline, provider, job) / sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_exemplars:avg
-        - expr: sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_exemplars_bucket:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_exemplars_sum:sum_rate
-        - expr: sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, job)
+        - expr: sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, installation, pipeline, provider, job)
           record: cluster_id_job:cortex_ingester_queried_exemplars_count:sum_rate
     - name: mimir_received_samples
       rules:
         - expr: |
-            sum by (cluster_id, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
           record: cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
     - name: mimir_exemplars_in
       rules:
         - expr: |
-            sum by (cluster_id, namespace, job) (rate(cortex_distributor_exemplars_in_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, namespace, job) (rate(cortex_distributor_exemplars_in_total[5m]))
           record: cluster_id_namespace_job:cortex_distributor_exemplars_in:rate5m
     - name: mimir_received_exemplars
       rules:
         - expr: |
-            sum by (cluster_id, namespace, job) (rate(cortex_distributor_received_exemplars_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, namespace, job) (rate(cortex_distributor_received_exemplars_total[5m]))
           record: cluster_id_namespace_job:cortex_distributor_received_exemplars:rate5m
     - name: mimir_exemplars_ingested
       rules:
         - expr: |
-            sum by (cluster_id, namespace, job) (rate(cortex_ingester_ingested_exemplars_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, namespace, job) (rate(cortex_ingester_ingested_exemplars_total[5m]))
           record: cluster_id_namespace_job:cortex_ingester_ingested_exemplars:rate5m
     - name: mimir_exemplars_appended
       rules:
         - expr: |
-            sum by (cluster_id, namespace, job) (rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, namespace, job) (rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total[5m]))
           record: cluster_id_namespace_job:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m
     - name: mimir_scaling_rules
       rules:
         - expr: |
             # Convenience rule to get the number of replicas for both a deployment and a statefulset.
             # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-            sum by (cluster_id, namespace, deployment) (
+            sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
               label_replace(
                 kube_deployment_spec_replicas,
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -211,14 +211,14 @@ spec:
               )
             )
             or
-            sum by (cluster_id, namespace, deployment) (
+            sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
               label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
             )
           record: cluster_id_namespace_deployment:actual_replicas:count
         - expr: |
             ceil(
               quantile_over_time(0.99,
-                sum by (cluster_id, namespace) (
+                sum by (cluster_id, installation, pipeline, provider, namespace) (
                   cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
                 )[24h:]
               )
@@ -230,7 +230,7 @@ spec:
           record: cluster_id_namespace_deployment_reason:required_replicas:count
         - expr: |
             ceil(
-              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
+              sum by (cluster_id, installation, pipeline, provider, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
               * 0.59999999999999998 / 240000
             )
           labels:
@@ -240,7 +240,7 @@ spec:
         - expr: |
             ceil(
               quantile_over_time(0.99,
-                sum by (cluster_id, namespace) (
+                sum by (cluster_id, installation, pipeline, provider, namespace) (
                   cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
                 )[24h:]
               )
@@ -253,7 +253,7 @@ spec:
         - expr: |
             ceil(
               quantile_over_time(0.99,
-                sum by(cluster_id, namespace) (
+                sum by(cluster_id, installation, pipeline, provider, namespace) (
                   cortex_ingester_memory_series
                 )[24h:]
               )
@@ -265,7 +265,7 @@ spec:
           record: cluster_id_namespace_deployment_reason:required_replicas:count
         - expr: |
             ceil(
-              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="max_global_series_per_user"})
+              sum by (cluster_id, installation, pipeline, provider, namespace) (cortex_limits_overrides{limit_name="max_global_series_per_user"})
               * 3 * 0.59999999999999998 / 1500000
             )
           labels:
@@ -274,7 +274,7 @@ spec:
           record: cluster_id_namespace_deployment_reason:required_replicas:count
         - expr: |
             ceil(
-              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
+              sum by (cluster_id, installation, pipeline, provider, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
               * 0.59999999999999998 / 80000
             )
           labels:
@@ -283,11 +283,11 @@ spec:
           record: cluster_id_namespace_deployment_reason:required_replicas:count
         - expr: |
             ceil(
-              (sum by (cluster_id, namespace) (
+              (sum by (cluster_id, installation, pipeline, provider, namespace) (
                 cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester.*"}
               ) / 4)
                 /
-              avg by (cluster_id, namespace) (
+              avg by (cluster_id, installation, pipeline, provider, namespace) (
                 memcached_limit_bytes{job=~".+/memcached"}
               )
             )
@@ -296,10 +296,10 @@ spec:
             reason: active_series
           record: cluster_id_namespace_deployment_reason:required_replicas:count
         - expr: |
-            sum by (cluster_id, namespace, deployment) (
+            sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
               label_replace(
                 label_replace(
-                  sum by (cluster_id, namespace, pod)(rate(container_cpu_usage_seconds_total[1m])),
+                  sum by (cluster_id, installation, pipeline, provider, namespace, pod)(rate(container_cpu_usage_seconds_total[1m])),
                   "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -319,7 +319,7 @@ spec:
             # This is the old expression, compatible with kube-state-metrics < v2.0.0,
             # where kube_pod_container_resource_requests_cpu_cores was removed:
             (
-              sum by (cluster_id, namespace, deployment) (
+              sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
                 label_replace(
                   label_replace(
                     kube_pod_container_resource_requests_cpu_cores,
@@ -335,7 +335,7 @@ spec:
             # This expression is compatible with kube-state-metrics >= v1.4.0,
             # where kube_pod_container_resource_requests was introduced.
             (
-              sum by (cluster_id, namespace, deployment) (
+              sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
                 label_replace(
                   label_replace(
                     kube_pod_container_resource_requests{resource="cpu"},
@@ -365,7 +365,7 @@ spec:
         - expr: |
             # Convenience rule to get the Memory utilization for both a deployment and a statefulset.
             # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-            sum by (cluster_id, namespace, deployment) (
+            sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
               label_replace(
                 label_replace(
                   container_memory_usage_bytes{image!=""},
@@ -388,7 +388,7 @@ spec:
             # This is the old expression, compatible with kube-state-metrics < v2.0.0,
             # where kube_pod_container_resource_requests_memory_bytes was removed:
             (
-              sum by (cluster_id, namespace, deployment) (
+              sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
                 label_replace(
                   label_replace(
                     kube_pod_container_resource_requests_memory_bytes,
@@ -404,7 +404,7 @@ spec:
             # This expression is compatible with kube-state-metrics >= v1.4.0,
             # where kube_pod_container_resource_requests was introduced.
             (
-              sum by (cluster_id, namespace, deployment) (
+              sum by (cluster_id, installation, pipeline, provider, namespace, deployment) (
                 label_replace(
                   label_replace(
                     kube_pod_container_resource_requests{resource="memory"},
@@ -434,38 +434,38 @@ spec:
     - name: mimir_alertmanager_rules
       rules:
         - expr: |
-            sum by (cluster_id, job, pod) (cortex_alertmanager_alerts)
+            sum by (cluster_id, installation, pipeline, provider, job, pod) (cortex_alertmanager_alerts)
           record: cluster_id_job_pod:cortex_alertmanager_alerts:sum
         - expr: |
-            sum by (cluster_id, job, pod) (cortex_alertmanager_silences)
+            sum by (cluster_id, installation, pipeline, provider, job, pod) (cortex_alertmanager_silences)
           record: cluster_id_job_pod:cortex_alertmanager_silences:sum
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_alerts_received_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_alerts_received_total[5m]))
           record: cluster_id_job:cortex_alertmanager_alerts_received_total:rate5m
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_alerts_invalid_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_alerts_invalid_total[5m]))
           record: cluster_id_job:cortex_alertmanager_alerts_invalid_total:rate5m
         - expr: |
-            sum by (cluster_id, job, integration) (rate(cortex_alertmanager_notifications_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job, integration) (rate(cortex_alertmanager_notifications_total[5m]))
           record: cluster_id_job_integration:cortex_alertmanager_notifications_total:rate5m
         - expr: |
-            sum by (cluster_id, job, integration) (rate(cortex_alertmanager_notifications_failed_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job, integration) (rate(cortex_alertmanager_notifications_failed_total[5m]))
           record: cluster_id_job_integration:cortex_alertmanager_notifications_failed_total:rate5m
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_state_replication_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_state_replication_total[5m]))
           record: cluster_id_job:cortex_alertmanager_state_replication_total:rate5m
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_state_replication_failed_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_state_replication_failed_total[5m]))
           record: cluster_id_job:cortex_alertmanager_state_replication_failed_total:rate5m
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_partial_state_merges_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_partial_state_merges_total[5m]))
           record: cluster_id_job:cortex_alertmanager_partial_state_merges_total:rate5m
         - expr: |
-            sum by (cluster_id, job) (rate(cortex_alertmanager_partial_state_merges_failed_total[5m]))
+            sum by (cluster_id, installation, pipeline, provider, job) (rate(cortex_alertmanager_partial_state_merges_failed_total[5m]))
           record: cluster_id_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m
     - name: mimir_ingester_rules
       rules:
         - expr: |
-            sum by(cluster_id, namespace, pod) (rate(cortex_ingester_ingested_samples_total[1m]))
+            sum by(cluster_id, installation, pipeline, provider, namespace, pod) (rate(cortex_ingester_ingested_samples_total[1m]))
           record: cluster_id_namespace_pod:cortex_ingester_ingested_samples_total:rate1m
 {{- end }}

--- a/helm/prometheus-rules/templates/recording-rules/mimir-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/recording-rules/mimir-mixins.rules.yml
@@ -8,574 +8,464 @@ metadata:
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: mimir_api_1
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job) / sum(rate(cortex_request_duration_seconds_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_request_duration_seconds:avg
-    - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_request_duration_seconds_count:sum_rate
-  - name: mimir_api_2
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:cortex_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:cortex_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-        / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:cortex_request_duration_seconds:avg
-    - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job,
-        route)
-      record: cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:cortex_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:cortex_request_duration_seconds_count:sum_rate
-  - name: mimir_api_3
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:cortex_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:cortex_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster,
-        namespace, job, route)
-      record: cluster_namespace_job_route:cortex_request_duration_seconds:avg
-    - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:cortex_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:cortex_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, namespace,
-        job, route)
-      record: cluster_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
-  - name: mimir_querier_api
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_querier_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_querier_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        job) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_querier_request_duration_seconds:avg
-    - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job)
-      record: cluster_job:cortex_querier_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_querier_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_querier_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:cortex_querier_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, route))
-      record: cluster_job_route:cortex_querier_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by
-        (cluster_id, provider, installation, pipeline, job, route)
-      record: cluster_job_route:cortex_querier_request_duration_seconds:avg
-    - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job, route)
-      record: cluster_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        job, route)
-      record: cluster_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster,
-        job, route)
-      record: cluster_job_route:cortex_querier_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, namespace, job, route))
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        namespace, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m]))
-        by (cluster_id, provider, installation, pipeline, namespace, job, route)
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds:avg
-    - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster,
-        namespace, job, route)
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster,
-        namespace, job, route)
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster,
-        namespace, job, route)
-      record: cluster_namespace_job_route:cortex_querier_request_duration_seconds_count:sum_rate
-  - name: mimir_cache
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_memcache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, method))
-      record: cluster_job_method:cortex_memcache_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_memcache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, method))
-      record: cluster_job_method:cortex_memcache_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_memcache_request_duration_seconds_sum[1m])) by (cluster,
-        job, method) / sum(rate(cortex_memcache_request_duration_seconds_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job, method)
-      record: cluster_job_method:cortex_memcache_request_duration_seconds:avg
-    - expr: sum(rate(cortex_memcache_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job, method)
-      record: cluster_job_method:cortex_memcache_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_memcache_request_duration_seconds_sum[1m])) by (cluster,
-        job, method)
-      record: cluster_job_method:cortex_memcache_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_memcache_request_duration_seconds_count[1m])) by (cluster,
-        job, method)
-      record: cluster_job_method:cortex_memcache_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_cache_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_cache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_cache_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_cache_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-        / sum(rate(cortex_cache_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_cache_request_duration_seconds:avg
-    - expr: sum(rate(cortex_cache_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job)
-      record: cluster_job:cortex_cache_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_cache_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_cache_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_cache_request_duration_seconds_count[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_cache_request_duration_seconds_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_cache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, method))
-      record: cluster_job_method:cortex_cache_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_cache_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job, method))
-      record: cluster_job_method:cortex_cache_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_cache_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job,
-        method) / sum(rate(cortex_cache_request_duration_seconds_count[1m])) by (cluster,
-        job, method)
-      record: cluster_job_method:cortex_cache_request_duration_seconds:avg
-    - expr: sum(rate(cortex_cache_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job, method)
-      record: cluster_job_method:cortex_cache_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_cache_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job,
-        method)
-      record: cluster_job_method:cortex_cache_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_cache_request_duration_seconds_count[1m])) by (cluster,
-        job, method)
-      record: cluster_job_method:cortex_cache_request_duration_seconds_count:sum_rate
-  - name: mimir_storage
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_kv_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_kv_request_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_kv_request_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_kv_request_duration_seconds:50quantile
-    - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-        / sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_kv_request_duration_seconds:avg
-    - expr: sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster,
-        job)
-      record: cluster_job:cortex_kv_request_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_kv_request_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_kv_request_duration_seconds_count:sum_rate
-  - name: mimir_queries
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_retries_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_query_frontend_retries:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_retries_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_query_frontend_retries:50quantile
-    - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, provider, installation, pipeline, job) / sum(rate(cortex_query_frontend_retries_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_retries:avg
-    - expr: sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_retries_bucket:sum_rate
-    - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_retries_sum:sum_rate
-    - expr: sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_retries_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds:50quantile
-    - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster,
-        job) / sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by
-        (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds:avg
-    - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le,
-        cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds_bucket:sum_rate
-    - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds_sum:sum_rate
-    - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster,
-        job)
-      record: cluster_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
-  - name: mimir_ingester_queries
-    rules:
-    - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_series:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_series_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_series:50quantile
-    - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, provider, installation, pipeline, job) / sum(rate(cortex_ingester_queried_series_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_series:avg
-    - expr: sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_series_bucket:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_series_sum:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_series_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_samples:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_samples:50quantile
-    - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, provider, installation, pipeline, job) / sum(rate(cortex_ingester_queried_samples_count[1m]))
-        by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_samples:avg
-    - expr: sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_samples_bucket:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_samples_sum:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_samples_count:sum_rate
-    - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_exemplars_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_exemplars:99quantile
-    - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_exemplars_bucket[1m]))
-        by (le, cluster_id, provider, installation, pipeline, job))
-      record: cluster_job:cortex_ingester_queried_exemplars:50quantile
-    - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, provider, installation, pipeline, job) /
-        sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_exemplars:avg
-    - expr: sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster,
-        job)
-      record: cluster_job:cortex_ingester_queried_exemplars_bucket:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_exemplars_sum:sum_rate
-    - expr: sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, provider, installation, pipeline, job)
-      record: cluster_job:cortex_ingester_queried_exemplars_count:sum_rate
-  - name: mimir_received_samples
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
-      record: cluster_namespace_job:cortex_distributor_received_samples:rate5m
-  - name: mimir_exemplars_in
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, job) (rate(cortex_distributor_exemplars_in_total[5m]))
-      record: cluster_namespace_job:cortex_distributor_exemplars_in:rate5m
-  - name: mimir_received_exemplars
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, job) (rate(cortex_distributor_received_exemplars_total[5m]))
-      record: cluster_namespace_job:cortex_distributor_received_exemplars:rate5m
-  - name: mimir_exemplars_ingested
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, job) (rate(cortex_ingester_ingested_exemplars_total[5m]))
-      record: cluster_namespace_job:cortex_ingester_ingested_exemplars:rate5m
-  - name: mimir_exemplars_appended
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, job) (rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total[5m]))
-      record: cluster_namespace_job:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m
-  - name: mimir_scaling_rules
-    rules:
-    - expr: |
-        # Convenience rule to get the number of replicas for both a deployment and a statefulset.
-        # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-        sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-          label_replace(
-            kube_deployment_spec_replicas,
-            # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-            # always matches everything and the (optional) zone is not removed.
-            "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
-          )
-        )
-        or
-        sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-          label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
-        )
-      record: cluster_namespace_deployment:actual_replicas:count
-    - expr: |
-        ceil(
-          quantile_over_time(0.99,
-            sum by (cluster_id, provider, installation, pipeline, namespace) (
-              cluster_namespace_job:cortex_distributor_received_samples:rate5m
-            )[24h:]
-          )
-          / 240000
-        )
-      labels:
-        deployment: distributor
-        reason: sample_rate
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          sum by (cluster_id, provider, installation, pipeline, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
-          * 0.59999999999999998 / 240000
-        )
-      labels:
-        deployment: distributor
-        reason: sample_rate_limits
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          quantile_over_time(0.99,
-            sum by (cluster_id, provider, installation, pipeline, namespace) (
-              cluster_namespace_job:cortex_distributor_received_samples:rate5m
-            )[24h:]
-          )
-          * 3 / 80000
-        )
-      labels:
-        deployment: ingester
-        reason: sample_rate
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          quantile_over_time(0.99,
-            sum by(cluster_id, provider, installation, pipeline, namespace) (
-              cortex_ingester_memory_series
-            )[24h:]
-          )
-          / 1500000
-        )
-      labels:
-        deployment: ingester
-        reason: active_series
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          sum by (cluster_id, provider, installation, pipeline, namespace) (cortex_limits_overrides{limit_name="max_global_series_per_user"})
-          * 3 * 0.59999999999999998 / 1500000
-        )
-      labels:
-        deployment: ingester
-        reason: active_series_limits
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          sum by (cluster_id, provider, installation, pipeline, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
-          * 0.59999999999999998 / 80000
-        )
-      labels:
-        deployment: ingester
-        reason: sample_rate_limits
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        ceil(
-          (sum by (cluster_id, provider, installation, pipeline, namespace) (
-            cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester.*"}
-          ) / 4)
-            /
-          avg by (cluster_id, provider, installation, pipeline, namespace) (
-            memcached_limit_bytes{job=~".+/memcached"}
-          )
-        )
-      labels:
-        deployment: memcached
-        reason: active_series
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-          label_replace(
-            label_replace(
-              node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate,
-              "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-            ),
-            # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-            # always matches everything and the (optional) zone is not removed.
-            "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
-          )
-        )
-      record: cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate
-    - expr: |
-        # Convenience rule to get the CPU request for both a deployment and a statefulset.
-        # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-        # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
-        # that remove resource metrics, ref:
-        # - https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
-        # - https://github.com/kubernetes/kube-state-metrics/pull/1004
-        #
-        # This is the old expression, compatible with kube-state-metrics < v2.0.0,
-        # where kube_pod_container_resource_requests_cpu_cores was removed:
-        (
-          sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-            label_replace(
+    - name: mimir_api_1
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_request_duration_seconds:avg
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_request_duration_seconds_count:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_request_duration_seconds:sum_rate
+    - name: mimir_api_2
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+          record: cluster_id_job_route:cortex_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+          record: cluster_id_job_route:cortex_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_request_duration_seconds:avg
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route)
+          record: cluster_id_job_route:cortex_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_request_duration_seconds_count:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_request_duration_seconds:sum_rate
+    - name: mimir_api_3
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route) / sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds:avg
+        - expr: sum(rate(cortex_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
+        - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_request_duration_seconds:sum_rate
+    - name: mimir_querier_api
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_querier_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_querier_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_querier_request_duration_seconds:avg
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_querier_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_querier_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_querier_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route))
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds:avg
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, job, route)
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, job, route)
+          record: cluster_id_job_route:cortex_querier_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route))
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route) / sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds:avg
+        - expr: sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_sum[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_querier_request_duration_seconds_count[1m])) by (cluster_id, namespace, job, route)
+          record: cluster_id_namespace_job_route:cortex_querier_request_duration_seconds_count:sum_rate
+    - name: mimir_storage
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_kv_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_kv_request_duration_seconds:50quantile
+        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_kv_request_duration_seconds:avg
+        - expr: sum(rate(cortex_kv_request_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_kv_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_kv_request_duration_seconds_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_kv_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_kv_request_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_kv_request_duration_seconds_count:sum_rate
+    - name: mimir_queries
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_query_frontend_retries:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_query_frontend_retries:50quantile
+        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, job) / sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_retries:avg
+        - expr: sum(rate(cortex_query_frontend_retries_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_retries_bucket:sum_rate
+        - expr: sum(rate(cortex_query_frontend_retries_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_retries_sum:sum_rate
+        - expr: sum(rate(cortex_query_frontend_retries_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_retries_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:50quantile
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, job) / sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds:avg
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_sum:sum_rate
+        - expr: sum(rate(cortex_query_frontend_queue_duration_seconds_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
+    - name: mimir_ingester_queries
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_series:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_series:50quantile
+        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_series:avg
+        - expr: sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_series_bucket:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_series_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_series_sum:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_series_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_series_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_samples:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_samples:50quantile
+        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_samples:avg
+        - expr: sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_samples_bucket:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_samples_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_samples_sum:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_samples_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_samples_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_exemplars:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job))
+          record: cluster_id_job:cortex_ingester_queried_exemplars:50quantile
+        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, job) / sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_exemplars:avg
+        - expr: sum(rate(cortex_ingester_queried_exemplars_bucket[1m])) by (le, cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_exemplars_bucket:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_exemplars_sum[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_exemplars_sum:sum_rate
+        - expr: sum(rate(cortex_ingester_queried_exemplars_count[1m])) by (cluster_id, job)
+          record: cluster_id_job:cortex_ingester_queried_exemplars_count:sum_rate
+    - name: mimir_received_samples
+      rules:
+        - expr: |
+            sum by (cluster_id, namespace, job) (rate(cortex_distributor_received_samples_total[5m]))
+          record: cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
+    - name: mimir_exemplars_in
+      rules:
+        - expr: |
+            sum by (cluster_id, namespace, job) (rate(cortex_distributor_exemplars_in_total[5m]))
+          record: cluster_id_namespace_job:cortex_distributor_exemplars_in:rate5m
+    - name: mimir_received_exemplars
+      rules:
+        - expr: |
+            sum by (cluster_id, namespace, job) (rate(cortex_distributor_received_exemplars_total[5m]))
+          record: cluster_id_namespace_job:cortex_distributor_received_exemplars:rate5m
+    - name: mimir_exemplars_ingested
+      rules:
+        - expr: |
+            sum by (cluster_id, namespace, job) (rate(cortex_ingester_ingested_exemplars_total[5m]))
+          record: cluster_id_namespace_job:cortex_ingester_ingested_exemplars:rate5m
+    - name: mimir_exemplars_appended
+      rules:
+        - expr: |
+            sum by (cluster_id, namespace, job) (rate(cortex_ingester_tsdb_exemplar_exemplars_appended_total[5m]))
+          record: cluster_id_namespace_job:cortex_ingester_tsdb_exemplar_exemplars_appended:rate5m
+    - name: mimir_scaling_rules
+      rules:
+        - expr: |
+            # Convenience rule to get the number of replicas for both a deployment and a statefulset.
+            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            sum by (cluster_id, namespace, deployment) (
               label_replace(
-                kube_pod_container_resource_requests_cpu_cores,
-                "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-              ),
-              # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-              # always matches everything and the (optional) zone is not removed.
-              "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                kube_deployment_spec_replicas,
+                # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                # always matches everything and the (optional) zone is not removed.
+                "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+              )
             )
-          )
-        )
-        or
-        # This expression is compatible with kube-state-metrics >= v1.4.0,
-        # where kube_pod_container_resource_requests was introduced.
-        (
-          sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-            label_replace(
+            or
+            sum by (cluster_id, namespace, deployment) (
+              label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
+            )
+          record: cluster_id_namespace_deployment:actual_replicas:count
+        - expr: |
+            ceil(
+              quantile_over_time(0.99,
+                sum by (cluster_id, namespace) (
+                  cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
+                )[24h:]
+              )
+              / 240000
+            )
+          labels:
+            deployment: distributor
+            reason: sample_rate
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
+              * 0.59999999999999998 / 240000
+            )
+          labels:
+            deployment: distributor
+            reason: sample_rate_limits
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              quantile_over_time(0.99,
+                sum by (cluster_id, namespace) (
+                  cluster_id_namespace_job:cortex_distributor_received_samples:rate5m
+                )[24h:]
+              )
+              * 3 / 80000
+            )
+          labels:
+            deployment: ingester
+            reason: sample_rate
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              quantile_over_time(0.99,
+                sum by(cluster_id, namespace) (
+                  cortex_ingester_memory_series
+                )[24h:]
+              )
+              / 1500000
+            )
+          labels:
+            deployment: ingester
+            reason: active_series
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="max_global_series_per_user"})
+              * 3 * 0.59999999999999998 / 1500000
+            )
+          labels:
+            deployment: ingester
+            reason: active_series_limits
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              sum by (cluster_id, namespace) (cortex_limits_overrides{limit_name="ingestion_rate"})
+              * 0.59999999999999998 / 80000
+            )
+          labels:
+            deployment: ingester
+            reason: sample_rate_limits
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            ceil(
+              (sum by (cluster_id, namespace) (
+                cortex_ingester_tsdb_storage_blocks_bytes{job=~".+/ingester.*"}
+              ) / 4)
+                /
+              avg by (cluster_id, namespace) (
+                memcached_limit_bytes{job=~".+/memcached"}
+              )
+            )
+          labels:
+            deployment: memcached
+            reason: active_series
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            sum by (cluster_id, namespace, deployment) (
               label_replace(
-                kube_pod_container_resource_requests{resource="cpu"},
-                "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-              ),
-              # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-              # always matches everything and the (optional) zone is not removed.
-              "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                label_replace(
+                  sum by (cluster_id, namespace, pod)(rate(container_cpu_usage_seconds_total[1m])),
+                  "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                ),
+                # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                # always matches everything and the (optional) zone is not removed.
+                "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+              )
             )
-          )
-        )
-      record: cluster_namespace_deployment:kube_pod_container_resource_requests_cpu_cores:sum
-    - expr: |
-        # Jobs should be sized to their CPU usage.
-        # We do this by comparing 99th percentile usage over the last 24hrs to
-        # their current provisioned #replicas and resource requests.
-        ceil(
-          cluster_namespace_deployment:actual_replicas:count
-            *
-          quantile_over_time(0.99, cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate[24h])
-            /
-          cluster_namespace_deployment:kube_pod_container_resource_requests_cpu_cores:sum
-        )
-      labels:
-        reason: cpu_usage
-      record: cluster_namespace_deployment_reason:required_replicas:count
-    - expr: |
-        # Convenience rule to get the Memory utilization for both a deployment and a statefulset.
-        # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-        sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-          label_replace(
-            label_replace(
-              container_memory_usage_bytes{image!=""},
-              "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-            ),
-            # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-            # always matches everything and the (optional) zone is not removed.
-            "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
-          )
-        )
-      record: cluster_namespace_deployment:container_memory_usage_bytes:sum
-    - expr: |
-        # Convenience rule to get the Memory request for both a deployment and a statefulset.
-        # Multi-zone deployments are grouped together removing the "zone-X" suffix.
-        # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
-        # that remove resource metrics, ref:
-        # - https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
-        # - https://github.com/kubernetes/kube-state-metrics/pull/1004
-        #
-        # This is the old expression, compatible with kube-state-metrics < v2.0.0,
-        # where kube_pod_container_resource_requests_memory_bytes was removed:
-        (
-          sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-            label_replace(
+          record: cluster_id_namespace_deployment:container_cpu_usage_seconds_total:sum_rate
+        - expr: |
+            # Convenience rule to get the CPU request for both a deployment and a statefulset.
+            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
+            # that remove resource metrics, ref:
+            # - https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
+            # - https://github.com/kubernetes/kube-state-metrics/pull/1004
+            #
+            # This is the old expression, compatible with kube-state-metrics < v2.0.0,
+            # where kube_pod_container_resource_requests_cpu_cores was removed:
+            (
+              sum by (cluster_id, namespace, deployment) (
+                label_replace(
+                  label_replace(
+                    kube_pod_container_resource_requests_cpu_cores,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
+              )
+            )
+            or
+            # This expression is compatible with kube-state-metrics >= v1.4.0,
+            # where kube_pod_container_resource_requests was introduced.
+            (
+              sum by (cluster_id, namespace, deployment) (
+                label_replace(
+                  label_replace(
+                    kube_pod_container_resource_requests{resource="cpu"},
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
+              )
+            )
+          record: cluster_id_namespace_deployment:kube_pod_container_resource_requests_cpu_cores:sum
+        - expr: |
+            # Jobs should be sized to their CPU usage.
+            # We do this by comparing 99th percentile usage over the last 24hrs to
+            # their current provisioned #replicas and resource requests.
+            ceil(
+              cluster_id_namespace_deployment:actual_replicas:count
+                *
+              quantile_over_time(0.99, cluster_id_namespace_deployment:container_cpu_usage_seconds_total:sum_rate[24h])
+                /
+              cluster_id_namespace_deployment:kube_pod_container_resource_requests_cpu_cores:sum
+            )
+          labels:
+            reason: cpu_usage
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+        - expr: |
+            # Convenience rule to get the Memory utilization for both a deployment and a statefulset.
+            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            sum by (cluster_id, namespace, deployment) (
               label_replace(
-                kube_pod_container_resource_requests_memory_bytes,
-                "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-              ),
-              # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-              # always matches everything and the (optional) zone is not removed.
-              "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                label_replace(
+                  container_memory_usage_bytes{image!=""},
+                  "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                ),
+                # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                # always matches everything and the (optional) zone is not removed.
+                "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+              )
             )
-          )
-        )
-        or
-        # This expression is compatible with kube-state-metrics >= v1.4.0,
-        # where kube_pod_container_resource_requests was introduced.
-        (
-          sum by (cluster_id, provider, installation, pipeline, namespace, deployment) (
-            label_replace(
-              label_replace(
-                kube_pod_container_resource_requests{resource="memory"},
-                "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
-              ),
-              # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-              # always matches everything and the (optional) zone is not removed.
-              "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+          record: cluster_id_namespace_deployment:container_memory_usage_bytes:sum
+        - expr: |
+            # Convenience rule to get the Memory request for both a deployment and a statefulset.
+            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            # This recording rule is made compatible with the breaking changes introduced in kube-state-metrics v2
+            # that remove resource metrics, ref:
+            # - https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
+            # - https://github.com/kubernetes/kube-state-metrics/pull/1004
+            #
+            # This is the old expression, compatible with kube-state-metrics < v2.0.0,
+            # where kube_pod_container_resource_requests_memory_bytes was removed:
+            (
+              sum by (cluster_id, namespace, deployment) (
+                label_replace(
+                  label_replace(
+                    kube_pod_container_resource_requests_memory_bytes,
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
+              )
             )
-          )
-        )
-      record: cluster_namespace_deployment:kube_pod_container_resource_requests_memory_bytes:sum
-    - expr: |
-        # Jobs should be sized to their Memory usage.
-        # We do this by comparing 99th percentile usage over the last 24hrs to
-        # their current provisioned #replicas and resource requests.
-        ceil(
-          cluster_namespace_deployment:actual_replicas:count
-            *
-          quantile_over_time(0.99, cluster_namespace_deployment:container_memory_usage_bytes:sum[24h])
-            /
-          cluster_namespace_deployment:kube_pod_container_resource_requests_memory_bytes:sum
-        )
-      labels:
-        reason: memory_usage
-      record: cluster_namespace_deployment_reason:required_replicas:count
-  - name: mimir_alertmanager_rules
-    rules:
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job, pod) (cortex_alertmanager_alerts)
-      record: cluster_job_pod:cortex_alertmanager_alerts:sum
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job, pod) (cortex_alertmanager_silences)
-      record: cluster_job_pod:cortex_alertmanager_silences:sum
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_alerts_received_total[5m]))
-      record: cluster_job:cortex_alertmanager_alerts_received_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_alerts_invalid_total[5m]))
-      record: cluster_job:cortex_alertmanager_alerts_invalid_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job, integration) (rate(cortex_alertmanager_notifications_total[5m]))
-      record: cluster_job_integration:cortex_alertmanager_notifications_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job, integration) (rate(cortex_alertmanager_notifications_failed_total[5m]))
-      record: cluster_job_integration:cortex_alertmanager_notifications_failed_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_state_replication_total[5m]))
-      record: cluster_job:cortex_alertmanager_state_replication_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_state_replication_failed_total[5m]))
-      record: cluster_job:cortex_alertmanager_state_replication_failed_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_partial_state_merges_total[5m]))
-      record: cluster_job:cortex_alertmanager_partial_state_merges_total:rate5m
-    - expr: |
-        sum by (cluster_id, provider, installation, pipeline, job) (rate(cortex_alertmanager_partial_state_merges_failed_total[5m]))
-      record: cluster_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m
-  - name: mimir_ingester_rules
-    rules:
-    - expr: |
-        sum by(cluster_id, provider, installation, pipeline, namespace, pod) (rate(cortex_ingester_ingested_samples_total[1m]))
-      record: cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m
+            or
+            # This expression is compatible with kube-state-metrics >= v1.4.0,
+            # where kube_pod_container_resource_requests was introduced.
+            (
+              sum by (cluster_id, namespace, deployment) (
+                label_replace(
+                  label_replace(
+                    kube_pod_container_resource_requests{resource="memory"},
+                    "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
+                  ),
+                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                  # always matches everything and the (optional) zone is not removed.
+                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                )
+              )
+            )
+          record: cluster_id_namespace_deployment:kube_pod_container_resource_requests_memory_bytes:sum
+        - expr: |
+            # Jobs should be sized to their Memory usage.
+            # We do this by comparing 99th percentile usage over the last 24hrs to
+            # their current provisioned #replicas and resource requests.
+            ceil(
+              cluster_id_namespace_deployment:actual_replicas:count
+                *
+              quantile_over_time(0.99, cluster_id_namespace_deployment:container_memory_usage_bytes:sum[24h])
+                /
+              cluster_id_namespace_deployment:kube_pod_container_resource_requests_memory_bytes:sum
+            )
+          labels:
+            reason: memory_usage
+          record: cluster_id_namespace_deployment_reason:required_replicas:count
+    - name: mimir_alertmanager_rules
+      rules:
+        - expr: |
+            sum by (cluster_id, job, pod) (cortex_alertmanager_alerts)
+          record: cluster_id_job_pod:cortex_alertmanager_alerts:sum
+        - expr: |
+            sum by (cluster_id, job, pod) (cortex_alertmanager_silences)
+          record: cluster_id_job_pod:cortex_alertmanager_silences:sum
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_alerts_received_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_alerts_received_total:rate5m
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_alerts_invalid_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_alerts_invalid_total:rate5m
+        - expr: |
+            sum by (cluster_id, job, integration) (rate(cortex_alertmanager_notifications_total[5m]))
+          record: cluster_id_job_integration:cortex_alertmanager_notifications_total:rate5m
+        - expr: |
+            sum by (cluster_id, job, integration) (rate(cortex_alertmanager_notifications_failed_total[5m]))
+          record: cluster_id_job_integration:cortex_alertmanager_notifications_failed_total:rate5m
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_state_replication_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_state_replication_total:rate5m
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_state_replication_failed_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_state_replication_failed_total:rate5m
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_partial_state_merges_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_partial_state_merges_total:rate5m
+        - expr: |
+            sum by (cluster_id, job) (rate(cortex_alertmanager_partial_state_merges_failed_total[5m]))
+          record: cluster_id_job:cortex_alertmanager_partial_state_merges_failed_total:rate5m
+    - name: mimir_ingester_rules
+      rules:
+        - expr: |
+            sum by(cluster_id, namespace, pod) (rate(cortex_ingester_ingested_samples_total[1m]))
+          record: cluster_id_namespace_pod:cortex_ingester_ingested_samples_total:rate1m
 {{- end }}

--- a/loki/.gitignore
+++ b/loki/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+dashboards_out/
+jsonnetfile.*
+

--- a/loki/mixin.libsonnet
+++ b/loki/mixin.libsonnet
@@ -1,0 +1,22 @@
+local loki = import 'loki-mixin/mixin-ssd.libsonnet';
+
+loki{
+  _config+:: {
+    tags: [
+      "owner:team-atlas",
+      "topic:observability",
+      "component:loki"
+    ],
+
+    per_node_label: 'node',
+    per_cluster_label: 'cluster_id',
+
+    canary+: {
+      enabled: true,
+    },
+
+    promtail+: {
+      enabled: true,
+    },
+  },
+}

--- a/loki/update.sh
+++ b/loki/update.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Update Loki mixins from upstream
+#
+# This script is used to update the Loki mixins from the upstream repository.
+#
+# Usage:
+#  ./loki/update.sh from the root of the repository
+
+set -e
+
+BRANCH="main"
+MIXIN_URL=https://github.com/grafana/loki/production/loki-mixin@$BRANCH
+OUTPUT_FILE="$(pwd)"/helm/prometheus-rules/templates/recording-rules/loki-mixins.rules.yml
+
+cd loki
+rm -rf vendor jsonnetfile.* "$OUTPUT_FILE"
+
+jb init
+jb install $MIXIN_URL
+mixtool generate rules mixin.libsonnet -r "$OUTPUT_FILE"
+
+# Remove the initial `groups:` line
+sed -i '1d' "$OUTPUT_FILE"
+
+# Add the PrometheusRule metadata header
+sed -i '1i\
+apiVersion: monitoring.coreos.com/v1\
+kind: PrometheusRule\
+metadata:\
+  labels:\
+    {{- include "labels.common" . | nindent 4 }}\
+  name: loki.recording.rules\
+  namespace: {{ .Values.namespace  }}\
+spec:\
+  groups:' "$OUTPUT_FILE"
+
+sed -i 's/cluster_id,/cluster_id, installation, pipeline, provider,/g' "$OUTPUT_FILE"

--- a/mimir/.gitignore
+++ b/mimir/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+dashboards_out/
+jsonnetfile.*
+

--- a/mimir/mixin.libsonnet
+++ b/mimir/mixin.libsonnet
@@ -1,0 +1,43 @@
+local mimir = import 'mimir-mixin/mixin-compiled.libsonnet';
+
+mimir{
+  _config+:: {
+    tags: [
+      "owner:team-atlas",
+      "topic:observability",
+      "component:mimir"
+    ],
+
+    per_cluster_label: 'cluster_id',
+    // Not sure why the default is set to instance, but we want to set it to node
+    per_node_label: 'node',
+    // We marked it as disabled as this should be enabled only if the enterprise gateway is enabled
+    gateway_enabled: false,
+    // Whether alerts for experimental ingest storage are enabled.
+    ingest_storage_enabled: false,
+    // Disable all autoscaling components because we currently do not use it
+    autoscaling: {
+      query_frontend: {
+        enabled: false,
+      },
+      ruler_query_frontend: {
+        enabled: false,
+      },
+      querier: {
+        enabled: false,
+      },
+      ruler_querier: {
+        enabled: false,
+      },
+      distributor: {
+        enabled: false,
+      },
+      ruler: {
+        enabled: false,
+      },
+      gateway: {
+        enabled: false,
+      },
+    },
+  },
+}

--- a/mimir/update.sh
+++ b/mimir/update.sh
@@ -38,3 +38,5 @@ spec:\
 # Add the mimir enabled helm conditional blocks
 sed -i '1i{{- if .Values.mimir.enabled }}' "$OUTPUT_FILE"
 sed -i -e '$a{{- end }}' "$OUTPUT_FILE"
+
+sed -i 's/cluster_id,/cluster_id, installation, pipeline, provider,/g' "$OUTPUT_FILE"

--- a/mimir/update.sh
+++ b/mimir/update.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Update Mimir mixins from upstream
+#
+# This script is used to update the Mimir mixins from the upstream repository.
+#
+# Usage:
+#  ./mimir/update.sh from the root of the repository
+
+set -e
+
+BRANCH="main"
+MIXIN_URL=https://github.com/grafana/mimir/operations/mimir-mixin@$BRANCH
+OUTPUT_FILE="$(pwd)"/helm/prometheus-rules/templates/recording-rules/mimir-mixins.rules.yml
+
+cd mimir
+rm -rf vendor jsonnetfile.* "$OUTPUT_FILE"
+
+jb init
+jb install $MIXIN_URL
+mixtool generate rules mixin.libsonnet -r "$OUTPUT_FILE"
+
+# Remove the initial `groups:` line
+sed -i '1d' "$OUTPUT_FILE"
+
+# Add the PrometheusRule metadata header
+sed -i '1i\
+apiVersion: monitoring.coreos.com/v1\
+kind: PrometheusRule\
+metadata:\
+  labels:\
+    {{- include "labels.common" . | nindent 4 }}\
+  name: mimir.recording.rules\
+  namespace: {{ .Values.namespace  }}\
+spec:\
+  groups:' "$OUTPUT_FILE"
+
+# Add the mimir enabled helm conditional blocks
+sed -i '1i{{- if .Values.mimir.enabled }}' "$OUTPUT_FILE"
+sed -i -e '$a{{- end }}' "$OUTPUT_FILE"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/dashboards/pull/510

This PR is needed by https://github.com/giantswarm/dashboards/pull/510 so dashboards that use the rules actually work. Current implementation is not ideal. I would rather we add those to the mimir-app but let's test it here for now

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
