### PR TITLE
Replace apiserver down with controlplane unhealthy inhibition in alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
+- Replace `cancel_if_apiserver_down` with `cancel_if_cluster_control_plane_unhealthy`
 
 ### Fixed
 
@@ -21,9 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `cluster_control_plane_unhealthy` inhibition.
-
-### Added
-
 - Added inhibitions expressions for CAPI clusters.
 
 ## [3.13.1] - 2024-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 - Replace `cancel_if_apiserver_down` with `cancel_if_cluster_control_plane_unhealthy`
+- Removed `apiserver_down` inhibition dummy trigger.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/app.rules.yml
@@ -36,7 +36,7 @@ spec:
       for: 40m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -95,7 +95,7 @@ spec:
       for: 40m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -114,7 +114,7 @@ spec:
       for: 40m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -153,7 +153,7 @@ spec:
       for: 15m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml
@@ -38,16 +38,6 @@ spec:
         scrape_timeout: "true"
         team: phoenix
         topic: monitoring
-    # TODO(@team-turtles): fix with real expr
-    - alert: ApiServerDown
-      annotations:
-        description: '{{`Never fires (dummy alert).`}}'
-      expr: vector(0) > 1
-      labels:
-        area: empowerment
-        apiserver_down: "true"
-        team: phoenix
-        topic: monitoring
     {{- if (eq .Values.managementCluster.provider.kind "aws") }}
     - alert: InhibitionClusterWithoutWorkerNodes
       annotations:

--- a/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/keda.rules.yml
@@ -17,7 +17,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -32,7 +32,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -47,7 +47,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -62,7 +62,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
@@ -43,7 +43,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_has_no_workers: "true"
@@ -62,7 +62,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_has_no_workers: "true"
@@ -82,7 +82,7 @@ spec:
       for: 20m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_has_no_workers: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/loki.rules.yml
@@ -42,7 +42,7 @@ spec:
       for: 120m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -59,7 +59,7 @@ spec:
         sum(increase(loki_panic_total[10m])) by (cluster_id, installation, provider, pipeline, namespace, job) > 0
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -77,7 +77,7 @@ spec:
       for: 30m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -21,7 +21,7 @@ spec:
       for: 15m
       labels:
         area: empowerment
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus.rules.yml
@@ -18,7 +18,7 @@ spec:
       for: 30m
       labels:
         area: empowerment
-        cancel_if_any_apiserver_down: "true"
+        cancel_if_any_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_status_deleting: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/sloth.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/sloth.rules.yml
@@ -17,7 +17,7 @@ spec:
       for: 5m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/up.all.rules.yml
@@ -18,7 +18,7 @@ spec:
       for: 15m
       labels:
         area: managedservices
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/vpa.all.rules.yml
@@ -20,7 +20,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/app.rules.test.yml
+++ b/test/tests/providers/global/app.rules.test.yml
@@ -67,7 +67,7 @@ tests:
               alertname: AppWithoutTeamAnnotation
               app: userd
               area: managedservices
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/grafana.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/grafana.management-cluster.rules.test.yml
@@ -13,7 +13,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: managedservices
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/kube-state-metrics.rules.test.yml
+++ b/test/tests/providers/global/kube-state-metrics.rules.test.yml
@@ -50,7 +50,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: "kaas"
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
@@ -77,7 +77,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: "kaas"
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
@@ -110,7 +110,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: "kaas"
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
@@ -168,7 +168,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: "kaas"
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
@@ -195,7 +195,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: "kaas"
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/global/loki.rules.test.yml
+++ b/test/tests/providers/global/loki.rules.test.yml
@@ -24,7 +24,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: managedservices
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -54,7 +54,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: managedservices
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -89,7 +89,7 @@ tests:
           - exp_labels:
               app: loki
               area: managedservices
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/sloth.rules.test.yml
+++ b/test/tests/providers/global/sloth.rules.test.yml
@@ -25,7 +25,7 @@ tests:
               severity: page
               team: atlas
               topic: observability
-              cancel_if_apiserver_down: "true"
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26508

This PR:
- replaces `cancel_if_apiserver_down` with `cancel_if_cluster_control_plane_unhealthy` and `cancel_if_any_apiserver_down` with `cancel_if_any_cluster_control_plane_unhealthy`
- removes `apiserver_down` inhibition dummy trigger

### Checklist

- [x] Update CHANGELOG.md

