### PR TITLE
Teleport alerts only on CAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed DeploymentNotSatisfiedBigMac alert to work for teleport related deployments only on CAPI flavored clusters
+
 ## [3.12.2] - 2024-04-25
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -164,7 +164,11 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
+      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
       expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|dex*|athena*|rbac-operator|credentiald"} > 0
+      {{- else }}
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|teleport-.*|dex*|athena*|rbac-operator|credentiald"} > 0
+      {{- end }}
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/deployment.management-cluster.rules.yml
@@ -165,9 +165,9 @@ spec:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|dex*|athena*|rbac-operator|credentiald"} > 0
-      {{- else }}
       expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|teleport-.*|dex*|athena*|rbac-operator|credentiald"} > 0
+      {{- else }}
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|dex*|athena*|rbac-operator|credentiald"} > 0
       {{- end }}
       for: 30m
       labels:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30670

This PR:

- Changes DeploymentNotSatisfiedBigMac alert to work for teleport only on CAPI flavored clusters

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
