### PR TITLE
fix: cert-manager related alerts for mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove cilium entry from KAAS SLOs.
-
 - Fix cert-manager rules for mimir.
-
 - Fix operatorkit related alerts for mimir.
-
 - Fix Loki/Mimir and Tempo mixins according to `pint` recommendations
 - Fix cilium related alerts for mimir.
 - Fix etcd alerts for Mimir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove cilium entry from KAAS SLOs.
+- Fix cert-manager rules for mimir.
 
 ## [3.13.1] - 2024-04-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cert-manager.rules.yml
@@ -17,7 +17,7 @@ spec:
           If memory usage value is equal to memory limit value then it is likely the pod will be evicted.
           If no limits are set then the pod will burst.
           `}}
-      expr: (sum by (cluster_id, pod, namespace, container) (container_memory_working_set_bytes{container=~"(cert-manager|cert-manager-app-controller)"}) / 1024 / 1024 / 1024) >= 0.85
+      expr: (sum by (cluster_id, installation, pipeline, provider, pod, namespace, container) (container_memory_working_set_bytes{container=~"(cert-manager|cert-manager-app-controller)"}) / 1024 / 1024 / 1024) >= 0.85
       for: 10m
       labels:
         area: kaas
@@ -44,7 +44,7 @@ spec:
       annotations:
         description: '{{`There are too many CertificateRequests in cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: cert-requests-too-many/
-      expr: sum by (cluster_id) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
+      expr: sum by (cluster_id, installation, pipeline, provider) (etcd_kubernetes_resources_count{kind="certificaterequests.cert-manager.io"}) > 10000
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/3312

This PR fixes the cert-manager alert for mimir

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
