### PR TITLE
record mimir memory usage to grafana-cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Recording rule to send mimir memory usage to grafana cloud
+
 ## [4.3.1] - 2024-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Recording rule to send mimir memory usage to grafana cloud
+- Recording rule to send mimir memory usage and metrics amount to grafana cloud
 
 ## [4.3.1] - 2024-06-18
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -371,6 +371,10 @@ spec:
       record: aggregation:prometheus:memory_percentage
     - expr: sum(label_replace(container_memory_working_set_bytes{container='prometheus', namespace=~'.*-prometheus'}, "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)")) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:prometheus:memory_usage
+  - name: mimir.grafana-cloud.recording
+    rules:
+    - expr: sum(container_memory_working_set_bytes{namespace='mimir', cluster_type="management_cluster", container=~'.+'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+      record: aggregation:mimir:memory_usage
   - name: dex.grafana-cloud.recording
     rules:    
     # Dex activity and status based on ingress controller data

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -375,6 +375,10 @@ spec:
     rules:
     - expr: sum(container_memory_working_set_bytes{namespace='mimir', cluster_type="management_cluster", container=~'.+'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:mimir:memory_usage
+    - expr: sum(scrape_samples_post_metric_relabeling{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+      record: aggregation:mimir:scrape_samples_post_metric_relabeling
+    - expr: sum(scrape_series_added{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+      record: aggregation:mimir:scrape_series_added
   - name: dex.grafana-cloud.recording
     rules:    
     # Dex activity and status based on ingress controller data


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31111

This PR adds a new recording rule that will send global mimir usage to grafana cloud, so we can:
* compare it with prometheus usage after installations get migrated
* monitor how it evolves over time

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
