### PR TITLE
pint: team filter and docs

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,3 +1,9 @@
+ifdef PINT_TEAM_FILTER
+PINT_FILES_LIST := $(shell grep -l "team:.*${PINT_TEAM_FILTER}" test/tests/providers/capi/capa-mimir/*.rules.yml)
+else
+PINT_FILES_LIST := $(shell find test/tests/providers/capi/capa-mimir/ -name "*.rules.yml")
+endif
+
 .PHONY: clean-dry-run
 clean-dry-run: ## dry run for `make clean` - print all untracked files
 	@git clean -xnf
@@ -32,10 +38,10 @@ test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
 test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid in CI
 	test/hack/bin/check-opsrecipes.sh --ci
 
-pint-full: install-tools template-chart ## Run pint with all checks
+pint: install-tools template-chart ## Run pint with all checks
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
-	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint test/tests/providers/capi/capa-mimir/*.rules.yml
+	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint ${PINT_FILES_LIST}
 
 pint-aggregations: install-tools template-chart ## Run pint with only the aggregation checks
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
-	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint test/tests/providers/capi/capa-mimir/*.rules.yml
+	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint ${PINT_FILES_LIST}

--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ Come as-is from https://github.com/grafana/tempo/tree/main/operations/tempo-mixi
 
 You can run all tests by running `make test`.
 
-There are 3 different types tests implemented:
+There are 4 different types tests implemented:
 
 - [Prometheus rules unit tests](#prometheus-rules-unit-tests)
 - [Alertmanager inhibition dependency check](#alertmanager-inhibition-dependency-check)
 - [Opsrecipe check](#opsrecipe-check)
+- [Prometheus Linter](#prometheus-linter)
 
 ---
 
@@ -318,3 +319,16 @@ The inhibition labels checking script is also run automatically at PR's creation
 You can run `make test-opsrecipes` to check if linked opsrecipes are valid.
 
 This check is not part of the global `make test` command until we fix all missing / wrong opsrecipes.
+
+## Prometheus Linter
+
+We are using [pint](https://cloudflare.github.io/pint/) to run some static checks on the rules.
+
+You can run them manually with `make pint`.
+
+### Pint specific cases
+
+If you want to run `pint` against a specific team's rules, you can run: `make pint PINT_TEAM_FILTER=myteam`
+
+We also have a target that does not run all pint checks, only checks for tags needed for aggregations with mimir.
+This one runs with `make pint-aggregations`.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3377

This PR:
- adds a feature to run pint against a specific team's rules
- adds some documentation

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
