### PR TITLE
Update tools usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed usage of yq, and jq in check-opsrecipes.sh
+- Fetch jq with make install-tools
+
 ### Added
 
 - Added a new alerting rule to `falco.rules.yml` to fire an alert for XZ-backdoor.

--- a/test/hack/bin/check-opsrecipes.sh
+++ b/test/hack/bin/check-opsrecipes.sh
@@ -86,6 +86,10 @@ main() {
     local -a E_unexistingrecipe=()
     local returncode=0
 
+    local -r GIT_WORKDIR="$(git rev-parse --show-toplevel)"
+    local -r YQ=test/hack/bin/yq
+    local -r JQ=test/hack/bin/jq
+
     # Investigation section
     ########################
 
@@ -144,7 +148,7 @@ main() {
             fi
 
         # parse rules yaml files, and for each rule found output alertname, opsrecipe, and severity, space-separated, on one line.
-        done < <(yq -o json "$rulesFile" | jq -j '.spec.groups[].rules[] | .alert, " ", .annotations.opsrecipe, " ", .labels.severity, "\n"')
+        done < <("$GIT_WORKDIR/$YQ" -o json "$rulesFile" | "$GIT_WORKDIR/$JQ" -j '.spec.groups[]?.rules[] | .alert, " ", .annotations.opsrecipe, " ", .labels.severity, "\n"')
 
         checkedRules+=("$rulesFile")
     done < <(find $RULES_FILES -type f -print0)

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -6,6 +6,7 @@ ARCHITECT_VERSION="6.8.0"
 PROMETHEUS_VERSION="2.41.0"
 HELM_VERSION="3.9.0"
 YQ_VERSION="4.26.1"
+JQ_VERSION="1.7.1"
 PINT_VERSION="0.58.1"
 
 GIT_WORKDIR=$(git rev-parse --show-toplevel)
@@ -19,6 +20,8 @@ Linux*)
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-linux-amd64.tar.gz"
     export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
     export YQ_BIN_FILE="yq_linux_amd64"
+    export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
+    export JQ_BIN_FILE="jq"
     export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
     export PINT_BIN_FILE="pint-linux-amd64"
     ;;
@@ -29,6 +32,8 @@ Darwin*)
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-darwin-amd64.tar.gz"
     export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
     export YQ_BIN_FILE="yq_darwin_amd64"
+    export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-macos-amd64"
+    export JQ_BIN_FILE="jq"
     export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
     export PINT_BIN_FILE="pint-darwin-amd64"
     TAR_CMD="gtar"
@@ -107,6 +112,10 @@ main() {
         "${GIT_WORKDIR}/test/hack/bin/yq-${YQ_VERSION}.tar.gz" \
         "$YQ_SOURCE" \
         "*/yq_*"
+    download \
+        "${JQ_SOURCE}" \
+        "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
+    chmod +x "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
     if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/yq" ]]; then
         ln -s "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/yq"
     fi


### PR DESCRIPTION
I encoutered the following error while trying to run `make test-opsrecipes`

```
bash test/hack/bin/check-opsrecipes.sh
jq: Unknown option -o
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.github.io/jq
... many of those error follow
```

Also came accross this
```
bash test/hack/bin/check-opsrecipes.sh
jq: error (at <stdin>:1): Cannot iterate over null (null)
... many of those error follow ...
```

This PR adds the following:

- Use yq from fetched tools in check-opsrecipes.sh
- Use jq from fetched tools in check-opsrecipes.sh
- Fetch jq with make install-tools
- Fix `iterate over null` by adding a question mark to `.spec.groups[]?`