### PR TITLE
tests: add pint targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `cluster_control_plane_unhealthy` inhibition.
 - Added inhibitions expressions for CAPI clusters.
+- make targets for pint linter
 
 ## [3.13.1] - 2024-04-30
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -31,3 +31,9 @@ test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
 
 test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid in CI
 	test/hack/bin/check-opsrecipes.sh --ci
+
+pint-full: install-tools template-chart ## Run pint with all checks
+	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint test/tests/providers/vintage/aws/*.rules.yml
+
+pint-aggregations: install-tools template-chart ## Run pint with only the aggregation checks
+	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint test/tests/providers/vintage/aws/*.rules.yml

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -33,7 +33,9 @@ test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are vali
 	test/hack/bin/check-opsrecipes.sh --ci
 
 pint-full: install-tools template-chart ## Run pint with all checks
-	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint test/tests/providers/vintage/aws/*.rules.yml
+	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
+	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint test/tests/providers/capi/capa-mimir/*.rules.yml
 
 pint-aggregations: install-tools template-chart ## Run pint with only the aggregation checks
-	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint test/tests/providers/vintage/aws/*.rules.yml
+	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
+	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint test/tests/providers/capi/capa-mimir/*.rules.yml

--- a/test/conf/pint/pint-aggregations.hcl
+++ b/test/conf/pint/pint-aggregations.hcl
@@ -1,0 +1,7 @@
+rule {
+  # Ensure that all aggregations are preserving "job" label.
+  aggregate ".+" {
+    severity = "bug"
+    keep     = ["cluster_id", "installation", "pipeline", "provider"]
+  }
+}

--- a/test/conf/pint/pint-aggregations.hcl
+++ b/test/conf/pint/pint-aggregations.hcl
@@ -1,5 +1,5 @@
 rule {
-  # Ensure that all aggregations are preserving "job" label.
+  # Ensure that all aggregations are preserving mandatory labels.
   aggregate ".+" {
     severity = "bug"
     keep     = ["cluster_id", "installation", "pipeline", "provider"]

--- a/test/conf/pint/pint-config.hcl
+++ b/test/conf/pint/pint-config.hcl
@@ -11,7 +11,7 @@ rule {
     label_values = true
   }
 
-  # Ensure that all aggregations are preserving "job" label.
+  # Ensure that all aggregations are preserving mandatory labels.
   aggregate ".+" {
     severity = "bug"
     keep     = ["cluster_id", "installation", "pipeline", "provider"]
@@ -24,8 +24,14 @@ rule {
     kind = "alerting"
   }
 
-  # Each alert must have a 'summary' annotation on every alert.
+  # Each alert must have a 'description' annotation.
   annotation "description" {
+    severity = "bug"
+    required = true
+  }
+
+  # Each alert must have a 'opsrecipe' annotation.
+  annotation "opsrecipe" {
     severity = "bug"
     required = true
   }
@@ -36,7 +42,7 @@ rule {
     required = true
   }
 
-  # Each alert must have a 'severity' annotation that's either 'critical' or 'warning'.
+  # Each alert must have a 'severity' annotation that's either 'page' or 'notify'.
   label "severity" {
     severity = "bug"
     value    = "(page|notify)"
@@ -48,10 +54,5 @@ rule {
     range   = "1d"
     step    = "1m"
     resolve = "5m"
-  }
-
-  annotation "opsrecipe" {
-    severity = "bug"
-    required = true
   }
 }

--- a/test/conf/pint/pint-config.hcl
+++ b/test/conf/pint/pint-config.hcl
@@ -1,0 +1,57 @@
+rule {
+  # Disallow spaces in label/annotation keys, they're only allowed in values.
+  reject ".* +.*" {
+    label_keys      = true
+    annotation_keys = true
+  }
+
+  # Disallow URLs in labels, they should go to annotations.
+  reject "https?://.+" {
+    label_keys   = true
+    label_values = true
+  }
+
+  # Ensure that all aggregations are preserving "job" label.
+  aggregate ".+" {
+    severity = "bug"
+    keep     = ["cluster_id", "installation", "pipeline", "provider"]
+  }
+}
+
+rule {
+  # This block will apply to all alerting rules.
+  match {
+    kind = "alerting"
+  }
+
+  # Each alert must have a 'summary' annotation on every alert.
+  annotation "description" {
+    severity = "bug"
+    required = true
+  }
+
+  # Each alert should have a 'dashboard' annotation.
+  annotation "dashboard" {
+    severity = "warning"
+    required = true
+  }
+
+  # Each alert must have a 'severity' annotation that's either 'critical' or 'warning'.
+  label "severity" {
+    severity = "bug"
+    value    = "(page|notify)"
+    required = true
+  }
+
+  # Check how many times each alert would fire in the last 1d.
+  alerts {
+    range   = "1d"
+    step    = "1m"
+    resolve = "5m"
+  }
+
+  annotation "opsrecipe" {
+    severity = "bug"
+    required = true
+  }
+}

--- a/test/conf/providers
+++ b/test/conf/providers
@@ -1,2 +1,4 @@
 vintage/aws
 capi/capz
+capi/capa
+capi/capa-mimir

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -6,6 +6,7 @@ ARCHITECT_VERSION="6.8.0"
 PROMETHEUS_VERSION="2.41.0"
 HELM_VERSION="3.9.0"
 YQ_VERSION="4.26.1"
+PINT_VERSION="0.58.1"
 
 GIT_WORKDIR=$(git rev-parse --show-toplevel)
 
@@ -18,6 +19,8 @@ Linux*)
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-linux-amd64.tar.gz"
     export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
     export YQ_BIN_FILE="yq_linux_amd64"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
+    export PINT_BIN_FILE="pint-linux-amd64"
     ;;
 
 Darwin*)
@@ -26,6 +29,8 @@ Darwin*)
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-darwin-amd64.tar.gz"
     export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
     export YQ_BIN_FILE="yq_darwin_amd64"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
+    export PINT_BIN_FILE="pint-darwin-amd64"
     TAR_CMD="gtar"
     ;;
 
@@ -57,6 +62,7 @@ extract() {
     local tarfile="$1" && shift
     local sourceurl="$1" && shift
     local wildcards="$1" && shift
+    local stripcomponents="${1:-1}" && shift || true
 
     # extract files only if not exist yet
     if [[ ! -f "$binfile" ]]; then
@@ -70,7 +76,7 @@ extract() {
         echo "## Extracted files:"
         "$TAR_CMD" -xvf "$tarfile" \
             -C "$GIT_WORKDIR/test/hack/bin/" \
-            --strip-components=1 \
+            --strip-components="$stripcomponents" \
             --wildcards "$wildcards"
     fi
 
@@ -103,6 +109,15 @@ main() {
         "*/yq_*"
     if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/yq" ]]; then
         ln -s "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/yq"
+    fi
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" \
+        "${GIT_WORKDIR}/test/hack/bin/pint-${PINT_VERSION}.tar.gz" \
+        "$PINT_SOURCE" \
+        "pint-*" \
+        0
+    if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/pint" ]]; then
+        ln -s "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/pint"
     fi
 }
 

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -10,13 +10,15 @@ main() {
   for provider in "${providers[@]}"; do
     echo "Templating chart for provider: $provider"
 
-    [[ $provider =~ ([a-z]+)/([a-z]+) ]]
+    [[ $provider =~ ([a-z]+)/([a-z]+)(-[a-z]+) ]]
+    [[ "${BASH_REMATCH[3]}" == "-mimir" ]] && mimir_enabled=true || mimir_enabled=false
 
     helm template \
       "$GIT_WORKDIR"/helm/prometheus-rules \
       --set="managementCluster.provider.flavor=${BASH_REMATCH[1]}" \
       --set="managementCluster.provider.kind=${BASH_REMATCH[2]}" \
       --set="managementCluster.name=myinstall" \
+      --set="mimir.enabled=$mimir_enabled" \
       --output-dir "$GIT_WORKDIR"/test/hack/output/"$provider"
   done
 }

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -70,6 +70,9 @@ main() {
         [[ -f "$expected_failure_file_provider" ]] \
             && mapfile -t expected_failure_prefixes_provider <"$expected_failure_file_provider"
 
+        # Create the directory for the provider if needed
+        [[ -d "$GIT_WORKDIR/test/tests/providers/$provider" ]] || mkdir -p "$GIT_WORKDIR/test/tests/providers/$provider"
+
         for file in "${all_files[@]}"; do
 
             [[ ! "$file" =~ .*$filter.* ]] && continue
@@ -83,17 +86,21 @@ main() {
             # Extract rules file from helm template
             echo "###    extracting $GIT_WORKDIR/test/tests/providers/$provider/$filename"
             if [[ -f "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/alerting-rules/$filename" ]]
+            # For alerting rules
             then
                 "$GIT_WORKDIR/$YQ" '.spec' "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/alerting-rules/$filename" > "$GIT_WORKDIR/test/tests/providers/$provider/$filename"
             elif [[ -f "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/recording-rules/$filename" ]]
+            # For recording rules
             then
                 "$GIT_WORKDIR/$YQ" '.spec' "$GIT_WORKDIR/test/hack/output/$provider/prometheus-rules/templates/recording-rules/$filename" > "$GIT_WORKDIR/test/tests/providers/$provider/$filename"
             else
+                # Fail when file is not found
                 echo "###    Failed extracting rules file $file"
                 failing_extraction+=("$provider:$file")
                 continue
             fi
 
+            # Skip next steps if GENERATE_ONLY is set
             if [[ "$GENERATE_ONLY" == "true" ]]; then continue; fi
 
             # Syntax check of rules file

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 
 set -eu
 
+# Global options
+
+## GENERATE_ONLY: if set to true, the script will only generate the rules files
+GENERATE_ONLY="${GENERATE_ONLY:-false}"
+
 array_contains() {
     local search="$1" && shift
 
@@ -88,6 +93,8 @@ main() {
                 failing_extraction+=("$provider:$file")
                 continue
             fi
+
+            if [[ "$GENERATE_ONLY" == "true" ]]; then continue; fi
 
             # Syntax check of rules file
             echo "###    promtool check rules $GIT_WORKDIR/test/tests/providers/$provider/$filename"

--- a/test/tests/providers/capi/capa-mimir/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/mimir.rules.test.yml
@@ -16,10 +16,9 @@ tests:
               app: mimir
               area: empowerment
               installation: myinstall
-              namespace: monitoring
               team: atlas
               topic: observability
-              type: heartbeat
+              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
       - alertname:  Heartbeat
@@ -31,10 +30,9 @@ tests:
               app: mimir
               area: empowerment
               installation: myinstall
-              namespace: monitoring
               team: atlas
               topic: observability
-              type: heartbeat
+              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
       - alertname:  Heartbeat
@@ -46,10 +44,9 @@ tests:
               app: mimir
               area: empowerment
               installation: myinstall
-              namespace: monitoring
               team: atlas
               topic: observability
-              type: heartbeat
+              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
   - interval: 1m

--- a/test/tests/providers/capi/capa-mimir/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/prometheus-agent.rules.test.yml
@@ -1,4 +1,5 @@
 ---
+# These tests differ between prometheus and mimir installations: the resulting labels are different
 rule_files:
 - prometheus-agent.rules.yml
 
@@ -6,8 +7,10 @@ tests:
   # Tests for `PrometheusAgentFailing` alert
   - interval: 1m
     input_series:
-      - series: 'up{instance="prometheus-agent",cluster_type="workload_cluster",cluster_id="gauss",installation="myinstall"}'
+      - series: 'up{instance="prometheus-agent",cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", job="prometheus-agent"}'
         values: "_x60  0+0x60 1+0x60"
+      - series: 'capi_cluster_status_condition{ cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
+        values: "1+0x180"
     alert_rule_test:
       - alertname: PrometheusAgentFailing
         eval_time: 30m
@@ -18,10 +21,19 @@ tests:
               team: atlas
               topic: observability
               inhibit_prometheus_agent_down: "true"
-              instance: prometheus-agent
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
+              cluster_id: "gauss"
+              cluster_type: "workload_cluster"
+              customer: "giantswarm"
+              installation: "myinstall"
+              name: "gauss"
+              pipeline: "testing"
+              provider: "capa"
+              region: "eu-west-2"
+              status: "True"
+              type: "ControlPlaneReady"
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
@@ -36,10 +48,19 @@ tests:
               team: atlas
               topic: observability
               inhibit_prometheus_agent_down: "true"
-              instance: prometheus-agent
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
+              cluster_id: "gauss"
+              cluster_type: "workload_cluster"
+              customer: "giantswarm"
+              installation: "myinstall"
+              name: "gauss"
+              pipeline: "testing"
+              provider: "capa"
+              region: "eu-west-2"
+              status: "True"
+              type: "ControlPlaneReady"
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
@@ -57,10 +78,16 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
-              instance: prometheus-agent
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
+              customer: "giantswarm"
+              name: "gauss"
+              pipeline: "testing"
+              provider: "capa"
+              region: "eu-west-2"
+              status: "True"
+              type: "ControlPlaneReady"
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."
@@ -78,10 +105,16 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
-              instance: prometheus-agent
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
+              customer: "giantswarm"
+              name: "gauss"
+              pipeline: "testing"
+              provider: "capa"
+              region: "eu-west-2"
+              status: "True"
+              type: "ControlPlaneReady"
             exp_annotations:
               dashboard: "promRW001/prometheus-remote-write"
               description: "Prometheus agent remote write is failing."

--- a/test/tests/providers/capi/capa/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa/prometheus-agent.rules.test.yml
@@ -1,0 +1,306 @@
+---
+# These tests differ between prometheus and mimir installations: the resulting labels are different
+rule_files:
+- prometheus-agent.rules.yml
+
+tests:
+  # Tests for `PrometheusAgentFailing` alert
+  - interval: 1m
+    input_series:
+      - series: 'up{instance="prometheus-agent",cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", job="prometheus-agent"}'
+        values: "_x60  0+0x60 1+0x60"
+      - series: 'capi_cluster_status_condition{ cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
+        values: "1+0x180"
+    alert_rule_test:
+      - alertname: PrometheusAgentFailing
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 150m
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 150m
+  # Tests for `PrometheusAgentShardsMissing` alert
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_shards{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '1+0x180'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m
+  # Tests for `PrometheusAgentShardsMissing` alert with missing `prometheus_operator_spec_shards` metric
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m

--- a/test/tests/providers/capi/capz/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capz/prometheus-agent.rules.test.yml
@@ -1,0 +1,306 @@
+---
+# These tests differ between prometheus and mimir installations: the resulting labels are different
+rule_files:
+- prometheus-agent.rules.yml
+
+tests:
+  # Tests for `PrometheusAgentFailing` alert
+  - interval: 1m
+    input_series:
+      - series: 'up{instance="prometheus-agent",cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", job="prometheus-agent"}'
+        values: "_x60  0+0x60 1+0x60"
+      - series: 'capi_cluster_status_condition{ cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
+        values: "1+0x180"
+    alert_rule_test:
+      - alertname: PrometheusAgentFailing
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 150m
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 150m
+  # Tests for `PrometheusAgentShardsMissing` alert
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_shards{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '1+0x180'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m
+  # Tests for `PrometheusAgentShardsMissing` alert with missing `prometheus_operator_spec_shards` metric
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m

--- a/test/tests/providers/vintage/aws/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/vintage/aws/prometheus-agent.rules.test.yml
@@ -1,0 +1,306 @@
+---
+# These tests differ between prometheus and mimir installations: the resulting labels are different
+rule_files:
+- prometheus-agent.rules.yml
+
+tests:
+  # Tests for `PrometheusAgentFailing` alert
+  - interval: 1m
+    input_series:
+      - series: 'up{instance="prometheus-agent",cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", job="prometheus-agent"}'
+        values: "_x60  0+0x60 1+0x60"
+      - series: 'capi_cluster_status_condition{ cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
+        values: "1+0x180"
+    alert_rule_test:
+      - alertname: PrometheusAgentFailing
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: gauss
+              cluster_type: workload_cluster
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              installation: myinstall
+              instance: prometheus-agent
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+            exp_annotations:
+              dashboard: "promRW001/prometheus-remote-write"
+              description: "Prometheus agent remote write is failing."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent fails to send samples to remote write endpoint."
+      - alertname: PrometheusAgentFailing
+        eval_time: 150m
+      - alertname: PrometheusAgentFailingInhibition
+        eval_time: 150m
+  # Tests for `PrometheusAgentShardsMissing` alert
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_shards{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '1+0x180'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m
+  # Tests for `PrometheusAgentShardsMissing` alert with missing `prometheus_operator_spec_shards` metric
+  - interval: 1m
+    input_series:
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-1-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_remote_storage_metadata_total{app="prometheus", cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus", instance="prometheus-agent", job="prometheus-agent", pod="prometheus-prometheus-agent-shard-2-0", remote_name="806b63", service="prometheus-agent", team="atlas", url="https://myinstall/mycluster/api/v1/write"}'
+        values: "10000+0x180"
+      - series: 'prometheus_operator_spec_replicas{cluster_id="test01", installation="myinstall", provider="aws", pipeline="testing", container="prometheus-operator-app", controller="prometheus", instance="prometheus-operator-app", job="prometheus-operator-app-operator", name="prometheus-agent", pod="prometheus-operator-app-operator-76b5899558-nz8h5", service="prometheus-operator-app-operator", team="atlas"}'
+        values: '3+0x60 5+0x60 3+0x60'
+    alert_rule_test:
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 40m
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: page
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 125m
+        exp_alerts:
+          - exp_labels:
+              area: empowerment
+              cluster_id: test01
+              installation: myinstall
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+              inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_is_not_running_prometheus_agent: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+            exp_annotations:
+              description: "Prometheus agent is missing shards."
+              opsrecipe: "prometheus-agent/"
+              summary: "Prometheus agent is missing shards."
+      - alertname: PrometheusAgentShardsMissing
+        eval_time: 130m
+      - alertname: PrometheusAgentShardsMissingInhibition
+        eval_time: 130m


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3377

Add 2 makefile targets to lint rules files:
- one that only checks for labels we want to ensure with mimir (`pint-aggregations`)
- one that does extra checks (`pint-full`)

For the moment, we have to manually run them. They fire lots of alerts that we have to fix.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
