### PR TITLE
add-extra-pint-validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed alert `DeploymentNotSatisfiedCrossplane` to `CrossplaneDeploymentNotSatisfied`
 - Renamed alert `DeploymentNotSatisfiedExternalSecrets` to `ExternalSecretsDeploymentNotSatisfied`
 - Renamed alert `DeploymentNotSatisfiedFlux` to `FluxDeploymentNotSatisfied`
+- Add extra pint validations.
 
 ## [4.3.5] - 2024-06-24
 

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/management-cluster.rules.yml
@@ -42,7 +42,7 @@ spec:
       expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_cpu_cores{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_cpu_cores_total{cluster_type="management_cluster"}[2d]) > 0.93
       for: 1h
       labels:
-        area: kass
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
         team: {{ include "providerTeam" . }}
@@ -54,7 +54,7 @@ spec:
       expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_memory_bytes{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_memory_bytes{cluster_type="management_cluster"}[2d]) > 0.93
       for: 1h
       labels:
-        area: kass
+        area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
         team: {{ include "providerTeam" . }}

--- a/test/conf/pint/pint-all.hcl
+++ b/test/conf/pint/pint-all.hcl
@@ -42,10 +42,17 @@ rule {
     required = true
   }
 
-  # Each alert must have a 'severity' annotation that's either 'page' or 'notify'.
+  # Each alert must have a 'severity' label that's either 'page' or 'notify'.
   label "severity" {
     severity = "bug"
     value    = "(page|notify)"
+    required = true
+  }
+
+  # Each alert must have an `area' label that's either 'kaas' or 'platform'.
+  label "area" {
+    severity = "bug"
+    value    = "(kaas|platform)"
     required = true
   }
 

--- a/test/conf/pint/pint-config.hcl
+++ b/test/conf/pint/pint-config.hcl
@@ -1,7 +1,39 @@
 rule {
+  # Disallow spaces in label/annotation keys, they're only allowed in values.
+  reject ".* +.*" {
+    label_keys      = true
+    annotation_keys = true
+  }
+
+  # Disallow URLs in labels, they should go to annotations.
+  reject "https?://.+" {
+    label_keys   = true
+    label_values = true
+  }
+
   # Ensure that all aggregations are preserving mandatory labels.
   aggregate ".+" {
     severity = "bug"
     keep     = ["cluster_id", "installation", "pipeline", "provider"]
+  }
+}
+
+rule {
+  # This block will apply to all alerting rules.
+  match {
+    kind = "alerting"
+  }
+
+  # Each alert must have a 'description' annotation.
+  annotation "description" {
+    severity = "bug"
+    required = true
+  }
+
+  # Check how many times each alert would fire in the last 1d.
+  alerts {
+    range   = "1d"
+    step    = "1m"
+    resolve = "5m"
   }
 }


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR add some extra pint validation steps

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
