### PR TITLE
remove old cloud api slos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove old cloud-api slos as they are now in sloth slos.
+
 ## [4.2.1] - 2024-06-14
-
-### Fixed
-
-- removed duplicate slo-target on AWS
 
 ### Changed
 
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Prefix all vintage alerts with `vintage` to facilitate maintenance.
   - Fix kubelet container runtime alerts.
   - Fix pod_name label to use pod instead.
+
+### Fixed
+
+- removed duplicate slo-target on AWS
 
 ## [4.2.0] - 2024-06-13
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
@@ -293,50 +293,6 @@ spec:
         label_application_giantswarm_io_team: {{ include "providerTeam" . }}
       record: slo_target
 
-    # core k8s components azure API requests
-    # record number of requests.
-    - expr: label_replace(sum(cloudprovider_azure_api_request_duration_seconds_count{job=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)")
-      labels:
-        class: MEDIUM
-        area: kaas
-        label_application_giantswarm_io_team: phoenix
-      record: raw_slo_requests
-      # record number of errors.
-    - expr: label_replace(sum(cloudprovider_azure_api_request_errors{job=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)")
-      labels:
-        area: kaas
-        class: MEDIUM
-        label_application_giantswarm_io_team: phoenix
-      record: raw_slo_errors
-      # -- 99% availability
-    - expr: label_replace(group(cloudprovider_azure_api_request_duration_seconds_count{job=~"kube-controller-manager|kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)") * 0 + 1 - 0.99
-      labels:
-        area: kaas
-        label_application_giantswarm_io_team: phoenix
-      record: slo_target
-
-    # core k8s components aws API requests
-    # record number of requests.
-    - expr: label_replace(sum(cloudprovider_aws_api_request_duration_seconds_count{job="kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)")
-      labels:
-        class: MEDIUM
-        area: kaas
-        label_application_giantswarm_io_team: phoenix
-      record: raw_slo_requests
-      # record number of errors.
-    - expr: label_replace(sum(cloudprovider_aws_api_request_errors{job="kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)")
-      labels:
-        area: kaas
-        class: MEDIUM
-        label_application_giantswarm_io_team: phoenix
-      record: raw_slo_errors
-      # -- 99% availability
-    - expr: label_replace(group(cloudprovider_aws_api_request_duration_seconds_count{job="kube-scheduler"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, job), "service", "$1", "job", "(.*)") * 0 + 1 - 0.99
-      labels:
-        area: kaas
-        label_application_giantswarm_io_team: phoenix
-      record: slo_target
-
       # -- generic stuff
       # -- standard burnrates based on https://sre.google/workbook/alerting-on-slos/#6-multiwindow-multi-burn-rate-alerts
     - expr: "vector(36)"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR removes the slos that were migrated to sloth https://github.com/giantswarm/sloth-rules/pull/194

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
