### PR TITLE
Record memory usage per scraping job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add recording rules to show prometheus scraping job memory usage.
+
 ### Changed
 
-Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
+- Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/recording-rules/monitoring.resource-usage-estimation.rules.yaml
+++ b/helm/prometheus-rules/templates/recording-rules/monitoring.resource-usage-estimation.rules.yaml
@@ -3,14 +3,13 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: resource-usage.recording.rules
+  name: monitoring.resource-usage-estimation.recording.rules
   namespace: {{ .Values.namespace  }}
 spec:
   groups:
-  - name: monitoring.resource-usage.recording
+  - name: monitoring.resource-usage-estimation.recording
     rules:
     - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="prometheus"}) by (cluster_id)
-      record: monitoring:resource_usage:memory_usage_bytes
+      record: giantswarm:observability:monitoring:resource_usage_estimation:memory_usage_bytes
     - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="prometheus"}) by (cluster_id)
-      record: monitoring:resource_usage:memory_working_set_bytes
-
+      record: giantswarm:observability:monitoring:resource_usage_estimation:memory_working_set_bytes

--- a/helm/prometheus-rules/templates/recording-rules/resource-usage.rules.yaml
+++ b/helm/prometheus-rules/templates/recording-rules/resource-usage.rules.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: resource-usage.recording.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: monitoring.resource-usage.recording
+    rules:
+    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="prometheus"}) by (cluster_id)
+      record: monitoring:resource_usage:memory_usage_bytes
+    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="prometheus"}) by (cluster_id)
+      record: monitoring:resource_usage:memory_working_set_bytes
+


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards data transparency, this PR adds recording rules to estimate the resource usage per scraping job (service and pod monitors alike).

This is what this looks like? 
![image](https://github.com/giantswarm/prometheus-rules/assets/2787548/3e5864ea-a018-4290-9bdf-9f5eb1f05a01)


### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
