### PR TITLE
Fix ops-recipe test script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix and improve the ops-recipe test script.
 - Fix cabbage alerts for multi-provider wcs.
 - Fix shield alert area labels.
 

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/calico.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/calico.rules.yml
@@ -1,5 +1,5 @@
-## TODO Remove with vintage
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+## TODO Remove with vintage
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/calico.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/calico.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-service.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-service.rules.yml
@@ -1,5 +1,5 @@
-## TODO Remove with vintage
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+## TODO Remove with vintage
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-service.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-service.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/docker.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/docker.rules.yml
@@ -1,5 +1,5 @@
-## TODO Remove with vintage
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+## TODO Remove with vintage
 # newer clusters don't use docker anymore
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/docker.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/docker.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 # newer clusters don't use docker anymore
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.aws.management-cluster.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 # This rule applies to vintage aws management clusters
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.aws.management-cluster.rules.yml
@@ -1,6 +1,6 @@
+{{- if eq .Values.managementCluster.provider.flavor "vintage" }}
 ## TODO Remove with vintage
 # This rule applies to vintage aws management clusters
-{{- if eq .Values.managementCluster.provider.flavor "vintage" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.kiam.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.kiam.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 # This rule applies to vintage aws clusters
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.kiam.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/inhibit.kiam.rules.yml
@@ -1,6 +1,6 @@
+{{- if eq .Values.managementCluster.provider.flavor "vintage" }}
 ## TODO Remove with vintage
 # This rule applies to vintage aws clusters
-{{- if eq .Values.managementCluster.provider.flavor "vintage" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vault.rules.yml
@@ -1,5 +1,5 @@
-## TODO Remove with vintage
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+## TODO Remove with vintage
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vault.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vault.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove with vintage
+## TODO Remove when all vintage installations are gone
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.capi.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.capi.rules.yml
@@ -1,5 +1,5 @@
-# This rule applies to all capi management clusters
 {{- if eq .Values.managementCluster.provider.flavor "capi" }}
+# This rule applies to all capi management clusters
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -36,7 +36,7 @@ spec:
     - alert: CiliumAPITooSlow
       annotations:
         description: '{{`Cilium API processing time is >50s pod="{{ $labels.pod }}" node="{{ $labels.node }}" method="{{ $labels.method}}" path="{{ $labels.path }}"`}}'
-        opsrecipe: cilium-performance-issues/#slow-cilium-api
+        opsrecipe: cilium/cilium-performance-issues/#slow-cilium-api
       expr: avg(rate(cilium_agent_api_process_time_seconds_sum{}[5m])/rate(cilium_agent_api_process_time_seconds_count{}[5m]) > 50) by (cluster_id, node, pod, method, path, installation, pipeline, provider)
       for: 20m
       labels:

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -59,7 +59,8 @@ listOpsRecipes () {
 
     # find all ops-recipes ".md" files, and keep only the opsrecipe name (may contain a path, like "rolling-nodes/rolling-nodes")
     find "$privateOpsrecipesParentDirectory"/content/docs/support-and-ops/ops-recipes -type f -name \*.md \
-        | sed -n 's_'"$privateOpsrecipesParentDirectory"'/content/docs/support-and-ops/ops-recipes/\(.*\).md_\1_p'
+        | sed -n 's_'"$privateOpsrecipesParentDirectory"'/content/docs/support-and-ops/ops-recipes/\(.*\).md_\1_p' \
+        | sed 's/\/_index//g' # Removes the _index.md files and keep the directory name
     rm -rf "$privateOpsrecipesParentDirectory"
 
     # Add extra opsrecipes
@@ -68,7 +69,6 @@ listOpsRecipes () {
     echo "workload-cluster-deployment-not-satisfied"
     echo "deployment-not-satisfied-china"
 }
-
 
 main() {
     local -a runInCi=false
@@ -147,7 +147,7 @@ main() {
         done < <(yq -o json "$rulesFile" | jq -j '.spec.groups[].rules[] | .alert, " ", .annotations.opsrecipe, " ", .labels.severity, "\n"')
 
         checkedRules+=("$rulesFile")
-    done < <(find $RULES_FILES -type f -print0)
+    done < <(find "${RULES_FILES[@]}" -type f -print0)
 
 
     # Output section - let's write down our findings


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards reenabling https://github.com/giantswarm/giantswarm/issues/23638

This PR fixes a few issues:
- After some changes, some rules were rendered containing only comments and this caused issues when running the script `jq: error (at <stdin>:1): Cannot iterate over null (null)`. This fixes the templating by moving the comment after the helm templating.
- This PR also makes sure this script work with ops-recipes under things like [cilium/cilium-performance-issues/_index.md](https://github.com/giantswarm/giantswarm/pull/30986/files#diff-c634cd07d1619810730614937e53dfd983b620de31aaa9de16bb909b8061ddce). I have tested it with a small modification because the ciliumslow opsrecipe in in the dev-and-releng folder for some weird reasons but here is the output if after I've added the dev-and-releng to the list of ops-recipes: 
`file cilium.rules.yml / alert: CiliumAPITooSlow / recipe: cilium/cilium-performance-issues - OK`

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
