### PR TITLE
fix turtles alerts for mimir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Finish reviewing `turles` alerts for multi-provider MCs and Mimir.
+  - Prefix all vintage alerts with `vintage` to facilitate maintenance.
+  - Fix kubelet container runtime alerts.
+  - Fix pod_name label to use pod instead.
+
 ## [4.2.0] - 2024-06-13
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vintage.kiam.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vintage.kiam.rules.yml
@@ -27,7 +27,7 @@ spec:
     rules:
     - alert: KiamMetadataFindRoleErrors
       annotations:
-        description: '{{`Kiam pod {{ $labels.namespace}}/{{ $labels.pod_name }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has increased metadata find role errors.`}}'
+        description: '{{`Kiam pod {{ $labels.namespace}}/{{ $labels.pod }} on {{ $labels.cluster_id}}/{{ $labels.cluster }} has increased metadata find role errors.`}}'
         opsrecipe: kiam-find-role-errors/
       expr: increase(kiam_metadata_find_role_errors_total[10m]) > 0
       for: 15m

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -44,7 +44,6 @@ spec:
         team: {{ include "providerTeam" . }}
         topic: kubernetes
 
-    ## TODO Split this alert into multiple alerts for each webhook.
     # Webhooks that are not explicitely owner by any team (customer owned ones).
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutSolutionEngineers
       annotations:

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/capi-machinepool.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/capi-machinepool.rules.yml
@@ -24,7 +24,6 @@ spec:
               {{`The clusters {{ $labels.cluster_name }} machinepool {{ $labels.exported_namespace }}/{{ $labels.name }} is not healthy.`}}
             opsrecipe: capi-machinepool/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
-
         - alert: MachinePoolPaused
           expr: capi_machinepool_annotation_paused{paused_value="true"} > 0
           for: 1h

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/kubelet.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/kubelet.rules.yml
@@ -46,8 +46,8 @@ spec:
         topic: kubernetes
     - alert: KubeletDockerOperationsErrorsTooHigh
       annotations:
-        description: '{{`Kubelet ({{ $labels.instance }}) is reporting errors rates while performing Docker {{ $labels.operation_type }} operations.`}}'
-      expr: rate(kubelet_docker_operations_errors[5m]) > 1
+        description: '{{`Kubelet ({{ $labels.instance }}) is reporting errors rates while performing runtime {{ $labels.operation_type }} operation.`}}'
+      expr: rate(kubelet_runtime_operations_errors_total[5m]) > 1
       for: 10m
       labels:
         area: kaas
@@ -60,8 +60,8 @@ spec:
         topic: kubernetes
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
-        description: '{{`Kubelet ({{ $labels.instance }}) is taking too long to perform Docker {{ $labels.operation_type }} operations.`}}'
-      expr: kubelet_docker_operations_latency_microseconds{quantile="0.9", operation_type!="pull_image"} > 115000000
+        description: '{{`Kubelet ({{ $labels.instance }}) is taking too long to perform runtime {{ $labels.operation_type }} operations.`}}'
+      expr: histogram_quantile(0.9, rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[5m])) > 120
       for: 10m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/management-cluster.rules.yml
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} cpu usage is too high.`}}'
         opsrecipe: management-cluster-resource-limit-reached/
-      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_cpu_cores{cluster_type="management_cluster"}[2d]) / avg_over_time(aggregation:kubernetes:node_allocatable_cpu_cores_total{cluster_type="management_cluster"}[2d]) > 0.93
+      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_cpu_cores{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_cpu_cores_total{cluster_type="management_cluster"}[2d]) > 0.93
       for: 1h
       labels:
         area: kass
@@ -51,7 +51,7 @@ spec:
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} memory usage is too high.`}}'
         opsrecipe: management-cluster-resource-limit-reached/
-      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_memory_bytes{cluster_type="management_cluster"}[2d]) / avg_over_time(aggregation:kubernetes:node_allocatable_memory_bytes{cluster_type="management_cluster"}[2d]) > 0.93
+      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_memory_bytes{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_memory_bytes{cluster_type="management_cluster"}[2d]) > 0.93
       for: 1h
       labels:
         area: kass
@@ -73,8 +73,8 @@ spec:
         severity: notify
         team: {{ include "providerTeam" . }}
         topic: managementcluster
-    {{- if (eq .Values.managementCluster.provider.kind "aws") }}
-    ## TODO Remove when all vintage clusters are gone
+    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+    ## TODO(@giantswarm/team-atlas) Remove when all vintage clusters are gone
     - alert: ManagementClusterCriticalPodNotRunning
       annotations:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/net-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/net-exporter.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: ClusterNetExporterCPUUsageTooHigh
       annotations:
         description: '{{`net-exporter cpu usage is too high.`}}'
-      expr: rate(container_cpu_user_seconds_total{pod_name=~"net-exporter-.*"}[5m]) > 0.015
+      expr: rate(container_cpu_user_seconds_total{pod=~"net-exporter-.*"}[5m]) > 0.015
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/network.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/network.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: NetworkErrorRateTooHigh
       annotations:
-        description: '{{`Network error rate is too high for {{ or $labels.pod_name $labels.instance }} to {{ $labels.host }}.`}}'
+        description: '{{`Network error rate is too high for {{ or $labels.pod $labels.instance }} to {{ $labels.host }}.`}}'
         opsrecipe: network-error/
       expr: rate(network_dial_error_total[15m]) > 0.002
       for: 15m
@@ -56,7 +56,7 @@ spec:
         topic: network
     - alert: NetworkCheckErrorRateTooHigh
       annotations:
-        description: '{{`Network check error rate is too high for {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`Network check error rate is too high for {{ or $labels.pod $labels.instance }}.`}}'
       expr: rate(network_error_total{}[15m]) > 0
       for: 15m
       labels:
@@ -78,7 +78,7 @@ spec:
         topic: network
     - alert: SYNRetransmissionRateTooHigh
       annotations:
-        description: '{{`SYN retransmission rate is too high for {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`SYN retransmission rate is too high for {{ or $labels.pod $labels.instance }}.`}}'
       expr: rate(node_netstat_TcpExt_TCPSynRetrans{}[15m]) > 3
       for: 5m
       labels:

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node.workload-cluster.rules.yml
@@ -45,7 +45,7 @@ spec:
       annotations:
         description: '{{`Control plane node in HA setup is down for a long time.`}}'
         opsrecipe: master-node-missing/
-      expr: sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (node) kube_node_role{role="control-plane"}) == 2 or sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (node) kube_node_role{role="master"}) == 2
+      expr: sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (cluster_id, node) group_left kube_node_role{role="control-plane"}) == 2 or sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (cluster_id, node) group_left kube_node_role{role="master"}) == 2
       for: 30m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/systemd.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/systemd.rules.yml
@@ -10,6 +10,7 @@ spec:
   groups:
   - name: systemd
     rules:
+    ## TODO(@giantswarm/team-turtles) Update those lists when all vintage clusters are gone
     - alert: ClusterCriticalSystemdUnitFailed
       annotations:
         description: '{{`Critical systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.bastions.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.bastions.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove when all vintage installations are gone
+## TODO(@giantswarm/team-atlas) Remove when all vintage installations are gone
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.docker.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.docker.rules.yml
@@ -1,5 +1,5 @@
 {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-## TODO Remove when all vintage installations are gone
+## TODO(@giantswarm/team-atlas) Remove when all vintage installations are gone
 # newer clusters don't use docker anymore
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.release.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vintage.release.rules.yml
@@ -1,12 +1,13 @@
+{{- if eq .Values.managementCluster.provider.flavor "vintage" }}
+## TODO(@giantswarm/team-atlas) Remove when all vintage installations are gone
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-{{- if not .Values.mimir.enabled }}
+    # No need for .Values.mimir.enabled condition - will be gone with Vintage
     cluster_type: "management_cluster"
-{{- end }}
   name: release.rules
   namespace: {{ .Values.namespace  }}
 spec:
@@ -25,3 +26,4 @@ spec:
         severity: page
         team: turtles
         topic: managementcluster
+{{- end }}

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/dns.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: DNSErrorRateTooHigh
       annotations:
-        description: '{{`DNS error rate is too high for {{ or $labels.pod_name $labels.instance }} to {{ $labels.host }}, using {{ $labels.proto }}.`}}'
+        description: '{{`DNS error rate is too high for {{ or $labels.pod $labels.instance }} to {{ $labels.host }}, using {{ $labels.proto }}.`}}'
         opsrecipe: network-error/
       expr: rate(dns_resolve_error_total[15m]) > 0.015
       for: 15m
@@ -29,7 +29,7 @@ spec:
         topic: network
     - alert: DNSCheckErrorRateTooHigh
       annotations:
-        description: '{{`DNS check error rate is too high for {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`DNS check error rate is too high for {{ or $labels.pod $labels.instance }}.`}}'
         opsrecipe: network-error/
       expr: rate(dns_error_total[15m]) > 0.015
       for: 15m


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes turtles alerts. Only the release operator one are not working because it's missing a servicemonitor

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
