### PR TITLE
Increase low kubelet volume space "for"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adjust the KubeletVolumeSpaceTooLow period to 30m. This will sync it better with the node-problem-detector.
+
 ## [3.14.1] - 2024-05-15
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/disk.workload-cluster.rules.yml
@@ -41,7 +41,7 @@ spec:
         description: '{{`Kubelet volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         opsrecipe: low-disk-space/#root-volume
       expr: node_filesystem_free_bytes{cluster_type="workload_cluster", mountpoint=~"(/rootfs)?/var/lib/kubelet"} < (2 * 1024 * 1024 * 1024)
-      for: 10m
+      for: 30m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
This will sync it better with the node-problem-detector

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
