### PR TITLE
remove-old-cilium-slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove old kaas daemonset slos as they are now in sloth slos.
+- Remove old cilium daemonset slos as they are now in sloth slos.
 
 ## [4.3.0] - 2024-06-17
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/service-level.rules.yml
@@ -10,48 +10,6 @@ spec:
   groups:
   - name: service-level.recording
     rules:
-      # -- empowerment daemonset
-    - expr: |
-        label_replace(
-          kube_daemonset_status_desired_number_scheduled{namespace=~"giantswarm|kube-system", daemonset="cilium"},
-        "service", "$1", "daemonset", "(.*)" )
-      labels:
-        class: MEDIUM
-        area: empowerment
-        label_application_giantswarm_io_team: cabbage
-      record: raw_slo_requests
-      # -- the errors are counted as follows:
-      # -- pods in a daemonset that are UNAVAILABLE NOW and have been UNAVAILABLE 10 MINUTES AGO
-      # -- which are on a SCHEDULABLE node that was CREATED AT LEAST 10 MINUTES AGO
-    - expr: |
-        (
-          (
-            label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset="cilium"},
-              "service", "$1", "daemonset", "(.*)" ) > 0
-            and on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, daemonset, node)
-            label_replace(
-              kube_daemonset_status_number_unavailable{namespace=~"giantswarm|kube-system", daemonset="cilium"} offset 10m,
-              "service", "$1", "daemonset", "(.*)" ) > 0
-          )
-          and
-          on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, node) kube_node_spec_unschedulable == 0
-        )
-        and
-        on (cluster_id, cluster_type, customer, installation, pipeline, provider, region, node) time() - kube_node_created > 10 * 60
-      labels:
-        class: MEDIUM
-        area: empowerment
-        label_application_giantswarm_io_team: cabbage
-      record: raw_slo_errors
-      # -- 99% availability
-      # -- this expression collects all the daemonsets and assigns the same slo target to all of them
-    - expr: sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, service, area) (raw_slo_errors{area="empowerment", service="cilium"} - raw_slo_errors{area="empowerment", service="cilium"}) + 1-0.99
-      labels:
-        area: empowerment
-        label_application_giantswarm_io_team: cabbage
-      record: slo_target
-
       # -- kubelet whole cluster
     - expr: kube_node_status_condition{condition="Ready"}
       labels:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR removes the migrated slos https://github.com/giantswarm/sloth-rules/pull/198

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
