### PR TITLE
Add `cluster_control_plane_unhealthy` inhibition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 
 - Remove cilium entry from KAAS SLOs.
 
+### Added
+
+- Add `cluster_control_plane_unhealthy` inhibition.
+
 ## [3.13.1] - 2024-04-30
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.management-cluster.rules.yml
@@ -95,4 +95,13 @@ spec:
         instance_state_not_running: "true"
         team: phoenix
         topic: status
+    - alert: InhibitionControlPlaneUnhealthy
+      annotations:
+        description: '{{`Control plane of cluster {{ $labels.cluster_id }} is not healthy.`}}'
+      expr: capi_kubeadmcontrolplane_status_condition{type="ControlPlaneComponentsHealthy", status="False"} == 1 or capi_kubeadmcontrolplane_status_condition{type="EtcdClusterHealthy", status="False"} == 1 or capi_kubeadmcontrolplane_status_condition{type="Available", status="False"} == 1
+      labels:
+        area: kaas
+        cluster_control_plane_unhealthy: "true"
+        team: phoenix
+        topic: status
 {{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26508
This PR adds the `cluster_control_plane_unhealthy inhibition`.

prometheus-meta-operator PR: https://github.com/giantswarm/prometheus-meta-operator/pull/1607

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
