### PR TITLE
Add missing opsrecipe annotation to mimir alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster_control_plane_unhealthy` inhibition.
+- Added inhibitions expressions for CAPI clusters.
+- make targets for pint linter
+
 ### Changed
 
 - Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
@@ -20,12 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cilium related alerts for mimir.
 - Fix etcd alerts for Mimir.
 - Add missing labels for apiserver alerts.
-
-### Added
-
-- Add `cluster_control_plane_unhealthy` inhibition.
-- Added inhibitions expressions for CAPI clusters.
-- make targets for pint linter
+- Add missing opsrecipe for mimir alerts.
 
 ## [3.13.1] - 2024-04-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
@@ -14,6 +14,7 @@ spec:
     - alert: "Heartbeat"
       annotations:
         description: This alert is used to ensure the entire alerting pipeline is functional.
+        opsrecipe: mimir/
       expr: up{app="mimir"} > 0
       labels:
         area: "empowerment"
@@ -29,6 +30,7 @@ spec:
     - alert: MimirRestartingTooOften
       annotations:
         description: '{{`Mimir containers are restarting too often.`}}'
+        opsrecipe: mimir/
       expr: |
         increase(
           kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="mimir", container!="prometheus"}[1h]
@@ -45,6 +47,7 @@ spec:
     - alert: MimirComponentDown
       annotations:
         description: '{{`Mimir component : {{ $labels.service }} is down.`}}'
+        opsrecipe: mimir/
       expr: count(up{app="mimir"} == 0) by (cluster_id, installation, provider, pipeline, service) > 0
       for: 5m
       labels:
@@ -73,6 +76,7 @@ spec:
     - alert: MimirRulerEventsFailed
       annotations:
         description: 'Mimir ruler is failing to process PrometheusRules.'
+        opsrecipe: mimir/
       expr: rate(mimir_rules_events_failed_total{cluster_type="management_cluster", namespace="mimir"}[5m]) > 0
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/mimir.rules.yml
@@ -62,6 +62,7 @@ spec:
     - alert: GrafanaAgentForPrometheusRulesDown
       annotations:
         description: 'Grafana-agent sending PrometheusRules to Mimir ruler is down.'
+        opsrecipe: mimir/
       expr: count(up{app="grafana-agent", namespace="mimir"} == 0) by (cluster_id, installation, provider, pipeline) > 0
       for: 1h
       labels:

--- a/test/tests/providers/capi/capa-mimir/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/mimir.rules.test.yml
@@ -21,6 +21,7 @@ tests:
               type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
+              opsrecipe: "mimir/"
       - alertname:  Heartbeat
         eval_time: 70m
       - alertname:  Heartbeat
@@ -35,6 +36,7 @@ tests:
               type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
+              opsrecipe: "mimir/"
       - alertname:  Heartbeat
         eval_time: 140m
       - alertname:  Heartbeat
@@ -49,6 +51,7 @@ tests:
               type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
+              opsrecipe: "mimir/"
   - interval: 1m
     input_series:
       # For the first 60min: test with 1 pod: none, up, down
@@ -78,6 +81,7 @@ tests:
               pipeline: testing
             exp_annotations:
               description: "Mimir component : mimir-ingester is down."
+              opsrecipe: "mimir/"
   - interval: 1m
     input_series:
       # test with 1 pod: none, up, down
@@ -106,6 +110,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Grafana-agent sending PrometheusRules to Mimir ruler is down."
+              opsrecipe: "mimir/"
   - interval: 1m
     input_series:
       # test: none, rate > 0, rate = 0
@@ -132,6 +137,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Mimir ruler is failing to process PrometheusRules."
+              opsrecipe: "mimir/"
       - alertname: MimirRulerEventsFailed
         eval_time: 160m
   - interval: 1m
@@ -159,6 +165,7 @@ tests:
               topic: observability
             exp_annotations:
               description: Mimir containers are restarting too often.
+              opsrecipe: "mimir/"
       - alertname: MimirRestartingTooOften
         eval_time: 140m  # After 140m minutes, all should be back to normal
         exp_alerts:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
