### PR TITLE
Add alert to know when we are running duplicate prometheus-operator-kubelet service in clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert to detect old and new prometheus-operator kubelet services in the same cluster (https://github.com/giantswarm/giantswarm/issues/30888).
+
 ## [3.15.0] - 2024-05-27
 
 ### Removed

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: true
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
         topic: observability

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -13,6 +13,24 @@ spec:
   groups:
   - name: prometheus-operator
     rules:
+    ## TODO remove once all clusters are passed v20
+    - alert: DuplicatePrometheusOperatorKubeletService
+      annotations:
+        description: '{{`Prometheus-operator in cluster {{ $labels.cluster_id }} has duplicate kubelet service.`}}'
+        opsrecipe: "prometheus-rule-failures/"
+      expr: count(kube_service_info{namespace=~"monitoring|kube-system", service=~"kube-prometheus-stack-kubelet|prometheus-operator-app-kubelet"}) by (cluster_id, installation, provider, pipeline) > 2
+      for: 20m
+      labels:
+        area: empowerment
+        cancel_if_cluster_control_plane_unhealthy: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        cancel_if_outside_working_hours: true
+        severity: page
+        team: atlas
+        topic: observability
     - alert: PrometheusOperatorDown
       annotations:
         description: '{{`Prometheus-operator ({{ $labels.instance }}) is down.`}}'

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -18,7 +18,7 @@ spec:
       annotations:
         description: '{{`Prometheus-operator in cluster {{ $labels.cluster_id }} has duplicate kubelet service.`}}'
         opsrecipe: "prometheus-rule-failures/"
-      expr: count(kube_service_info{namespace=~"monitoring|kube-system", service=~"kube-prometheus-stack-kubelet|prometheus-operator-app-kubelet"}) by (cluster_id, installation, provider, pipeline) > 2
+      expr: count(kube_service_info{namespace=~"monitoring|kube-system", service=~"kube-prometheus-stack-kubelet|prometheus-operator-app-kubelet"}) by (cluster_id, installation, provider, pipeline) > 1
       for: 20m
       labels:
         area: empowerment

--- a/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/alerting-rules/prometheus-operator.rules.yml
@@ -21,7 +21,7 @@ spec:
       expr: count(kube_service_info{namespace=~"monitoring|kube-system", service=~"kube-prometheus-stack-kubelet|prometheus-operator-app-kubelet"}) by (cluster_id, installation, provider, pipeline) > 1
       for: 20m
       labels:
-        area: empowerment
+        area: platform
         cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/30888

This PR adds a BH alert that triggers when there;s more than 2 prometheus operator services and we need to clean up 
![image](https://github.com/giantswarm/prometheus-rules/assets/2787548/359d5b5b-6b59-44f5-a5f2-76672516eeed)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
