### PR TITLE
Fix MimirToGrafanaCloudExporterFailures alerts: labels cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MimirToGrafanaCloudExporterFailures alerts: labels cleanup
+
 ## [4.3.4] - 2024-06-21
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
@@ -36,9 +36,16 @@ spec:
       # For remote read, we are looking the number of read queries are increasing
       # For remote write, we are looking the rate (on 10 minutes) of failed samples are not greater than 0 for 30 minutes
       expr: |
-        sum by (cluster_id, installation, provider, pipeline) (
-          rate(prometheus_remote_storage_read_queries_total{job="mimir/mimir-to-grafana-cloud", code=~"2.."}[10m]) == 0
-          or rate(prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud"}[10m]) > 0
+        (
+          sum by (cluster_id, installation, provider, pipeline) (
+            rate(prometheus_remote_storage_read_queries_total{job="mimir/mimir-to-grafana-cloud", code=~"2.."}[10m])
+          ) == 0
+        )
+        or
+        (
+          sum by (cluster_id, installation, provider, pipeline) (
+            rate(prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud"}[10m])
+          ) > 0
         )
       for: 30m
       labels:


### PR DESCRIPTION
Another installation with the same alert, but a different reason for the alert. :shrug: 

Towards: [#inc-2024-06-21-gazelle-gazelle-mimirtografanacloudexporterfailures](https://gigantic.slack.com/archives/C078QR3M6A3)

This PR fixes the case when you have metrics for different URLs.
![image](https://github.com/giantswarm/prometheus-rules/assets/12008875/5f11b044-5d23-49d6-8166-50a98b66c139)

The URL was not discarded early enough with the previous syntax.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
