### PR TITLE
Add ops-recipe for `KeyPairStorageAlmostFull` alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `cluster_control_plane_unhealthy` inhibition.
 - Added inhibitions expressions for CAPI clusters.
 - make targets for pint linter
+- Added ops-recipe for `KeyPairStorageAlmostFull` alert
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/cluster-service.rules.yml
@@ -16,7 +16,7 @@ spec:
     - alert: KeyPairStorageAlmostFull
       annotations:
         description: '{{`Number of keypairs limit almost reached in cluster-service storageconfig`}}'
-        opsrecipe: https://github.com/giantswarm/giantswarm/pull/11618
+        opsrecipe: cluster-service-storageconfig-full/
       # Observed max CR record was hit at ~2800 entries
       expr: cluster_service_key_pair_total > 2400
       for: 10m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30536

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
