### PR TITLE
add LokiNeedsToBeScaledDown alerting rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for loki rules to management clusters in alloy config
 - grafana datasource for MC loki ruler
+- Add `LokiNeedsToBeScaledDown` alert.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -85,7 +85,7 @@ spec:
         topic: observability
     - alert: LokiNeedsToBeScaledDown
       annotations:
-        description: 'Loki is consuming very few resources and needs to be scaled down.'
+        description: '{{`Loki component {{ $labels.labelpod }} is consuming very few resources and needs to be scaled down.`}}'
         opsrecipe: loki/
       expr: |-
         sum by (cluster_id, installation, namespace, pipeline, provider, labelpod) (label_replace(container_memory_working_set_bytes{container="loki", namespace="loki"}, "labelpod", "$1", "pod", "(loki-[[:alnum:]]*)-.*")) 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -88,14 +88,14 @@ spec:
         description: 'Loki is consuming very few resources and needs to be scaled down.'
         opsrecipe: loki/
       expr: |-
-        sum by (cluster_id, installation, namespace, pipeline, provider) (container_memory_working_set_bytes{container="loki", namespace="loki"}) 
+        sum by (cluster_id, installation, namespace, pipeline, provider, labelpod) (label_replace(container_memory_working_set_bytes{container="loki", namespace="loki"}, "labelpod", "$1", "pod", "(loki-[[:alnum:]]*)-.*")) 
           / 
-        sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="loki", namespace="loki", unit="byte"}) 
+        sum by(cluster_id, installation, namespace, pipeline, provider, labelpod) (label_replace(kube_pod_container_resource_requests{container="loki", namespace="loki", unit="byte"}, "labelpod", "$1", "pod", "(loki-[[:alnum:]]*)-.*")) 
           <= 0.30 
         and
-        sum(rate(container_cpu_usage_seconds_total{container="loki", namespace="loki"}[5m])) by (cluster_id, installation, namespace, pipeline, provider) 
+        sum(label_replace(rate(container_cpu_usage_seconds_total{container="loki", namespace="loki"}[5m]), "labelpod", "$1", "pod", "(loki-[[:alnum:]]*)-.*")) by (cluster_id, installation, namespace, pipeline, provider, labelpod) 
           / 
-        sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="loki", namespace="loki", unit="core"}) 
+        sum by(cluster_id, installation, namespace, pipeline, provider, labelpod) (label_replace(kube_pod_container_resource_requests{container="loki", namespace="loki", unit="core"}, "labelpod", "$1", "pod", "(loki-[[:alnum:]]*)-.*")) 
           <= 0.30
       for: 1d
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -83,3 +83,28 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: LokiNeedsToBeScaledDown
+      annotations:
+        description: 'Loki is consuming very few resources and needs to be scaled down.'
+        opsrecipe: loki/
+      expr: |-
+        sum by (cluster_id, installation, namespace, pipeline, provider) (container_memory_working_set_bytes{container="loki", namespace="loki"}) 
+          / 
+        sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="loki", namespace="loki", unit="byte"}) 
+          <= 0.30 
+        and
+        sum(rate(container_cpu_usage_seconds_total{container="loki", namespace="loki"}[5m])) by (cluster_id, installation, namespace, pipeline, provider) 
+          / 
+        sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="loki", namespace="loki", unit="core"}) 
+          <= 0.30
+      for: 60m
+      labels:
+        area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -97,7 +97,7 @@ spec:
           / 
         sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="loki", namespace="loki", unit="core"}) 
           <= 0.30
-      for: 60m
+      for: 1d
       labels:
         area: platform
         cancel_if_cluster_control_plane_unhealthy: "true"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -138,24 +138,24 @@ tests:
     input_series:
       # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
       - series: 'container_memory_working_set_bytes{pod="loki-backend-0", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "8+0x20 2+0x40 8+0x140 2+0x40 8+0x60"
+        values: "8+0x20 2+0x1450 8+0x2900 2+0x1450 8+0x1450"
       - series: 'container_memory_working_set_bytes{pod="loki-backend-1", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "8+0x20 2+0x40 8+0x140 2+0x40 8+0x60"
+        values: "8+0x20 2+0x1450 8+0x2900 2+0x1450 8+0x1450"
       # loki-backend memory requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="loki-backend-0", container="loki", namespace="loki", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "12+0x300"
+        values: "12+0x7270"
       - series: 'kube_pod_container_resource_requests{pod="loki-backend-1", container="loki", namespace="loki", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "12+0x300"       
+        values: "12+0x7270"       
       # loki-backend real cpu usage gradually increases until it goes below 30% of the cpu requests.                        
       - series: 'container_cpu_usage_seconds_total{pod="loki-backend-0", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "0+60x100 6000+10x40 6400+60x60 10000+10x40 10400+60x60"
+        values: "0+60x1470 0+10x1450 0+60x1450 0+10x1450 0+60x1450"
       - series: 'container_cpu_usage_seconds_total{pod="loki-backend-1", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "0+30x300"
+        values: "0+30x7270"
       # loki-backend cpu requests stay the same for the entire duration of the test
       - series: 'kube_pod_container_resource_requests{pod="loki-backend-0", container="loki", namespace="loki", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "1.5+0x300"                                 
+        values: "1.5+0x7270"                                 
       - series: 'kube_pod_container_resource_requests{pod="loki-backend-1", container="loki", namespace="loki", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "1.5+0x300"  
+        values: "1.5+0x7270"  
     alert_rule_test:
       - alertname: LokiNeedsToBeScaledDown
         eval_time: 15m 
@@ -168,7 +168,7 @@ tests:
       - alertname: LokiNeedsToBeScaledDown
         eval_time: 180m 
       - alertname: LokiNeedsToBeScaledDown
-        eval_time: 240m 
+        eval_time: 5820m 
         exp_alerts:
           - exp_labels:
               area: platform
@@ -179,6 +179,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: golem
               installation: "golem"
+              labelpod: "loki-backend"
               pipeline: "testing"
               provider: "capa"
               namespace: loki
@@ -189,4 +190,4 @@ tests:
               description: Loki component loki-backend is consuming very few resources and needs to be scaled down.
               opsrecipe: "loki/"
       - alertname: LokiNeedsToBeScaledDown
-        eval_time: 280m 
+        eval_time: 7265m 

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -134,3 +134,59 @@ tests:
       - alertname: LokiRestartingTooOften
         eval_time: 140m  # After 140m minutes, all should be back to normal
         exp_alerts:
+  - interval: 1m
+    input_series:
+      # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
+      - series: 'container_memory_working_set_bytes{pod="loki-backend-0", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "8+0x20 2+0x40 8+0x140 2+0x40 8+0x60"
+      - series: 'container_memory_working_set_bytes{pod="loki-backend-1", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "8+0x20 2+0x40 8+0x140 2+0x40 8+0x60"
+      # loki-backend memory requests stay the same for the entire duration of the test.
+      - series: 'kube_pod_container_resource_requests{pod="loki-backend-0", container="loki", namespace="loki", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "12+0x300"
+      - series: 'kube_pod_container_resource_requests{pod="loki-backend-1", container="loki", namespace="loki", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "12+0x300"       
+      # loki-backend real cpu usage gradually increases until it goes below 30% of the cpu requests.                        
+      - series: 'container_cpu_usage_seconds_total{pod="loki-backend-0", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "0+60x100 6000+10x40 6400+60x60 10000+10x40 10400+60x60"
+      - series: 'container_cpu_usage_seconds_total{pod="loki-backend-1", container="loki", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "0+30x300"
+      # loki-backend cpu requests stay the same for the entire duration of the test
+      - series: 'kube_pod_container_resource_requests{pod="loki-backend-0", container="loki", namespace="loki", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "1.5+0x300"                                 
+      - series: 'kube_pod_container_resource_requests{pod="loki-backend-1", container="loki", namespace="loki", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "1.5+0x300"  
+    alert_rule_test:
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 15m 
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 55m 
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 100m
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 135m
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 180m 
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 240m 
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_control_plane_unhealthy: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: golem
+              installation: "golem"
+              pipeline: "testing"
+              provider: "capa"
+              namespace: loki
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: Loki component loki-backend is consuming very few resources and needs to be scaled down.
+              opsrecipe: "loki/"
+      - alertname: LokiNeedsToBeScaledDown
+        eval_time: 280m 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3534

This PR adds a new alerting rule based on the `MimirIngesterNeedsToBeScaledDown` which pages whenever loki has used less than 30% of its requested resources for more than 1h. 

The query takes all loki components (except for the `loki-multi-tenant-proxy`) and looks at their combined usage. This means that if this alert pages, it will be up to the oncaller to investigate further to find which component in the loki setup is using very few resources.  Because of this, I will also update the loki ops-recipe to help the oncallers on how to investigate quickly. 

WDYT ?

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
