### PR TITLE
move alloy namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move alloy to monitoring namespace
+
 ## [4.7.0] - 2024-07-15
 
 ### Added
 
 - Support for loki rules to management clusters in alloy config
 - grafana datasource for MC loki ruler
-
-### Changed
-
-- Move alloy to monitoring namespace
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for loki rules to management clusters in alloy config
 - grafana datasource for MC loki ruler
 
+### Changed
+
+- Move alloy to monitoring namespace
+
 ### Fixed
 
 - Make dns-operator-azure capz only.

--- a/helm/prometheus-rules/templates/alloy-rules.yaml
+++ b/helm/prometheus-rules/templates/alloy-rules.yaml
@@ -24,7 +24,7 @@ spec:
       name: ""
       namespace: ""
   name: alloy
-  namespace: mimir
+  namespace: monitoring
   # used by renovate
   # repo: giantswarm/alloy
   version: 0.2.0


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR moves alloy in the monitoring namespace  because it is now used for both mimir and loki

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
