### PR TITLE
Restrict grafana-agent-rules CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Restrict `grafana-agent-rules` CiliumNetworkPolicy.
 - Update team bigmac rules based on the label changes
 - Split the phoenix job alert into 2:
   - a new file named job.aws.rules that contains the aws specific alerts
@@ -55,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.0] - 2024-05-30
 
-### Added 
+### Added
 
 - Add `aggregation:capi_infrastructure_crd_versions` metric to Grafana Cloud.
 

--- a/helm/prometheus-rules/templates/grafana-agent-rules-configmap.yaml
+++ b/helm/prometheus-rules/templates/grafana-agent-rules-configmap.yaml
@@ -2,6 +2,38 @@
 apiVersion: v1
 data:
   values: |
+    networkPolicy:
+      cilium:
+        egress:
+        - toEntities:
+          - kube-apiserver
+          - world
+        - toEndpoints:
+          - matchLabels:
+              io.kubernetes.pod.namespace: kube-system
+              k8s-app: coredns
+          - matchLabels:
+              io.kubernetes.pod.namespace: kube-system
+              k8s-app: k8s-dns-node-cache
+          toPorts:
+          - ports:
+            - port: "1053"
+              protocol: UDP
+            - port: "1053"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+        - toEndpoints:
+          - matchLabels:
+              app.kubernetes.io/component: ruler
+              app.kubernetes.io/name: mimir
+              io.kubernetes.pod.namespace: mimir
+          toPorts:
+          - ports:
+            - port: "8080"
+              protocol: TCP
     grafana-agent:
       agent:
         configMap:

--- a/helm/prometheus-rules/templates/grafana-agent-rules.yaml
+++ b/helm/prometheus-rules/templates/grafana-agent-rules.yaml
@@ -27,5 +27,5 @@ spec:
   namespace: mimir
   # used by renovate
   # repo: giantswarm/grafana-agent-app
-  version: 0.4.3
+  version: 0.4.4
 {{- end -}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30870

This PR overrides the egress rules in the `grafana-agent-rules` CNP to make it more restrictive.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
