### PR TITLE
fix-external-dns-alerts-for-multi-provider-wc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new alerting rule to `falco.rules.yml` to fire an alert for XZ-backdoor.
 
+### Fixed
+
+- Fix cabbage alerts for multi-provider wcs.
+
 ## [4.1.2] - 2024-05-31
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 80
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage
@@ -29,7 +29,7 @@ spec:
       expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 95
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         severity: page
         team: cabbage
         topic: cilium
@@ -42,7 +42,7 @@ spec:
       expr: max(rate(cilium_policy_change_total{outcome=~"fail.*"}[20m]) OR rate(cilium_policy_import_errors_total[20m])) by (cluster_id, installation, pipeline, provider) > 0
       for: 10m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
@@ -18,7 +18,7 @@ spec:
         sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) / (sum(kube_deployment_status_replicas_available{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) + sum(kube_deployment_status_replicas_unavailable{deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider))* 100 < 51
       for: 10m
       labels:
-        area: empowerment
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -41,7 +41,7 @@ spec:
         )
       for: 120m
       labels:
-        area: empowerment
+        area: platform
         cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
@@ -1,4 +1,3 @@
-{{- if (eq .Values.managementCluster.provider.kind "aws") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -18,10 +17,10 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access registry (cloud service provider DNS service).`}}'
         opsrecipe: external-dns-cant-access-registry/
-      expr: rate(external_dns_registry_errors_total[2m]) > 0
+      expr: rate(external_dns_registry_errors_total{provider="aws|capa|capz|eks"}[2m]) > 0
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -33,10 +32,10 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access source (Service or Ingress resource).`}}'
         opsrecipe: external-dns-cant-access-source/
-      expr: rate(external_dns_source_errors_total[2m]) > 0
+      expr: rate(external_dns_source_errors_total{provider="aws|capa|capz|eks"}[2m]) > 0
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -48,10 +47,10 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: external-dns-down/
-      expr: label_replace(up{app=~"external-dns-(app|monitoring)"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
+      expr: label_replace(up{app=~"external-dns-(app|monitoring)", provider="aws|capa|capz|eks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
@@ -60,4 +59,3 @@ spec:
         severity: page
         team: cabbage
         topic: external-dns
-{{- end }}

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} / (managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"}) * 100 <= 50
       for: 10m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -31,7 +31,7 @@ spec:
       expr: sum by (node, pod, cluster_id, installation, pipeline, provider) (container_memory_usage_bytes{pod=~".*(ingress-nginx|nginx-ingress-controller).*", container=""}) / ignoring (pod) group_left sum (node_memory_MemTotal_bytes) by (node, cluster_id, installation, pipeline, provider) * 100 > 33
       for: 3m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
         team: cabbage
@@ -43,7 +43,7 @@ spec:
       expr: count(kube_replicaset_spec_replicas{replicaset=~".*(ingress-nginx|nginx-ingress-controller).*"}) by (cluster_id, installation, pipeline, provider, namespace) > 15
       for: 2m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
         team: cabbage
@@ -55,7 +55,7 @@ spec:
       expr: count by (cluster_id, installation, pipeline, provider) (kube_endpoint_address_available{endpoint=~".*(ingress-nginx|nginx-ingress-controller).*"}) == 0
       for: 2m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -69,7 +69,7 @@ spec:
       expr: label_replace(up{app=~".*(ingress-nginx|nginx-ingress-controller).*"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
-        area: managedapps
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -19,7 +19,7 @@ spec:
       expr: kong_datastore_reachable == 0
       for: 10m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
@@ -33,7 +33,7 @@ spec:
       expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*"}) < 0.6
       for: 30m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/linkerd.deployment.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/linkerd.deployment.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: managed_app_deployment_status_replicas_unavailable{namespace=~"linkerd.*"} > 0
       for: 30m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/network.all.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/network.all.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: rate(dns_resolve_error_total[15m]) > 0.015
       for: 15m
       labels:
-        area: empowerment
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"
@@ -34,7 +34,7 @@ spec:
       expr: rate(dns_error_total[15m]) > 0.015
       for: 15m
       labels:
-        area: empowerment
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_with_no_nodepools: "true"
         cancel_if_cluster_with_notready_nodepools: "true"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -17,7 +17,7 @@ tests:
         eval_time: 50m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               severity: page
               team: cabbage
               topic: cilium
@@ -39,7 +39,7 @@ tests:
         eval_time: 70m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               severity: page
               team: cabbage
               topic: cilium
@@ -67,7 +67,7 @@ tests:
         eval_time: 60m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               severity: page
               team: cabbage
               topic: cilium
@@ -91,7 +91,7 @@ tests:
         eval_time: 260m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               severity: page
               team: cabbage
               topic: cilium

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/kong.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/kong.rules.test.yml
@@ -17,7 +17,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: KongDatastoreNotReachable
-              area: managedservices
+              area: platform
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_outside_working_hours: "false"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/linkerd.deployment.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/linkerd.deployment.rules.test.yml
@@ -17,7 +17,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: LinkerdDeploymentNotSatisfied
-              area: managedservices
+              area: platform
               cancel_if_outside_working_hours: "true"
               namespace: linkerd
               deployment: linkerd-destination


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Closes https://github.com/giantswarm/giantswarm/issues/30976

This PR fixes the external dns alert for multi-provider WCs

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
