### PR TITLE
Fix grafana cloud exporter absent alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fluentbit alerts now have a dashboard
 
+### Fixed
+
+- Add missing labels to `MimirToGrafanaCloudExporterDown` alert
+
 ## [4.4.0] - 2024-06-26
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.yml
@@ -16,7 +16,7 @@ spec:
         opsrecipe: mimir-grafana-cloud-exporter-failing/
         dashboard: iWowmlSmk/prometheus?var-cluster=mimir-to-grafana-cloud
       # We can use absent function here because the prometheus mimir-to-grafana-cloud is a MC component only
-      expr: up{job="mimir/mimir-to-grafana-cloud"} == 0 or absent(up{job="mimir/mimir-to-grafana-cloud"})
+      expr: up{job="mimir/mimir-to-grafana-cloud"} == 0 or absent(up{job="mimir/mimir-to-grafana-cloud", cluster_type="management_cluster", cluster_id="{{ .Values.managementCluster.name }}", installation="{{ .Values.managementCluster.name }}", provider="{{ .Values.managementCluster.provider.kind }}", pipeline="{{ .Values.managementCluster.pipeline }}"})
       for: 30m
       labels:
         area: platform

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -20,6 +20,7 @@ main() {
       --set="managementCluster.provider.flavor=${BASH_REMATCH[1]}" \
       --set="managementCluster.provider.kind=${BASH_REMATCH[2]}" \
       --set="managementCluster.name=myinstall" \
+      --set="managementCluster.pipeline=stable" \
       --set="mimir.enabled=$mimir_enabled" \
       --output-dir "$GIT_WORKDIR"/test/hack/output/helm-chart/"$provider"
 

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir-to-grafana-cloud-exporter.rules.test.yml
@@ -6,7 +6,7 @@ tests:
   # Tests for `MimirToGrafanaCloudExporterDown` alert
   - interval: 1m
     input_series:
-      - series: 'up{job="mimir/mimir-to-grafana-cloud", cluster_id="golem", installation="golem", namespace="mimir", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'up{job="mimir/mimir-to-grafana-cloud", cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", customer="giantswarm", pipeline="stable", provider="capa", region="eu-west-2"}'
         values: "_x60 1+0x60 0+0x60 1+0x60"
     alert_rule_test:
       - alertname: MimirToGrafanaCloudExporterDown
@@ -14,14 +14,19 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
-              severity: page
-              team: atlas
-              topic: observability
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
               job: mimir/mimir-to-grafana-cloud
+              pipeline: stable
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
             exp_annotations:
               dashboard: "iWowmlSmk/prometheus?var-cluster=mimir-to-grafana-cloud"
               description: "Prometheus Mimir to Grafana-Cloud is down."
@@ -33,21 +38,22 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
-              severity: page
-              team: atlas
-              topic: observability
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
-              cluster_id: golem
+              cluster_id: myinstall
+              cluster_type: management_cluster
               customer: giantswarm
-              installation: golem
-              namespace: mimir
+              installation: myinstall
               job: mimir/mimir-to-grafana-cloud
-              pipeline: testing
+              namespace: mimir
+              pipeline: stable
               provider: capa
               region: eu-west-2
+              severity: page
+              team: atlas
+              topic: observability
             exp_annotations:
               dashboard: "iWowmlSmk/prometheus?var-cluster=mimir-to-grafana-cloud"
               description: "Prometheus Mimir to Grafana-Cloud is down."
@@ -58,10 +64,10 @@ tests:
   - interval: 1m
     input_series:
       # remote read is working for 2 hours and then fails for 1 hour
-      - series: 'prometheus_remote_storage_read_queries_total{code="200", job="mimir/mimir-to-grafana-cloud", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'prometheus_remote_storage_read_queries_total{code="200", job="mimir/mimir-to-grafana-cloud", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x60 0+10x60 0+0x60 0+10x180"
       # remote write has no failure for 4 hours and then fails for 2 hours
-      - series: 'prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'prometheus_remote_storage_samples_failed_total{job="mimir/mimir-to-grafana-cloud", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x60 0+0x180 0+10x120"
     alert_rule_test:
       - alertname: MimirToGrafanaCloudExporterFailures
@@ -78,8 +84,8 @@ tests:
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
-              cluster_id: "golem"
-              installation: "golem"
+              cluster_id: "myinstall"
+              installation: "myinstall"
               pipeline: "testing"
               provider: "capa"
             exp_annotations:
@@ -100,8 +106,8 @@ tests:
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
-              cluster_id: "golem"
-              installation: "golem"
+              cluster_id: "myinstall"
+              installation: "myinstall"
               pipeline: "testing"
               provider: "capa"
             exp_annotations:
@@ -112,15 +118,15 @@ tests:
   - interval: 1m
     input_series:
       # remote read is working for 2 hours and then fails for 1 hour
-      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea5", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea5", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x60 1+0x60 _x80"
-      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea6", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea6", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x122 1+0x2 _x78"
-      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea7", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea7", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x124 1+0x2 _x76"
-      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea8", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea8", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x126 1+0x2 _x74"
-      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea9", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="golem", customer="giantswarm", installation="golem", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
+      - series: 'kube_pod_status_ready{condition="true", uid="0bb4e0cc-12df-4085-8d39-8e08b9c64ea9", pod="prometheus-mimir-to-grafana-cloud-0", cluster_id="myinstall", customer="giantswarm", installation="myinstall", namespace="mimir", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "_x128 1+0x72"
     alert_rule_test:
       - alertname: MimirToGrafanaCloudExporterTooManyRestarts
@@ -138,8 +144,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
               pod: "prometheus-mimir-to-grafana-cloud-0"
-              cluster_id: "golem"
-              installation: "golem"
+              cluster_id: "myinstall"
+              installation: "myinstall"
               pipeline: "testing"
               provider: "capa"
             exp_annotations:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR makes sure we have the basic labels in the `MimirToGrafanaCloudExporterDown` alert so we do not have alerts like this: https://giantswarm.app.opsgenie.com/alert/detail/8c7105d9-ea86-4aec-8d14-3f68d0341632-1719827332301/details

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
