### PR TITLE
Fixed mimir recording rules to grafana cloud.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mimir recording rules to grafana cloud so they only run on mimir and they are safer when labels are missing.
+
 ## [4.3.2] - 2024-06-21
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -364,6 +364,7 @@ spec:
     rules:
     - expr: sum(ALERTS{alertstate="firing"}) by (alertname, cluster_id, cluster_type, customer, installation, pipeline, provider, region, area, severity, team, topic)
       record: aggregation:prometheus:alerts
+    {{- if not .Values.mimir.enabled }}
     # Metric container_memory_working_set_bytes comes from the cAdvisor component scraped on management clusters which is then scraped by the management cluster prometheus.
     # This means the cluster_id label on this metric will be the cluster_id of the management cluster for all the series, not the workload cluster id.
     # As we want to record the memory usage of the prometheis per cluster, we need to extract the cluster id from the prometheus pod name (i.e. pod=prometheus-xyz-ordinal => cluster_id=xyz).
@@ -371,14 +372,17 @@ spec:
       record: aggregation:prometheus:memory_percentage
     - expr: sum(label_replace(container_memory_working_set_bytes{container='prometheus', namespace=~'.*-prometheus'}, "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)")) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:prometheus:memory_usage
+    {{- end }}
+  {{- if .Values.mimir.enabled }}
   - name: mimir.grafana-cloud.recording
     rules:
     - expr: sum(container_memory_working_set_bytes{namespace='mimir', cluster_type="management_cluster", container=~'.+'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:mimir:memory_usage
-    - expr: sum(scrape_samples_post_metric_relabeling{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+    - expr: sum(scrape_samples_post_metric_relabeling{cluster_id=~'.+'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:mimir:scrape_samples_post_metric_relabeling
-    - expr: sum(scrape_series_added{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+    - expr: sum(scrape_series_added{cluster_id=~'.+'}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:mimir:scrape_series_added
+  {{- end }}
   - name: dex.grafana-cloud.recording
     rules:    
     # Dex activity and status based on ingress controller data


### PR DESCRIPTION
- add conditions to
    - run the mimir recording rules only on mimir
    - the prometheus recording rules only on prometheus.

- improve queries to not fail when cluster_id is missing. Currently happens on a few clusters, may be only with prometheus with the old label-defined discovery. But added the fix anyway, can't hurt.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
