### PR TITLE
disabel aggregation:kyverno_policy_deployment_status_team recording rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled `aggregation:kyverno_policy_deployment_status_team` recording rule to save on Grafana Cloud cost.
+
 ## [4.5.0] - 2024-07-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -430,23 +430,24 @@ spec:
     - expr: sum(kyverno_policy) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, background, category, kind, policy, rule, type, validationFailureAction)
       record: aggregation:kyverno_policy_status
     # Kyverno policy workload status by team - Deployments
-    - expr: |-
-        label_join(
-          sum(
-            label_join(policy_report_result{
-              policy!="check-deprecated-apis-1-25",
-              cluster_type="management_cluster",
-              kind="Deployment"
-            }, "deployment", ",", "name")
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, deployment, category, policy, status)
-          * on(deployment) group_left(team, app) sum(
-            label_join(label_join(kube_deployment_labels{
-              cluster_type="management_cluster",
-              label_application_giantswarm_io_team!=""
-            }, "app", ",", "label_app_kubernetes_io_name"), "team", ",", "label_application_giantswarm_io_team")
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, team, app, deployment),
-        "name", ",", "deployment")
-      record: aggregation:kyverno_policy_deployment_status_team
+    # This rule has been temporaly disabled to save on Grafana Cloud costs.
+    # - expr: |-
+    #     label_join(
+    #       sum(
+    #         label_join(policy_report_result{
+    #           policy!="check-deprecated-apis-1-25",
+    #           cluster_type="management_cluster",
+    #           kind="Deployment"
+    #         }, "deployment", ",", "name")
+    #       ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, deployment, category, policy, status)
+    #       * on(deployment) group_left(team, app) sum(
+    #         label_join(label_join(kube_deployment_labels{
+    #           cluster_type="management_cluster",
+    #           label_application_giantswarm_io_team!=""
+    #         }, "app", ",", "label_app_kubernetes_io_name"), "team", ",", "label_application_giantswarm_io_team")
+    #       ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, team, app, deployment),
+    #     "name", ",", "deployment")
+    #   record: aggregation:kyverno_policy_deployment_status_team
     # Kyverno policy workload status by team - DaemonSets
     - expr: |-
         label_join(


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24418

This PR disables the `aggregation:kyverno_policy_deployment_status_team` rule to save on Grafana Cloud costs. After a quick calculation, this should help save ~$300 monthly.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
