### PR TITLE
Fix cabbage alerts for mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add recording rules to show prometheus scraping job memory usage.
 - Add `cluster_control_plane_unhealthy` inhibition.
-- Added inhibitions expressions for CAPI clusters.
+- Add inhibitions expressions for CAPI clusters.
+- Add ops-recipe for `KeyPairStorageAlmostFull` alert
+- Add missing opsrecipe for Mimir alerts.
+- Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 - make targets for pint linter
-- Added ops-recipe for `KeyPairStorageAlmostFull` alert
 
 ### Changed
 
-- Add opsrecipe to `CoreDNSMaxHPAReplicasReached`
 - Replace `cancel_if_apiserver_down` with `cancel_if_cluster_control_plane_unhealthy`
-- Removed `apiserver_down` inhibition dummy trigger.
 
 ### Fixed
 
-- Fix honeybadger alerts for mimir.
-- Remove cilium entry from KAAS SLOs.
-- Fix cert-manager rules for mimir.
-- Fix operatorkit related alerts for mimir.
+- Fix cabbage alert labels for Mimir.
+- Fix honeybadger alert labels for Mimir.
+- Fix cert-manager alert labels for Mimir.
+- Fix operatorkit alert labels for Mimir.
 - Fix Loki/Mimir and Tempo mixins according to `pint` recommendations
-- Fix cilium related alerts for mimir.
-- Fix etcd alerts for Mimir.
-- Add missing labels for apiserver alerts.
-- Add missing opsrecipe for mimir alerts.
+- Fix cilium alert labels for Mimir.
+- Fix etcd alert labels for Mimir.
+- Fix apiserver alert labels for Mimir.
+
+### Removed
+
+- Removed `apiserver_down` inhibition dummy trigger.
+- Remove cilium entry from KAAS SLOs.
 
 ## [3.13.1] - 2024-04-30
 

--- a/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/coredns.rules.yml
@@ -15,7 +15,7 @@ spec:
         description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: core-dns-deployment-not-satisfied/
       expr: |
-        sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id) / (sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id) + sum(kube_deployment_status_replicas_unavailable{deployment=~"coredns.*"}) by (cluster_id))* 100 < 51
+        sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) / (sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) + sum(kube_deployment_status_replicas_unavailable{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider))* 100 < 51
       for: 10m
       labels:
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/ingress-controller.rules.yml
@@ -28,7 +28,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller {{ $labels.pod }} memory usage is too high.`}}'
         opsrecipe: ic-memory-too-high/
-      expr: sum by (node, pod, cluster_id) (container_memory_usage_bytes{pod=~".*(ingress-nginx|nginx-ingress-controller).*", container=""}) / ignoring (pod) group_left sum (node_memory_MemTotal_bytes) by (node, cluster_id) * 100 > 33
+      expr: sum by (node, pod, cluster_id, installation, pipeline, provider) (container_memory_usage_bytes{pod=~".*(ingress-nginx|nginx-ingress-controller).*", container=""}) / ignoring (pod) group_left sum (node_memory_MemTotal_bytes) by (node, cluster_id, installation, pipeline, provider) * 100 > 33
       for: 3m
       labels:
         area: managedservices
@@ -40,7 +40,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller in namespace {{ $labels.namespace}} has {{ $value }} replica sets.`}}'
         opsrecipe: high-number-replicasets/
-      expr: count(kube_replicaset_spec_replicas{replicaset=~".*(ingress-nginx|nginx-ingress-controller).*"}) by (cluster_id, namespace) > 15
+      expr: count(kube_replicaset_spec_replicas{replicaset=~".*(ingress-nginx|nginx-ingress-controller).*"}) by (cluster_id, installation, pipeline, provider, namespace) > 15
       for: 2m
       labels:
         area: managedservices
@@ -52,7 +52,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller has no live endpoints.`}}'
         opsrecipe: ingress-controller-no-live-endpoints/
-      expr: count by (cluster_id) (kube_endpoint_address_available{endpoint=~".*(ingress-nginx|nginx-ingress-controller).*"}) == 0
+      expr: count by (cluster_id, installation, pipeline, provider) (kube_endpoint_address_available{endpoint=~".*(ingress-nginx|nginx-ingress-controller).*"}) == 0
       for: 2m
       labels:
         area: managedservices

--- a/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/network.all.rules.yml
@@ -103,7 +103,7 @@ spec:
     - alert: Network95thPercentileLatencyTooHigh
       annotations:
         description: '{{`Network 95th percentile latency is too high.`}}'
-      expr: histogram_quantile(0.95, sum(irate(network_latency_seconds_bucket{}[15m])) by (le, cluster_id)) > 0.5
+      expr: histogram_quantile(0.95, sum(irate(network_latency_seconds_bucket{}[15m])) by (le, cluster_id, installation, pipeline, provider)) > 0.5
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the cabbage alerts for mimir (adds the necessary labels) and also rewrites the changelog a bit

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
