### PR TITLE
remove old prometheus alerts if mimir is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove old cloud-api slos as they are now in sloth slos.
+- Remove old `Heartbeat` and `MatchingNumberOfPrometheusAndCluster` on mimir-equipped installations.
 
 ## [4.2.1] - 2024-06-14
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-meta-operator.rules.yml
@@ -9,6 +9,7 @@ spec:
   groups:
   - name: observability
     rules:
+    {{- if not .Values.mimir.enabled }}
     - alert: "Heartbeat"
       expr: up{job=~".*prometheus/prometheus.*",instance!="prometheus-agent"} == 1
       labels:
@@ -58,6 +59,7 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    {{- end }}
     - alert: "PrometheusMetaOperatorReconcileErrors"
       annotations:
         description: '{{`prometheus-meta-operator controller {{ $labels.controller }} too many reconcile errors.`}}'


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR removes the Prometheus specific alerts if mimir is enabled because they were replaced with better alternatives (the mimir heartbeat and PrometheusAgentFailing)


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
