### PR TITLE
Add cilium-agent alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add new node inhibitions to avoid paging for daemonsets when nodes are not ready/unschedulable.
+- Add alert for cilium-agent replacing SLO.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -61,7 +61,7 @@ spec:
         topic: cilium
     - alert: CiliumAgentPodUnavailable
       annotations:
-        description: '{{`At least one cilium-agent pod is not running for 15mins.`}}'
+        description: '{{`At least one cilium-agent pod not running for 15mins.`}}'
         opsrecipe: cilium-troubleshooting/
       expr: sum by (cluster_id, installation, pipeline, provider) (kube_daemonset_status_number_unavailable{daemonset="cilium"}) > 0
       for: 15m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -59,4 +59,16 @@ spec:
         severity: page
         team: cabbage
         topic: cilium
-
+    - alert: CiliumAgentPodUnavailable
+      annotations:
+        description: '{{`At least one cilium-agent pod is not running for 15mins.`}}'
+        opsrecipe: cilium-troubleshooting/
+      expr: sum by (cluster_id, installation, pipeline, provider) (kube_daemonset_status_number_unavailable{daemonset="cilium"}) > 0
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        severity: page
+        team: cabbage
+        topic: cilium

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -101,13 +101,11 @@ tests:
               opsrecipe: "unsupported-cilium-network-policy/"
   - interval: 1m
     input_series:
-      - series: 'kube_daemonset_status_number_unavailable{cluster_id="test01", installation="test", pipeline="stable", provider="thecloud"}'
-        values: "_x20 1+0x15 0+0x20"
+      - series: 'kube_daemonset_status_number_unavailable{cluster_id="test01", installation="test", pipeline="stable", provider="thecloud", daemonset="cilium"}'
+        values: "_x20 1+0x30 0+0x20"
     alert_rule_test:
       - alertname: CiliumAgentPodUnavailable
         eval_time: 10m
-      - alertname: CiliumAgentPodUnavailable
-        eval_time: 40m
       - alertname: CiliumAgentPodUnavailable
         eval_time: 50m
         exp_alerts:
@@ -116,6 +114,12 @@ tests:
               severity: page
               team: cabbage
               topic: cilium
+              cluster_id: test01
+              installation: test
+              pipeline: stable
+              provider: thecloud
+              cancel_if_cluster_status_deleting: true
+              cancel_if_cluster_status_creating: true
             exp_annotations:
               description: "At least one cilium-agent pod not running for 15mins."
               opsrecipe: "cilium-troubleshooting/"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -107,9 +107,9 @@ tests:
       - alertname: CiliumAgentPodUnavailable
         eval_time: 10m
       - alertname: CiliumAgentPodUnavailable
-        eval_time: 30m
+        eval_time: 40m
       - alertname: CiliumAgentPodUnavailable
-        eval_time: 70m
+        eval_time: 50m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -99,3 +99,23 @@ tests:
             exp_annotations:
               description: "Too many Cilium Network Policy errors."
               opsrecipe: "unsupported-cilium-network-policy/"
+  - interval: 1m
+    input_series:
+      - series: 'kube_daemonset_status_number_unavailable{cluster_id="test01", installation="test", pipeline="stable", provider="thecloud"}'
+        values: "_x20 1+0x15 0+0x20"
+    alert_rule_test:
+      - alertname: CiliumAgentPodUnavailable
+        eval_time: 10m
+      - alertname: CiliumAgentPodUnavailable
+        eval_time: 30m
+      - alertname: CiliumAgentPodUnavailable
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: cilium
+            exp_annotations:
+              description: "At least one cilium-agent pod not running for 15mins."
+              opsrecipe: "cilium-troubleshooting/"


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
