### PR TITLE
Remove crsync absent deployments alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed alerts for absent `crsync` deployments. They cause false alerts because the rules apply to all prometheus instances on the MC.
+
 ## [3.13.0] - 2024-04-30
 
 ### Added

--- a/helm/prometheus-rules/templates/alerting-rules/crsync.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/crsync.rules.yml
@@ -13,36 +13,6 @@ spec:
   groups:
   - name: crsync
     rules:
-    - alert: CrsyncDockerIoIsMissing
-      annotations:
-        description: 'CrSync deployment for docker.io is absent'
-        opsrecipe: crsync-deployments-missing/
-      expr: absent(kube_deployment_status_replicas_available{namespace="crsync", deployment="crsync-docker-io"})
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: honeybadger
-        topic: releng
-    - alert: CrsyncGiantswarmAzureCrIoIsMissing
-      annotations:
-        description: 'CrSync deployment for giantswarm.azurecr.io is absent'
-        opsrecipe: crsync-deployments-missing/
-      expr: absent(kube_deployment_status_replicas_available{namespace="crsync", deployment="crsync-giantswarm-azurecr-io"})
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: honeybadger
-        topic: releng
     - alert: CrsyncDeploymentNotSatisfied
       annotations:
         description: '{{`CrSync deployment {{ $labels.deployment }} is not satisfied in {{ $labels.installation }} / {{ $labels.cluster_id }} at the {{ $labels.namespace }} namespace.`}}'


### PR DESCRIPTION
It causes false triggers because the MC where the rule is applied has multiple prometheus instances and they all take the rule into account, but only the operations one should have the alert.

We can get it back online when we has a single instance / mimir.

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30623

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
