### PR TITLE
Add inhibitions expressions for CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 
 - Remove cilium entry from KAAS SLOs.
 
+### Added
+
+- Added inhibitions expressions for CAPI clusters.
+
 ## [3.13.1] - 2024-04-30
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -80,7 +80,7 @@ spec:
     - alert: InhibitionClusterNodePoolsNotReady
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} node pools are not ready. Either they have been scaled down to 0 or they are not up yet.`}}'
-      expr: cluster_operator_node_pool_desired_workers == 0 and cluster_operator_node_pool_ready_workers == 0 or capi_machinepool_status_condition{type="Ready", status="False"} == 1
+      expr: (cluster_operator_node_pool_desired_workers == 0 and cluster_operator_node_pool_ready_workers == 0) or capi_machinepool_status_condition{type="Ready", status="False"} == 1
       labels:
         area: kaas
         cluster_with_notready_nodepools: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -17,7 +17,7 @@ spec:
     - alert: InhibitionClusterStatusCreating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Creating''.`}}'
-      expr: label_replace(max_over_time(statusresource_cluster_status{status="Creating"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Creating"}[30m]) == 1
+      expr: label_replace(max_over_time(statusresource_cluster_status{status="Creating"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Creating"}[30m]) == 1 or max_over_time(capi_cluster_status_phase{phase="Provisioning"}[30m]) == 1
       labels:
         area: kaas
         cluster_status_creating: "true"
@@ -26,7 +26,7 @@ spec:
     - alert: InhibitionClusterStatusCreated
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Created''.`}}'
-      expr: label_replace(statusresource_cluster_status{status="Created"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Created"} == 1
+      expr: label_replace(statusresource_cluster_status{status="Created"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Created"} == 1 or (capi_cluster_status_phase{phase="Provisioned"} == 1 and capi_cluster_status_condition{type="Ready", status="True"} == 1)
       labels:
         area: kaas
         cluster_status_created: "true"
@@ -35,7 +35,7 @@ spec:
     - alert: InhibitionClusterStatusUpdating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updating''.`}}'
-      expr: label_replace(statusresource_cluster_status{status="Updating"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or label_replace(changes(statusresource_cluster_status{status="Updating"}[10m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) == 1
+      expr: label_replace(statusresource_cluster_status{status="Updating"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or label_replace(changes(statusresource_cluster_status{status="Updating"}[10m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) == 1 or (capi_cluster_status_condition{type="Ready", status="False"} == 1 and (capi_kubeadmcontrolplane_status_condition{type="MachinesSpecUpToDate", status="False"} == 1 or capi_kubeadmcontrolplane_status_condition{type="MachinesReady", status="False"} == 1))
       labels:
         area: kaas
         cluster_status_updating: "true"
@@ -44,7 +44,7 @@ spec:
     - alert: InhibitionClusterStatusUpdated
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updated''.`}}'
-      expr: label_replace(statusresource_cluster_status{status="Updated"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updated"} == 1
+      expr: label_replace(statusresource_cluster_status{status="Updated"}, "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or cluster_operator_cluster_status{status="Updated"} == 1 or (capi_cluster_status_condition{type="Ready", status="True"} == 1 and (capi_kubeadmcontrolplane_status_condition{type="MachinesSpecUpToDate", status="True"} == 1 and capi_kubeadmcontrolplane_status_condition{type="MachinesReady", status="True"} == 1))
       labels:
         area: kaas
         cluster_status_updated: "true"
@@ -53,7 +53,7 @@ spec:
     - alert: InhibitionClusterStatusDeleting
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Deleting''.`}}'
-      expr: label_replace(max_over_time(statusresource_cluster_status{status="Deleting"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Deleting"}[30m]) == 1
+      expr: label_replace(max_over_time(statusresource_cluster_status{status="Deleting"}[30m]), "cluster_id", "$1", "exported_cluster_id", "(.+)") == 1 or max_over_time(cluster_operator_cluster_status{status="Deleting"}[30m]) == 1 or max_over_time(capi_cluster_status_phase{phase="Deleting"}[30m]) == 1
       labels:
         area: kaas
         cluster_status_deleting: "true"
@@ -71,7 +71,7 @@ spec:
     - alert: InhibitionClusterScalingNodePools
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} node pools are scaling.`}}'
-      expr: cluster_operator_node_pool_desired_workers != cluster_operator_node_pool_ready_workers
+      expr: cluster_operator_node_pool_desired_workers != cluster_operator_node_pool_ready_workers or (capi_machinepool_status_phase{phase="ScalingUp"} == 1 or capi_machinepool_status_phase{phase="ScalingDown"} == 1)
       labels:
         area: kaas
         cluster_with_scaling_nodepools: "true"
@@ -80,7 +80,7 @@ spec:
     - alert: InhibitionClusterNodePoolsNotReady
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} node pools are not ready. Either they have been scaled down to 0 or they are not up yet.`}}'
-      expr: cluster_operator_node_pool_desired_workers == 0 and cluster_operator_node_pool_ready_workers == 0
+      expr: cluster_operator_node_pool_desired_workers == 0 and cluster_operator_node_pool_ready_workers == 0 or capi_machinepool_status_condition{type="Ready", status="False"} == 1
       labels:
         area: kaas
         cluster_with_notready_nodepools: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3338
This PR adds the expressions to have inhibitions working on capi clusters.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
