### PR TITLE
add dashboard to fluentbit alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- fluentbit alerts now have a dashboard
+
 ## [4.4.0] - 2024-06-26
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
@@ -14,6 +14,7 @@ spec:
       annotations:
         description: '{{`Fluentbit ({{ $labels.instance }}) is erroring.`}}'
         opsrecipe: fluentbit-too-many-erros/
+        dashboard: fluentbit/fluentbit
       # If we have some failures sending data, raise an alert
       expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
       for: 20m
@@ -30,6 +31,7 @@ spec:
       annotations:
         description: '{{`Fluentbit ({{ $labels.instance }}) is dropping more than 1% records.`}}'
         opsrecipe: fluentbit-too-many-erros/
+        dashboard: fluentbit/fluentbit
       # Check the ratio of dropped records over the total number of records.
       expr: rate(fluentbit_output_dropped_records_total[10m]) / (rate(fluentbit_output_proc_records_total[10m]) + rate(fluentbit_output_dropped_records_total[10m])) > 0.01
       for: 20m
@@ -46,6 +48,7 @@ spec:
       annotations:
         description: '{{`Fluentbit is down on node ({{ $labels.node }}).`}}'
         opsrecipe: fluentbit-down/
+        dashboard: fluentbit/fluentbit
       expr: sum(up{job="fluent-logshipping-app"}) by (job, cluster_id, installation, provider, pipeline, namespace, node) == 0
       for: 15m
       labels:
@@ -61,6 +64,7 @@ spec:
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
         opsrecipe: daemonset-not-satisfied/
+        dashboard: fluentbit/fluentbit
       expr: kube_daemonset_status_number_unavailable{daemonset="fluent-logshipping-app"} > 0
       for: 1h
       labels:


### PR DESCRIPTION
We have a dashboard for fluentbit, but it was not linked to the alerts.
This PR fixes it.


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
