### PR TITLE
fix: cert-exporter alert description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increase time in volume filled related alerts to allow node-problem-detector to shut down nodes properly.
 
+### Fixed
+
+- Fix cert-exporter alerts to render the secret namespace and not the cert-exporter namespace in the alert description.
+
 ### Removed
 
 - Remove old kaas daemonset slos as they are now in sloth slos.

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/certificate.all.rules.yml
@@ -60,7 +60,7 @@ spec:
         topic: cert-manager
     - alert: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate CR {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
       expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",exported_namespace=~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
       labels:
@@ -71,7 +71,7 @@ spec:
         topic: cert-manager
     - alert: CustomerManagedCertificateCRWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate CR {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate CR {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         opsrecipe: managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
       expr: (cert_exporter_certificate_cr_not_after{managed_issuer="true",cluster_type="workload_cluster",exported_namespace!~"kube-system|giantswarm|monitoring"} - time()) < 13 * 24 * 60 * 60
       labels:

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/certificate.management-cluster.rules.yml
@@ -15,9 +15,9 @@ spec:
     rules:
     - alert: ManagementClusterCertificateIsMissing
       annotations:
-        description: '{{`Cannot renew Certificate for Secret {{ $labels.namespace }}/{{ $labels.certificatename }} because it is missing.`}}'
+        description: '{{`Cannot renew Certificate for Secret {{ $labels.exported_namespace }}/{{ $labels.certificatename }} because it is missing.`}}'
         opsrecipe: managed-app-cert-manager/missing-certificate-for-secret/
-      expr: count(cert_exporter_secret_not_after{cluster_type="management_cluster", secretkey="tls.crt", certificatename!=""}) by (cluster_id, installation, pipeline, provider, certificatename, namespace) unless count(label_replace(cert_exporter_certificate_cr_not_after{cluster_type="management_cluster"}, "certificatename", "$1", "name", "(.*)")) by (cluster_id, installation, pipeline, provider, certificatename, namespace)
+      expr: count(cert_exporter_secret_not_after{cluster_type="management_cluster", secretkey="tls.crt", certificatename!=""}) by (cluster_id, installation, pipeline, provider, certificatename, exported_namespace) unless count(label_replace(cert_exporter_certificate_cr_not_after{cluster_type="management_cluster"}, "certificatename", "$1", "name", "(.*)")) by (cluster_id, installation, pipeline, provider, certificatename, exported_namespace)
       for: 5m
       labels:
         area: kaas

--- a/test/tests/providers/global/kaas/turtles/alerting-rules/certificate.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/turtles/alerting-rules/certificate.management-cluster.rules.test.yml
@@ -5,9 +5,9 @@ rule_files:
 tests:
   - interval: 5m
     input_series:
-      - series: 'cert_exporter_secret_not_after{secretkey="tls.crt", certificatename="aws-admission-controller-certificates"}'
+      - series: 'cert_exporter_secret_not_after{secretkey="tls.crt", certificatename="aws-admission-controller-certificates", exported_namespace="giantswarm"}'
         values: "1+0x20 0+0x100"
-      - series: 'cert_exporter_certificate_cr_not_after{name="aws-admission-controller-certificates"}'
+      - series: 'cert_exporter_certificate_cr_not_after{name="aws-admission-controller-certificates", exported_namespace="giantswarm"}'
         values: "1+0x20 0+0x100"
     alert_rule_test:
       - alertname: ManagementClusterCertificateIsMissing


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the namespace in the cert-exporter alerts descriptions as namespace is the pod namespace whereas exporte_namespace is the certificate namespace

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
