### PR TITLE
Fix node load alerts for CAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix node load alerts for CAPI clusters.
+
 ## [3.14.2] - 2024-05-16
 
 ### Changed

--- a/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
@@ -19,13 +19,23 @@ spec:
       #
       # If the kubelet status is flapping between Ready and something else,
       # matching against the kubelet labels, as kube_node_status_condition labels
-      # by the node name, and node_exporter labels by the ip,
+      # by the node name, and node_exporter labels by the node name,
       # unless,
-      # the load over 15 minutes divided by number of CPUs is higher than 2 (the node is overloaded),
-      # relabelling 'ip' to 'label_ip' to match against 'kube_node_labels'.
+      # the load over 15 minutes divided by number of CPUs is higher than 2 (the node is overloaded).
       annotations:
-        description: '{{`Node {{ $labels.label_ip }} status is flapping under load.`}}'
-      expr: label_replace(node_load15{cluster_type="management_cluster"} / count(count(node_cpu_seconds_total{cluster_type="management_cluster"}) without (mode)) without (cpu) >= 2, "label_ip", "$1", "ip", "(.*)" ) unless on (label_ip) kube_node_labels{cluster_type="management_cluster"} and on (ip) changes(kube_node_status_condition{cluster_type="management_cluster", condition="Ready", status="true"}[30m]) >= 6
+        description: '{{`Node {{ $labels.node }} status is flapping under load.`}}'
+      expr: |
+        (
+          sum(node_load15{cluster_type="management_cluster", app!="vault", role!="bastion"})
+            by (cluster_id, installation, node, pipeline, provider)
+          / count(rate(node_cpu_seconds_total{cluster_type="management_cluster", app!="vault", role!="bastion"}[5m]))
+            by (cluster_id, installation, node, pipeline, provider)
+        ) >= 2
+        unless on (cluster_id, installation, node, pipeline, provider) (
+          kube_node_labels{cluster_type="management_cluster"}
+          and on (cluster_id, installation, node, pipeline, provider)
+          changes(kube_node_status_condition{cluster_type="management_cluster", condition="Ready", status="true"}[30m])
+        ) >= 6
       for: 10m
       labels:
         area: kaas
@@ -89,8 +99,12 @@ spec:
     # Alert if load average is 2 times the number of CPUs.
     - alert: MachineLoadTooHigh
       annotations:
-        description: '{{`Machine {{ $labels.instance }} CPU load is too high.`}}'
-      expr: node_load5{cluster_type="management_cluster"} > 2 * count(node_cpu_seconds_total{cluster_type="management_cluster", mode="idle"}) without (cpu,mode)
+        description: '{{`Machine {{ $labels.node }} CPU load is too high.`}}'
+      expr: |
+        sum(node_load5{cluster_type="management_cluster", app!="vault", role!="bastion"})
+          by (node, cluster_id, installation, pipeline, provider) > 2
+        * count(rate(node_cpu_seconds_total{cluster_type="management_cluster", mode="idle", app!="vault", role!="bastion"}[5m]))
+          by (node, cluster_id, installation, pipeline, provider)
       for: 3m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.management_cluster.rules.yml
@@ -28,7 +28,7 @@ spec:
         (
           sum(node_load15{cluster_type="management_cluster", app!="vault", role!="bastion"})
             by (cluster_id, installation, node, pipeline, provider)
-          / count(rate(node_cpu_seconds_total{cluster_type="management_cluster", app!="vault", role!="bastion"}[5m]))
+          / count(rate(node_cpu_seconds_total{cluster_type="management_cluster", app!="vault", role!="bastion", mode="idle"}[5m]))
             by (cluster_id, installation, node, pipeline, provider)
         ) >= 2
         unless on (cluster_id, installation, node, pipeline, provider) (

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -49,13 +49,23 @@ spec:
       #
       # If the kubelet status is flapping between Ready and something else,
       # matching against the kubelet labels, as kube_node_status_condition labels
-      # by the node name, and node_exporter labels by the ip,
+      # by the node name, and node_exporter labels by the node name,
       # unless,
-      # the load over 15 minutes divided by number of CPUs is higher than 2 (the node is overloaded),
-      # relabelling 'ip' to 'label_ip' to match against 'kube_node_labels'.
+      # the load over 15 minutes divided by number of CPUs is higher than 2 (the node is overloaded).
       annotations:
-        description: '{{`Node {{ $labels.label_ip }} status is flapping under load.`}}'
-      expr: label_replace(node_load15{cluster_type="workload_cluster"} / count(count(node_cpu_seconds_total{cluster_type="workload_cluster"}) without (mode)) without (cpu) >= 2, "label_ip", "$1", "ip", "(.*)" ) unless on (cluster_id, label_ip) kube_node_labels{cluster_type="workload_cluster"} and on (cluster_id, ip) changes(kube_node_status_condition{cluster_type="workload_cluster", condition="Ready", status="true"}[30m]) >= 6
+        description: '{{`Node {{ $labels.node }} status is flapping under load.`}}'
+      expr: |
+        (
+          sum(node_load15{cluster_type="workload_cluster"})
+            by (cluster_id, installation, node, pipeline, provider)
+          / count(rate(node_cpu_seconds_total{cluster_type="workload_cluster"}[5m]))
+            by (cluster_id, installation, node, pipeline, provider)
+        ) >= 2
+        unless on (cluster_id, installation, node, pipeline, provider) (
+          kube_node_labels{cluster_type="workload_cluster"}
+          and on (cluster_id, installation, node, pipeline, provider)
+          changes(kube_node_status_condition{cluster_type="workload_cluster", condition="Ready", status="true"}[30m])
+        ) >= 6
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/node.workload_cluster.rules.yml
@@ -58,7 +58,7 @@ spec:
         (
           sum(node_load15{cluster_type="workload_cluster"})
             by (cluster_id, installation, node, pipeline, provider)
-          / count(rate(node_cpu_seconds_total{cluster_type="workload_cluster"}[5m]))
+          / count(rate(node_cpu_seconds_total{cluster_type="workload_cluster", mode="idle"}[5m]))
             by (cluster_id, installation, node, pipeline, provider)
         ) >= 2
         unless on (cluster_id, installation, node, pipeline, provider) (


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes some pint warning but also fixes the node load alerts for CAPI as the ip label does not exist in CAPI land because CAPI does not add it to the nodes.

@giantswarm/team-turtles could you check that this is alright? I think the comment above the query makes no sense but I'm not into fixing it myself as I'm not even sure if you want to keep this alert.

My initial concern was to remove the use of without and that was a damn rabbit hole

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
