### PR TITLE
remove scrape timeout inhibition leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix cabbage alerts for multi-provider wcs.
 
+### Removed
+
+- cleanup: remove scrape timeout inhibition leftovers (documentation and labels)
+
 ## [4.1.2] - 2024-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ In order for Alertmanager inhibition to work we need 3 elements:
   - an Inhibition definition mapping source labels to target labels in the alertmanager config file
   - an Alert rule with some target labels
 
-An alert having a target label will be inhibited whenever the condition specified in the target label's name is fulfilled. This is why target labels' names are most of the time prefixed by "cancel_if_" (e.g "cancel_if_scrape_timeout").
+An alert having a target label will be inhibited whenever the condition specified in the target label's name is fulfilled. This is why target labels' names are most of the time prefixed by "cancel_if_" (e.g "cancel_if_outside_working_hours").
 
-An alert with a source label will define the conditions under which the target label is effective. For example, if an alert with the "scrape_timeout" label were to fire, all other alerts having the corresponding target label, i.e "cancel_if_scrape_timeout" would be inhibited.
+An alert with a source label will define the conditions under which the target label is effective. For example, if an alert with the "outside_working_hours" label were to fire, all other alerts having the corresponding target label, i.e "cancel_if_outside_working_hours" would be inhibited.
 
 This is possible thanks to the alertmanager config file stored in the Prometheus-Meta-operator which defines the target/source labels coupling.
 

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vertical-pod-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vertical-pod-autoscaler.rules.yml
@@ -24,7 +24,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: turtles

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -46,7 +46,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
@@ -63,7 +62,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas
@@ -81,7 +79,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
@@ -43,7 +43,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_cluster_has_no_workers: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/sloth.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/sloth.rules.yml
@@ -21,7 +21,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -157,7 +157,6 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: honeybadger

--- a/test/hack/checkLabels/main.go
+++ b/test/hack/checkLabels/main.go
@@ -24,16 +24,16 @@ import (
 * - an Alert with some target labels
 *
 * example:
-* - Alert `ScrapeTimeout` has label `scrape_timeout=true`
-* - Inhibition definition says `source_matchers: [scrape_timeout=true], target_matchers: [cancel_if_scrape_timeout=true]` (leaving out the equal part to simplify)
-* - Alert `MyAlert` has label `cancel_if_scrape_timeout=true`
+* - Alert `InhibitionOutsideWorkingHours` has label `outside_working_hours=true`
+* - Inhibition definition says `source_matchers: [outside_working_hours=true], target_matchers: [cancel_if_outside_working_hours=true]` (leaving out the equal part to simplify)
+* - Alert `MyAlert` has label `cancel_if_outside_working_hours=true`
 *
 * GLOSSARY
 * https://github.com/giantswarm/prometheus-rules/#inhibitions
 * am_sourceMatchers and am_targetMatchers are the labels defined in the alertmanager config file
 * sourceLabels are the labels defined in the alerting rules from which originate the inhibitions
-* 	--> For example, 'scrape_timeout' is the source label for the 'cancel_if_scrape_timeout' inhibition label
-* cancelLabels is another name for the inhibition labels (for example : 'cancel_if_scrape_timeout')
+* 	--> For example, 'outside_working_hours' is the source label for the 'cancel_if_outside_working_hours' inhibition label
+* cancelLabels is another name for the inhibition labels (for example : 'cancel_if_outside_working_hours')
 **/
 const output = "../output/helm-chart"
 const alertRulesPath = "alerting-rules"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -29,7 +29,6 @@ tests:
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
-              cancel_if_scrape_timeout: "true"
               cluster_id: gaia-wc01
               installation: gaia
               pipeline: stable
@@ -59,7 +58,6 @@ tests:
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
-              cancel_if_scrape_timeout: "true"
               cluster_id: gaia-wc01
               installation: gaia
               provider: aws
@@ -92,7 +90,6 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
-              cancel_if_scrape_timeout: "true"
               cancel_if_outside_working_hours: "true"
               cluster_id: gaia-wc01
               container: loki

--- a/test/tests/providers/global/platform/atlas/alerting-rules/sloth.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/sloth.rules.test.yml
@@ -29,7 +29,6 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
-              cancel_if_scrape_timeout: "true"
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Sloth is down."


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR is a follow up of https://github.com/giantswarm/prometheus-meta-operator/pull/1649 and cleans up leftovers :)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
