### PR TITLE
Remove Kyverno AdmissionReportsTooHigh alert

### DIFF
--- a/helm/prometheus-rules/templates/alerting-rules/kyverno.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kyverno.all.rules.yml
@@ -27,21 +27,6 @@ spec:
         topic: kyverno
   - name: resources
     rules:
-    - alert: KyvernoAdmissionReportCountTooHigh
-      annotations:
-        description: "{{`Kyverno {{ $labels.kind }} are too high. This is an indicator that Kyverno\'s report processing may not be keeping up with cluster demand.`}}"
-        opsrecipe: kyverno-reports/
-      expr: aggregation:kyverno_resource_counts{kind=~"(clusteradmissionreports|admissionreports).kyverno.io"} > 50000
-      for: 15m
-      labels:
-        area: managedservices
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: page
-        team: shield
-        topic: kyverno
     - alert: KyvernoUpdateRequestsCountTooHigh
       annotations:
         description: "{{`Kyverno {{ $labels.kind }} are too high. This is an indicator that Kyverno's background controller may not be able to create some resources.`}}"

--- a/test/tests/providers/global/kyverno.all.rules.test.yml
+++ b/test/tests/providers/global/kyverno.all.rules.test.yml
@@ -42,24 +42,6 @@ tests:
               description: "Kyverno has no available replicas but webhooks are present."
               opsrecipe: "kyverno-webhooks/"
       # Kyverno reports too high alert
-      - alertname: KyvernoAdmissionReportCountTooHigh
-        eval_time: 60m
-        exp_alerts:
-          - exp_labels:
-              area: managedservices
-              cluster_id: gremlin
-              severity: page
-              team: shield
-              topic: kyverno
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cancel_if_outside_working_hours: "false"
-              kind: "admissionreports.kyverno.io"
-            exp_annotations:
-              description: "Kyverno admissionreports.kyverno.io are too high. This is an indicator that Kyverno's report processing may not be keeping up with cluster demand."
-              opsrecipe: "kyverno-reports/"
-      # Kyverno reports too high alert
       - alertname: KyvernoUpdateRequestsCountTooHigh
         eval_time: 45m
         exp_alerts:


### PR DESCRIPTION
This alert is outdated now. Kyverno has moved away from storing AdmissionReports and these should not stack up anymore. We could rework it in the future and something general for other report types.