### PR TITLE
add-nodes-inhibitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add new node inhibitions to avoid paging for daemonsets when nodes are not ready/unschedulable.
+
 ### Changed
 
 - fluentbit alerts now have a dashboard

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.nodes.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.nodes.rules.yml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+{{- if not .Values.mimir.enabled }}
+    cluster_type: "management_cluster"
+{{- end }}
+  name: inhibit.nodes.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: inhibit.nodes
+    rules:
+    - alert: InhibitionNodeNotReady
+      annotations:
+        description: '{{`Node {{ $labels.node }} is not ready.`}}'
+      expr: kube_node_status_condition{condition="Ready", status!="true"} > 0
+      labels:
+        area: kaas
+        node_not_ready: "true"
+        team: turtles
+        topic: kubernetes
+    - alert: InhibitionNodeUnschedulable
+      annotations:
+        description: '{{`Node {{ $labels.node }} is unschedulable.`}}'
+      expr: kube_node_spec_unschedulable > 0
+      labels:
+        area: kaas
+        node_unschedulable: "true"
+        team: turtles
+        topic: kubernetes


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/prometheus-rules/pull/1207/files

This PR adds node state inhibition to avoid paging for daemonset not able to schedule on not ready/unschedulable nodes

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
