### PR TITLE
Fix cert-exporter alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix cabbage alerts for multi-provider wcs.
 - Fix shield alert area labels.
+- Fix `cert-exporter` alerting.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/_helpers.tpl
+++ b/helm/prometheus-rules/templates/_helpers.tpl
@@ -45,14 +45,6 @@ phoenix
 {{- end -}}
 {{- end -}}
 
-{{- define "isCertExporterInstalled" -}}
-{{- if has .Values.managementCluster.provider.kind (list "cloud-director" "vsphere" "capa") -}}
-false
-{{- else -}}
-true
-{{- end -}}
-{{- end -}}
-
 {{- define "isBastionBeingMonitored" -}}
 {{ not (eq .Values.managementCluster.provider.flavor "capi") }}
 {{- end -}}

--- a/helm/prometheus-rules/templates/shared/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/shared/alerting-rules/certificate.workload-cluster.rules.yml
@@ -1,4 +1,3 @@
-{{- if eq (include "isCertExporterInstalled" .) "true" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -31,7 +30,7 @@ spec:
       annotations:
         description: '{{`Certificate metrics are missing for cluster {{ $labels.cluster_id }}.`}}'
         opsrecipe: absent-metrics
-      expr: max(up{cluster_id!="", cluster_type="workload_cluster"}) by (cluster_id) unless on (cluster_id) count (cert_exporter_not_after{cluster_type="workload_cluster"}) by (cluster_id) > 0
+      expr: max(up{cluster_id!="", cluster_type="workload_cluster"}) by (cluster_id, installation, pipeline, provider) unless on (cluster_id) count (cert_exporter_not_after{cluster_type="workload_cluster"}) by (cluster_id, installation, pipeline, provider) > 0
       for: 30m
       labels:
         area: kaas
@@ -42,4 +41,3 @@ spec:
         severity: page
         team: {{ include "providerTeam" . }}
         topic: security
-{{- end -}}


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ensures that cert-exporter alerts page everywhere because it's deployed on all providers

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
