### PR TITLE
fix: cilium related alerts for mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove cilium entry from KAAS SLOs.
+- Fix cilium related alerts for mimir.
 
 ## [3.13.1] - 2024-04-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cilium.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Cilium BPF map is about to fill up.`}}'
         opsrecipe: cilium-bpf-map/
-      expr: avg(cilium_bpf_map_pressure) by (cluster_id, map_name) * 100 > 80
+      expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 80
       for: 15m
       labels:
         area: managedservices
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`Cilium BPF map is about filled up.`}}'
         opsrecipe: cilium-bpf-map/
-      expr: avg(cilium_bpf_map_pressure) by (cluster_id, map_name) * 100 > 95
+      expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 95
       for: 15m
       labels:
         area: managedservices
@@ -39,7 +39,7 @@ spec:
         opsrecipe: unsupported-cilium-network-policy/
       # cilium_policy_change_total - for cilium >=1.15
       # cilium_policy_import_errors_total - for cilium <1.15
-      expr: max(rate(cilium_policy_change_total{outcome=~"fail.*"}[20m]) OR rate(cilium_policy_import_errors_total[20m])) > 0
+      expr: max(rate(cilium_policy_change_total{outcome=~"fail.*"}[20m]) by (cluster_id, installation, pipeline, provider) OR rate(cilium_policy_import_errors_total[20m])) > 0
       for: 10m
       labels:
         area: managedservices


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/3312

This PR fixes the cilium alert for mimir

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
