### PR TITLE
fix shield area labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix cabbage alerts for multi-provider wcs.
+- Fix shield alert area labels.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/platform/shield/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/platform/shield/alerting-rules/falco.rules.yml
@@ -21,7 +21,7 @@ spec:
         opsrecipe: falco-alert/
       expr: increase(falco_events{priority=~"0|1|2|3"}[10m] ) > 0
       labels:
-        area: kaas
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -37,7 +37,7 @@ spec:
         opsrecipe: falco-alert/
       expr: increase(falco_events{priority=~"4|5"}[10m] ) > 0
       labels:
-        area: kaas
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -52,7 +52,7 @@ spec:
         opsrecipe: falco-alert/
       expr: increase(falco_events{priority="6"}[10m] ) > 0
       labels:
-        area: kaas
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -67,7 +67,7 @@ spec:
         opsrecipe: falco-alert/
       expr: falco_events{rule="Backdoored library loaded into SSHD (CVE-2024-3094)"} > 0
       labels:
-        area: kaas
+        area: platform
         cancel_if_cluster_status_creating: "false"
         cancel_if_cluster_status_deleting: "false"
         cancel_if_cluster_status_updating: "false"

--- a/helm/prometheus-rules/templates/platform/shield/alerting-rules/kyverno.all.rules.yml
+++ b/helm/prometheus-rules/templates/platform/shield/alerting-rules/kyverno.all.rules.yml
@@ -17,7 +17,7 @@ spec:
       expr: sum(kube_validatingwebhookconfiguration_info{validatingwebhookconfiguration=~"kyverno-.*"}) by (cluster_id, installation, pipeline, provider) > 0 and sum(kube_deployment_status_replicas{deployment=~"kyverno|kyverno-admission-controller"}) by (cluster_id, installation, pipeline, provider) == 0
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -34,7 +34,7 @@ spec:
       expr: aggregation:kyverno_resource_counts{kind=~"(generate|update)requests.kyverno.io"} > 5000
       for: 15m
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -51,7 +51,7 @@ spec:
       expr: sum(kube_deployment_spec_replicas{deployment=~"kyverno|kyverno-kyverno-plugin|kyverno-policy-reporter"}) by (cluster_id, installation, pipeline, provider) == 0
       for: 4h
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -66,7 +66,7 @@ spec:
       expr: sum(kube_deployment_spec_replicas{deployment="kyverno"}) by (cluster_id, installation, pipeline, provider) != 0 and sum(kube_deployment_spec_replicas{deployment="kyverno"}) by (cluster_id, installation, pipeline, provider) < 3
       for: 1h
       labels:
-        area: managedservices
+        area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/platform/shield/alerting-rules/kyverno.all.rules.test.yml
+++ b/test/tests/providers/global/platform/shield/alerting-rules/kyverno.all.rules.test.yml
@@ -29,7 +29,7 @@ tests:
         eval_time: 15m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               cluster_id: gremlin
               installation: gremlin
               pipeline: testing
@@ -49,7 +49,7 @@ tests:
         eval_time: 45m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               cluster_id: gremlin
               installation: gremlin
               pipeline: testing
@@ -70,7 +70,7 @@ tests:
         eval_time: 240m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               cluster_id: gremlin
               installation: gremlin
               pipeline: testing
@@ -90,7 +90,7 @@ tests:
         eval_time: 310m
         exp_alerts:
           - exp_labels:
-              area: managedservices
+              area: platform
               cluster_id: gremlin
               installation: gremlin
               pipeline: testing


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes Shield alerts area labels

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
