### PR TITLE
link AlloyForPrometheusRulesDown alert to mimir-rules ops-recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- link AlloyForPrometheusRulesDown alert to mimir-rules ops-recipe
+
 ## [4.6.1] - 2024-07-09
 
 ## [4.6.0] - 2024-07-09

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -62,7 +62,7 @@ spec:
     - alert: AlloyForPrometheusRulesDown
       annotations:
         description: 'Alloy sending PrometheusRules to Mimir ruler is down.'
-        opsrecipe: mimir/
+        opsrecipe: mimir-rules/
       expr: count(up{job="alloy-rules", namespace="mimir"} == 0) by (cluster_id, installation, provider, pipeline) > 0
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -62,7 +62,7 @@ spec:
     - alert: AlloyForPrometheusRulesDown
       annotations:
         description: 'Alloy sending PrometheusRules to Mimir ruler is down.'
-        opsrecipe: mimir-rules/
+        opsrecipe: prometheus-rules/
       expr: count(up{job="alloy-rules", namespace="mimir"} == 0) by (cluster_id, installation, provider, pipeline) > 0
       for: 1h
       labels:

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -113,7 +113,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Alloy sending PrometheusRules to Mimir ruler is down."
-              opsrecipe: "mimir/"
+              opsrecipe: "mimir-rules/"
   - interval: 1m
     input_series:
       # test: none, rate > 0, rate = 0

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -113,7 +113,7 @@ tests:
               topic: observability
             exp_annotations:
               description: "Alloy sending PrometheusRules to Mimir ruler is down."
-              opsrecipe: "mimir-rules/"
+              opsrecipe: "prometheus-rules/"
   - interval: 1m
     input_series:
       # test: none, rate > 0, rate = 0


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3521

Link AlloyForPrometheusRulesDown to newly created mimir-rules ops-recipe