### PR TITLE
Update Linkerd alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update ops-recipe link for promtail alerts.
+- Remove Linkerd form Service SLO alerts.
+- Include all Linkerd Namespaces in LinkerdDeploymentNotSatisfied alert.
+- Make LinkerdDeploymentNotSatisfied alert business hours only.
 
 ## [3.11.2] - 2024-04-18
 

--- a/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
@@ -18,7 +18,7 @@ spec:
       for: 30m
       labels:
         area: managedservices
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: true
         severity: page
         team: cabbage
         topic: linkerd

--- a/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/linkerd.deployment.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Linkerd Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: managed-app-linkerd/
-      expr: managed_app_deployment_status_replicas_unavailable{deployment=~"linkerd.*"} > 0
+      expr: managed_app_deployment_status_replicas_unavailable{namespace=~"linkerd.*"} > 0
       for: 30m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/service-level.rules.yml
@@ -18,21 +18,21 @@ spec:
       expr: |
         label_replace(
             (
-                  slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                  slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*", namespace!~"linkerd.*"}
                 > on (cluster_id, service) group_left ()
                   slo_threshold_high
               and
-                  slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                  slo_errors_per_request:ratio_rate5m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*", namespace!~"linkerd.*"}
                 > on (cluster_id, service) group_left ()
                   slo_threshold_high
             )
           or
             (
-                  slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                  slo_errors_per_request:ratio_rate6h{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*", namespace!~"linkerd.*"}
                 > on (cluster_id, service) group_left ()
                   slo_threshold_low
               and
-                  slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*"}
+                  slo_errors_per_request:ratio_rate30m{service!~"efk-.*|.*external-dns.*|kong-.*|.*(ingress-nginx|nginx-ingress-controller).*", namespace!~"linkerd.*"}
                 > on (cluster_id, service) group_left ()
                   slo_threshold_low
             ),

--- a/test/tests/providers/global/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/linkerd.deployment.rules.test.yml
@@ -18,7 +18,7 @@ tests:
           - exp_labels:
               alertname: LinkerdDeploymentNotSatisfied
               area: managedservices
-              cancel_if_outside_working_hours: "false"
+              cancel_if_outside_working_hours: "true"
               namespace: linkerd
               deployment: linkerd-destination
               managed_app: destination


### PR DESCRIPTION
---
Towards: https://github.com/giantswarm/giantswarm/issues/30443

This PR
- Cancel linkerd alert outside business hours
- Remove Linkerd deployments from SLO
- Cover all linkerd namespaces with Linkerd alert

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
