### PR TITLE
add support for loki rules to management clusters in alloy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for loki rules to management clusters in alloy config
+- grafana datasource for MC loki ruler
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for loki rules to management clusters in alloy config
+
 ### Fixed
 
 - Fix PromtailDown alert to fire only when the node is ready.

--- a/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
+++ b/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
@@ -45,6 +45,24 @@ data:
             mimir.rules.kubernetes "local" {
               address = "http://mimir-ruler.mimir.svc:8080/"
               tenant_id = "anonymous"
+              rule_selector {
+                  match_expression {
+                    key = "application.giantswarm.io/prometheus-rule-kind"
+                    operator = "NotIn"
+                    values = ["loki"]
+                  }
+              }
+            }
+            loki.rules.kubernetes "local" {
+              address = "http://loki-backend.loki.svc:3100/"
+              tenant_id = "{{ .Values.managementCluster.name }}"
+              rule_selector {
+                  match_expression {
+                    key = "application.giantswarm.io/prometheus-rule-kind"
+                    operator = "In"
+                    values = ["loki"]
+                  }
+              }
             }
       controller:
         type: "deployment"

--- a/helm/prometheus-rules/templates/loki-ruler-datasource-configmap.yaml
+++ b/helm/prometheus-rules/templates/loki-ruler-datasource-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-ruler-datasource-{{ .Values.managementCluster.name }}
+  namespace: monitoring
+  labels:
+    app.giantswarm.io/kind: datasource
+data:
+  loki-ruler-{{ .Values.managementCluster.name }}.yaml: |
+    apiVersion: 1
+    datasources:
+    - access: proxy
+      editable: false
+      jsonData:
+        manageAlerts: true
+        httpHeaderName1: X-Scope-OrgID
+      secureJsonData:
+        httpHeaderValue1: {{ .Values.managementCluster.name }}
+      name: Loki-ruler-{{ .Values.managementCluster.name }}
+      type: loki
+      url: http://loki-backend.loki.svc:3100
+{{- end -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3178

This PR adds:
- support for loading loki rules into Loki's management-cluster tenant.
- a grafana datasource so we can see them on grafana

prometheusRules for loki should have a label `application.giantswarm.io/prometheus-rule-kind: loki`.


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
