### PR TITLE
fix MimirToGrafanaCloudExporterFailures alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MimirToGrafanaCloudExporterFailures alerts
+
 ## [4.3.3] - 2024-06-21
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
@@ -37,7 +37,7 @@ spec:
       # For remote write, we are looking the rate (on 10 minutes) of failed samples are not greater than 0 for 30 minutes
       expr: |
         sum by (cluster_id, installation, provider, pipeline) (
-          rate(prometheus_remote_storage_read_queries_total{job="mimir/mimir-to-grafana-cloud"}[10m]) == 0
+          rate(prometheus_remote_storage_read_queries_total{job="mimir/mimir-to-grafana-cloud", code=~"2.."}[10m]) == 0
           or rate(prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud"}[10m]) > 0
         )
       for: 30m

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.test.yml
@@ -58,7 +58,7 @@ tests:
   - interval: 1m
     input_series:
       # remote read is working for 2 hours and then fails for 1 hour
-      - series: 'prometheus_remote_storage_read_queries_total{job="mimir/mimir-to-grafana-cloud", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'prometheus_remote_storage_read_queries_total{code="200", job="mimir/mimir-to-grafana-cloud", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x60 0+10x60 0+0x60 0+10x180"
       # remote write has no failure for 4 hours and then fails for 2 hours
       - series: 'prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'


### PR DESCRIPTION

Towards: [#inc-2024-06-21-gazelle-gazelle-mimirtografanacloudexporterfailures](https://gigantic.slack.com/archives/C078QR3M6A3)

When we have a metrics with error codes, and the rate of these metrics is 0 (ie all is good), it fired an alert.
![image](https://github.com/giantswarm/prometheus-rules/assets/12008875/818722a0-dffa-4cdf-92f0-b1aaec8dffce)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
