### PR TITLE
Remove api-server from old slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `aggregation:capi_infrastructure_crd_versions` metric to Grafana Cloud.
 
+### Removed
+
+- Remove api-server from old SLO framework.
+
 ## [4.0.0] - 2024-05-29
 
 ### Changed

--- a/helm/prometheus-rules/templates/shared/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/shared/recording-rules/service-level.rules.yml
@@ -10,37 +10,6 @@ spec:
   groups:
   - name: service-level.recording
     rules:
-      # -- api-server
-    - expr: "count(up{app='kubernetes'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)"
-      labels:
-        class: HIGH
-        area: kaas
-        service: api-server
-        label_application_giantswarm_io_team: {{ include "providerTeam" . }}
-      record: raw_slo_requests
-    # The first statement ensures that an api-server error is counted if the kubernetes api is not up for a specific cluster.
-    # The next statement returns 1 for a cluster with "updated", "created" or unknown (absent) status.
-    # It returns 0 for clusters in "updating", "creating" and "deleting" status.
-    # By multiplying with this statement we ensure that errors for transitioning clusters are not counted.
-    - expr: sum((up{app='kubernetes'} * -1) + 1) by (cluster_id, cluster_type) *
-            ignoring (cluster_type) group_left (cluster_id)
-            (
-              max(cluster_operator_cluster_status{status=~"Updated|Created"}) by (cluster_id, cluster_type)
-              or absent(cluster_operator_cluster_status)
-            )
-      labels:
-        class: HIGH
-        area: kaas
-        service: api-server
-      record: raw_slo_errors
-      # -- 99,9% availability
-    - expr: "vector((1 - 0.999))"
-      labels:
-        area: kaas
-        service: api-server
-        label_application_giantswarm_io_team: {{ include "providerTeam" . }}
-      record: slo_target
-
       # -- KAAS daemonset
     - expr: |
         label_replace(


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR removes the api-server from the slo framework

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
