### PR TITLE
pint: run in CI

### DIFF
--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -36,3 +36,11 @@ jobs:
         env:
           OPSRECIPES_DIR: ./giantswarm
         run: make test-ci-opsrecipes
+  prometheus-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+      - name: run pint linter
+        run: make pint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- pint tests: run automatically on CI. Also, target names have changed.
+
 ### Fixed
 
 - Fix node load alerts for CAPI clusters.

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -38,10 +38,10 @@ test-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid
 test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are valid in CI
 	test/hack/bin/check-opsrecipes.sh --ci
 
-pint: install-tools template-chart ## Run pint with all checks
+pint: install-tools template-chart ## Run pint
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
 	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint ${PINT_FILES_LIST}
 
-pint-aggregations: install-tools template-chart ## Run pint with only the aggregation checks
+pint-all: install-tools template-chart ## Run pint with extra checks
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
-	test/hack/bin/pint -c test/conf/pint/pint-aggregations.hcl lint ${PINT_FILES_LIST}
+	test/hack/bin/pint -c test/conf/pint/pint-all.hcl lint ${PINT_FILES_LIST}

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,9 +1,3 @@
-ifdef PINT_TEAM_FILTER
-PINT_FILES_LIST := $(shell grep -l "team:.*${PINT_TEAM_FILTER}" test/tests/providers/capi/capa-mimir/*.rules.yml)
-else
-PINT_FILES_LIST := $(shell find test/tests/providers/capi/capa-mimir/ -name "*.rules.yml")
-endif
-
 .PHONY: clean-dry-run
 clean-dry-run: ## dry run for `make clean` - print all untracked files
 	@git clean -xnf
@@ -40,8 +34,8 @@ test-ci-opsrecipes: install-tools template-chart ## Check if opsrecipes are vali
 
 pint: install-tools template-chart ## Run pint
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
-	test/hack/bin/pint -c test/conf/pint/pint-config.hcl lint ${PINT_FILES_LIST}
+	./test/hack/bin/run-pint.sh test/conf/pint/pint-config.hcl ${PINT_TEAM_FILTER}
 
 pint-all: install-tools template-chart ## Run pint with extra checks
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
-	test/hack/bin/pint -c test/conf/pint/pint-all.hcl lint ${PINT_FILES_LIST}
+	./test/hack/bin/run-pint.sh test/conf/pint/pint-all.hcl ${PINT_TEAM_FILTER}

--- a/README.md
+++ b/README.md
@@ -343,5 +343,5 @@ You can run them manually with `make pint`.
 
 If you want to run `pint` against a specific team's rules, you can run: `make pint PINT_TEAM_FILTER=myteam`
 
-We also have a target that does not run all pint checks, only checks for tags needed for aggregations with mimir.
-This one runs with `make pint-aggregations`.
+We also have a target that runs extra checks (that we hope to make default in the future).
+This one runs with `make pint-all`.

--- a/test/conf/pint/pint-aggregations.hcl
+++ b/test/conf/pint/pint-aggregations.hcl
@@ -1,7 +1,0 @@
-rule {
-  # Ensure that all aggregations are preserving mandatory labels.
-  aggregate ".+" {
-    severity = "bug"
-    keep     = ["cluster_id", "installation", "pipeline", "provider"]
-  }
-}

--- a/test/conf/pint/pint-all.hcl
+++ b/test/conf/pint/pint-all.hcl
@@ -1,0 +1,58 @@
+rule {
+  # Disallow spaces in label/annotation keys, they're only allowed in values.
+  reject ".* +.*" {
+    label_keys      = true
+    annotation_keys = true
+  }
+
+  # Disallow URLs in labels, they should go to annotations.
+  reject "https?://.+" {
+    label_keys   = true
+    label_values = true
+  }
+
+  # Ensure that all aggregations are preserving mandatory labels.
+  aggregate ".+" {
+    severity = "bug"
+    keep     = ["cluster_id", "installation", "pipeline", "provider"]
+  }
+}
+
+rule {
+  # This block will apply to all alerting rules.
+  match {
+    kind = "alerting"
+  }
+
+  # Each alert must have a 'description' annotation.
+  annotation "description" {
+    severity = "bug"
+    required = true
+  }
+
+  # Each alert must have a 'opsrecipe' annotation.
+  annotation "opsrecipe" {
+    severity = "bug"
+    required = true
+  }
+
+  # Each alert should have a 'dashboard' annotation.
+  annotation "dashboard" {
+    severity = "warning"
+    required = true
+  }
+
+  # Each alert must have a 'severity' annotation that's either 'page' or 'notify'.
+  label "severity" {
+    severity = "bug"
+    value    = "(page|notify)"
+    required = true
+  }
+
+  # Check how many times each alert would fire in the last 1d.
+  alerts {
+    range   = "1d"
+    step    = "1m"
+    resolve = "5m"
+  }
+}

--- a/test/conf/pint/pint-config.hcl
+++ b/test/conf/pint/pint-config.hcl
@@ -1,58 +1,7 @@
 rule {
-  # Disallow spaces in label/annotation keys, they're only allowed in values.
-  reject ".* +.*" {
-    label_keys      = true
-    annotation_keys = true
-  }
-
-  # Disallow URLs in labels, they should go to annotations.
-  reject "https?://.+" {
-    label_keys   = true
-    label_values = true
-  }
-
   # Ensure that all aggregations are preserving mandatory labels.
   aggregate ".+" {
     severity = "bug"
     keep     = ["cluster_id", "installation", "pipeline", "provider"]
-  }
-}
-
-rule {
-  # This block will apply to all alerting rules.
-  match {
-    kind = "alerting"
-  }
-
-  # Each alert must have a 'description' annotation.
-  annotation "description" {
-    severity = "bug"
-    required = true
-  }
-
-  # Each alert must have a 'opsrecipe' annotation.
-  annotation "opsrecipe" {
-    severity = "bug"
-    required = true
-  }
-
-  # Each alert should have a 'dashboard' annotation.
-  annotation "dashboard" {
-    severity = "warning"
-    required = true
-  }
-
-  # Each alert must have a 'severity' annotation that's either 'page' or 'notify'.
-  label "severity" {
-    severity = "bug"
-    value    = "(page|notify)"
-    required = true
-  }
-
-  # Check how many times each alert would fire in the last 1d.
-  alerts {
-    range   = "1d"
-    step    = "1m"
-    resolve = "5m"
   }
 }

--- a/test/hack/bin/run-pint.sh
+++ b/test/hack/bin/run-pint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+## Arguments:
+
+# 1. config file
+# 2. team filter (optional)
+
+
+main () {
+    echo "Running Pint"
+    declare -a PINT_FILES_LIST
+
+    PINT_CONFIG="${1:-test/conf/pint/pint-config.hcl}"
+
+    if [[ "${2:-}" != "" ]]; then
+        mapfile -t PINT_FILES_LIST < <(grep -l "team:.*${PINT_TEAM_FILTER}" test/tests/providers/capi/capa-mimir/*.rules.yml)
+    else
+        mapfile -t PINT_FILES_LIST < <(find test/tests/providers/capi/capa-mimir/ -name "*.rules.yml")
+    fi
+
+    test/hack/bin/pint -c "$PINT_CONFIG" lint "${PINT_FILES_LIST[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3377

This PR runs Pint tests as part of the CI.
Also, pint targets have changed:
- before, we had `pint-aggregations` and `pint`
- now, we have `pint` and `pint-all`.
The idea is that `pint` is the default, but we can gradually add tests from `pint-all` to the default target.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
