### PR TITLE
remove: old kaas daemonset slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove old cloud-api slos as they are now in sloth slos.
+- Remove old kaas daemonset slos as they are now in sloth slos.
 
 ## [4.2.1] - 2024-06-14
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
@@ -10,47 +10,6 @@ spec:
   groups:
   - name: service-level.recording
     rules:
-      # -- KAAS daemonset
-    - expr: |
-        label_replace(
-          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node"},
-        "service", "$1", "daemonset", "(.*)" )
-      labels:
-        class: MEDIUM
-        area: kaas
-        label_application_giantswarm_io_team: {{ include "providerTeam" . }}
-      record: raw_slo_requests
-      # -- the errors are counted as follows:
-      # -- pods in a daemonset that are UNAVAILABLE NOW and have been UNAVAILABLE 10 MINUTES AGO
-      # -- which are on a SCHEDULABLE node that was CREATED AT LEAST 10 MINUTES AGO
-    - expr: |
-        (
-          (
-            label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node"},
-              "service", "$1", "daemonset", "(.*)" ) > 0
-            and on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, daemonset, node)
-            label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node"} offset 10m,
-              "service", "$1", "daemonset", "(.*)" ) > 0
-          )
-          and
-          on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, node) kube_node_spec_unschedulable == 0
-        )
-        and
-        on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, node) time() - kube_node_created > 10 * 60
-      labels:
-        class: MEDIUM
-        area: kaas
-      record: raw_slo_errors
-      # -- 99% availability
-      # -- this expression collects all the daemonsets and assigns the same slo target to all of them
-    - expr: sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, area) (raw_slo_errors{area="kaas", service=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node"} - raw_slo_errors{area="kaas", service=~"aws-node|aws-cloud-controller-manager|ebs-csi-node|calico-node|cert-exporter|kube-proxy|net-exporter|node-exporter|azure-cloud-controller-manager|azure-cloud-node-manager|azure-scheduled-events|csi-azuredisk-node"}) + 1-0.99
-      labels:
-        area: kaas
-        label_application_giantswarm_io_team: {{ include "providerTeam" . }}
-      record: slo_target
-
       # -- empowerment daemonset
     - expr: |
         label_replace(


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR removes the kaas daemonset slos that are "added" here https://github.com/giantswarm/sloth-rules/pull/196

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
