### PR TITLE
Fix resource usage estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix resource estimation recording rules for clusters that have more than 1 prometheus.
+
 ## [3.14.0] - 2024-05-15
 
 ### Added

--- a/helm/prometheus-rules/templates/recording-rules/monitoring.resource-usage-estimation.rules.yaml
+++ b/helm/prometheus-rules/templates/recording-rules/monitoring.resource-usage-estimation.rules.yaml
@@ -9,7 +9,7 @@ spec:
   groups:
   - name: monitoring.resource-usage-estimation.recording
     rules:
-    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="prometheus"}) by (cluster_id)
+    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series{instance="localhost:9090"}) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="prometheus", namespace="kube-system"}) by (cluster_id)
       record: giantswarm:observability:monitoring:resource_usage_estimation:memory_usage_bytes
-    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="prometheus"}) by (cluster_id)
+    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series{instance="localhost:9090"}) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="prometheus", namespace="kube-system"}) by (cluster_id)
       record: giantswarm:observability:monitoring:resource_usage_estimation:memory_working_set_bytes


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the resource usage estimation when used on clusters that have another prometheus instance running (customers using the prometheus-operator for their use cases)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
