### PR TITLE
Add aggregation:capi_infrastructure_crd_versions metric to Grafana Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Add `aggregation:capi_infrastructure_crd_versions` metric to Grafana Cloud.
+
 ## [4.0.0] - 2024-05-29
 
 ### Changed

--- a/helm/prometheus-rules/templates/shared/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/shared/recording-rules/grafana-cloud.rules.yml
@@ -550,3 +550,10 @@ spec:
     rules:
       - expr: sum(trivy_compliance_info{title!~".*Pod.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, compliance_id, compliance_name, severity, title, status)
         record: aggregation:cluster_compliance_info
+{{- if eq .Values.managementCluster.provider.kind "capa" }}
+  # Keeps track of the versions of the CAPI infrastructure CRDs in the management cluster. Currently only used for CAPA.
+  - name: capi_crds.grafana-cloud.recording
+    rules:
+      - expr: sum(capi_crd_info{resource_name=~".*infrastructure.cluster.x-k8s.io.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, version)
+        record: aggregation:capi_infrastructure_crd_versions
+{{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3344

Exposes the installed CAPI infrastructure CRDs installed on MCs

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
