### PR TITLE
Add new alert when sloth restarts too often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - fluentbit alerts now have a dashboard
+- add alert on sloth restarting too often (https://github.com/giantswarm/giantswarm/issues/31133)
 
 ## [4.4.0] - 2024-06-26
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/sloth.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/sloth.rules.yml
@@ -18,9 +18,24 @@ spec:
       labels:
         area: platform
         cancel_if_cluster_control_plane_unhealthy: "true"
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
+    # Coming from https://github.com/giantswarm/giantswarm/issues/31133
+    # This alert ensures sloth container are not restarting too often (flappiness).
+    - alert: SlothRestartingTooOften
+      annotations:
+        description: '{{`Sloth is restarting too often.`}}'
+        opsrecipe: sloth-down/
+      expr: |
+        increase(
+          kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="monitoring", container="sloth"}[1h]
+        ) > 5
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
         team: atlas

--- a/test/tests/providers/global/platform/atlas/alerting-rules/sloth.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/sloth.rules.test.yml
@@ -26,10 +26,32 @@ tests:
               team: atlas
               topic: observability
               cancel_if_cluster_control_plane_unhealthy: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
             exp_annotations:
               description: "Sloth is down."
               opsrecipe: sloth-down/
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="monitoring", container="sloth"}'
+        values: "0+0x20 0+5x20 100+0x140" # 0 restarts after 20 minutes then we restart 5 times per minute for 20 minutes then we stop restarting for 140 minutes
+    alert_rule_test:
+      - alertname: SlothRestartingTooOften
+        eval_time: 15m  # should be OK after 15 minutes
+      - alertname: SlothRestartingTooOften
+        eval_time: 85m  # After 85 minutes, should fire an alert for the t+85 error
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_control_plane_unhealthy: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_type: management_cluster
+              container: sloth
+              namespace: monitoring
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: Sloth is restarting too often.
+              opsrecipe: sloth-down/
+      - alertname: SlothRestartingTooOften
+        eval_time: 140m  # After 140m minutes, all should be back to normal


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/31133

This PR adds a new alert when sloth is restarting more than 5 times an hour so we can know when it's having issues

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
