### PR TITLE
Fix remaining pint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix remaining pint issues.
+
 ## [4.0.0] - 2024-05-29
 
 ### Changed

--- a/helm/prometheus-rules/templates/shared/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/shared/recording-rules/service-level.rules.yml
@@ -22,8 +22,8 @@ spec:
     # The next statement returns 1 for a cluster with "updated", "created" or unknown (absent) status.
     # It returns 0 for clusters in "updating", "creating" and "deleting" status.
     # By multiplying with this statement we ensure that errors for transitioning clusters are not counted.
-    - expr: sum((up{app='kubernetes'} * -1) + 1) by (cluster_id, cluster_type) *
-            ignoring (cluster_type) group_left (cluster_id)
+    - expr: sum((up{app='kubernetes'} * -1) + 1) by (cluster_id, installation, pipeline, provider, cluster_type) *
+            ignoring (cluster_type, installation, pipeline, provider) group_left (cluster_id)
             (
               max(cluster_operator_cluster_status{status=~"Updated|Created"}) by (cluster_id, cluster_type)
               or absent(cluster_operator_cluster_status)
@@ -85,7 +85,7 @@ spec:
       # -- empowerment daemonset
     - expr: |
         label_replace(
-          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"cilium"},
+          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset="cilium"},
         "service", "$1", "daemonset", "(.*)" )
       labels:
         class: MEDIUM
@@ -99,11 +99,11 @@ spec:
         (
           (
             label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"cilium"},
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset="cilium"},
               "service", "$1", "daemonset", "(.*)" ) > 0
             and on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, daemonset, node)
             label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"cilium"} offset 10m,
+              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset="cilium"} offset 10m,
               "service", "$1", "daemonset", "(.*)" ) > 0
           )
           and
@@ -118,7 +118,7 @@ spec:
       record: raw_slo_errors
       # -- 99% availability
       # -- this expression collects all the daemonsets and assigns the same slo target to all of them
-    - expr: sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, area) (raw_slo_errors{area="empowerment", service=~"cilium"}) + 1-0.99
+    - expr: sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, area) (raw_slo_errors{area="empowerment", service="cilium"}) + 1-0.99
       labels:
         area: empowerment
         label_application_giantswarm_io_team: cabbage
@@ -393,7 +393,7 @@ spec:
     - expr: sum(sum_over_time(raw_slo_errors[3d])) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, class, area, label_application_giantswarm_io_team) / sum(sum_over_time(raw_slo_requests[3d])) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, class, area, label_application_giantswarm_io_team)
       record: slo_errors_per_request:ratio_rate3d
       # -- We use the `min` function here because we have `slo_burnrate_high` for each installation and cluster_id, even though the metric value is always the same.
-    - expr: slo_target*scalar(min(slo_burnrate_high))
+    - expr: slo_target*scalar(min(slo_burnrate_high) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, class, area, label_application_giantswarm_io_team))
       record: slo_threshold_high
-    - expr: slo_target*scalar(min(slo_burnrate_low))
+    - expr: slo_target*scalar(min(slo_burnrate_low) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, class, area, label_application_giantswarm_io_team))
       record: slo_threshold_low


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the last pint warnings

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
