### PR TITLE
Fix incorrect ksm alert fixing on mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix node load alerts for CAPI clusters.
 - Remove trailing spaces in rules.
+- Fix `KubeStateMetricsNotRetrievingMetrics` on mimir.
 
 ## [3.14.2] - 2024-05-16
 

--- a/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/kube-state-metrics.rules.yml
@@ -78,7 +78,7 @@ spec:
         opsrecipe: kube-state-metrics-down/
       expr: |-
         # When it looks up but we don't have metrics
-        count({app="kube-state-metrics"}) by (cluster_id, installation, provider, pipeline) < 10
+        count({app="kube-state-metrics", __name__=~"kube_.+"}) by (cluster_id, installation, provider, pipeline) <= 100
       for: 20m
       labels:
         area: kaas


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR fixes the ongoing ksm alerts on grizzly, caused by some leftover slos (data being kept for 30 days, the initial query was counting them so firing for the wrong reasons).

Adding the regex of __name__ ensures we only count the ksm generated alerts in the query.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
