### PR TITLE
add LokiNeedsToBeScaledUp alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove Linkerd alerts.
 
+### Added 
+
+- Add `LokiNeedsToBeScaledUp` alerting rule.
+
 ## [4.8.0] - 2024-07-15
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -83,15 +83,15 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    - alert: LokiNeedsToBeScaledUp
+    - alert: LokiHpaReachedMaxReplicas
       annotations:
-        description: '{{`Loki component {{ $labels.horizontalpodautoscaler }} needs to be scaled up.`}}'
+        description: '{{`Loki component {{ $labels.horizontalpodautoscaler }} has reached its maxReplicas number but still needs to be scaled up.`}}'
         opsrecipe: loki/
       expr: |
         sum by (cluster_id, installation, namespace, pipeline, provider, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_desired_replicas{namespace="loki", horizontalpodautoscaler=~"loki-backend|loki-write|loki-read"})
           != 
         sum by (cluster_id, installation, namespace, pipeline, provider, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{namespace="loki", horizontalpodautoscaler=~"loki-backend|loki-write|loki-read"})
-      for: 10m
+      for: 4h
       labels:
         area: platform
         cancel_if_cluster_control_plane_unhealthy: "true"

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -83,3 +83,22 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: LokiNeedsToBeScaledUp
+      annotations:
+        description: '{{`Loki component {{ $labels.horizontalpodautoscaler }} needs to be scaled up.`}}'
+        opsrecipe: loki/
+      expr: |
+        sum by (cluster_id, installation, namespace, pipeline, provider, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_desired_replicas{namespace="loki", horizontalpodautoscaler=~"loki-backend|loki-write|loki-read"})
+          != 
+        sum by (cluster_id, installation, namespace, pipeline, provider, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{namespace="loki", horizontalpodautoscaler=~"loki-backend|loki-write|loki-read"})
+      for: 10m
+      labels:
+        area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -138,14 +138,14 @@ tests:
     input_series:
       # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
       - series: 'kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x20 3+0x20 2+0x20"
+        values: "2+0x20 3+0x250 2+0x250"
       - series: 'kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x60"
+        values: "2+0x520"
     alert_rule_test:
-      - alertname: LokiNeedsToBeScaledUp
+      - alertname: LokiHpaReachedMaxReplicas
         eval_time: 15m
-      - alertname: LokiNeedsToBeScaledUp
-        eval_time: 35m
+      - alertname: LokiHpaReachedMaxReplicas
+        eval_time: 265m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -166,5 +166,5 @@ tests:
             exp_annotations:
               description: Loki component loki-backend needs to be scaled up.
               opsrecipe: loki/
-      - alertname: LokiNeedsToBeScaledUp
-        eval_time: 55m 
+      - alertname: LokiHpaReachedMaxReplicas
+        eval_time: 515m 

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -138,14 +138,14 @@ tests:
     input_series:
       # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
       - series: 'kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x20 3+0x1500 2+0x1500"
+        values: "2+0x20 3+0x20 2+0x20"
       - series: 'kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x3020"
+        values: "2+0x60"
     alert_rule_test:
       - alertname: LokiNeedsToBeScaledUp
         eval_time: 15m
       - alertname: LokiNeedsToBeScaledUp
-        eval_time: 1500m
+        eval_time: 35m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -167,4 +167,4 @@ tests:
               description: Loki component loki-backend needs to be scaled up.
               opsrecipe: loki/
       - alertname: LokiNeedsToBeScaledUp
-        eval_time: 3010m 
+        eval_time: 55m 

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -138,14 +138,14 @@ tests:
     input_series:
       # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
       - series: 'kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x20 3+0x20 2+0x20"
+        values: "2+0x20 3+0x1500 2+0x1500"
       - series: 'kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "2+0x60"
+        values: "2+0x3020"
     alert_rule_test:
       - alertname: LokiNeedsToBeScaledUp
         eval_time: 15m
       - alertname: LokiNeedsToBeScaledUp
-        eval_time: 35m
+        eval_time: 1500m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -167,4 +167,4 @@ tests:
               description: Loki component loki-backend needs to be scaled up.
               opsrecipe: loki/
       - alertname: LokiNeedsToBeScaledUp
-        eval_time: 55m 
+        eval_time: 3010m 

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -221,7 +221,7 @@ tests:
               pipeline: testing
               provider: capa
             exp_annotations:
-              description: Loki component loki-backend needs to be scaled up.
+              description: Loki component loki-backend has reached its maxReplicas number but still needs to be scaled up.
               opsrecipe: loki/
       - alertname: LokiHpaReachedMaxReplicas
         eval_time: 515m 

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -134,3 +134,37 @@ tests:
       - alertname: LokiRestartingTooOften
         eval_time: 140m  # After 140m minutes, all should be back to normal
         exp_alerts:
+  - interval: 1m
+    input_series:
+      # loki-backend real memory usage gradually decreases until it goes below 30% of the memory requests.
+      - series: 'kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "2+0x20 3+0x20 2+0x20"
+      - series: 'kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="loki-backend", namespace="loki", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
+        values: "2+0x60"
+    alert_rule_test:
+      - alertname: LokiNeedsToBeScaledUp
+        eval_time: 15m
+      - alertname: LokiNeedsToBeScaledUp
+        eval_time: 35m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_control_plane_unhealthy: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              severity: page
+              team: atlas
+              topic: observability
+              namespace: loki
+              cluster_id: golem
+              horizontalpodautoscaler: loki-backend
+              installation: golem
+              pipeline: testing
+              provider: capa
+            exp_annotations:
+              description: Loki component loki-backend needs to be scaled up.
+              opsrecipe: loki/
+      - alertname: LokiNeedsToBeScaledUp
+        eval_time: 55m 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3534

This PR adds a `LokiNeedsToBeScaledUp` alert to notify oncalers that loki is going to be scaled up by the hpa. This means that if an oncaller gets paged by this, he/she will need to make sure that no previous user-values or any other change has been made to the loki workload that would compere with the upscaling. 

In particular, if some resources are lowered down by a user-values compared to what's defined in the shared-configs or in the installation's specific config repo,  the oncaller will have to remove that configmap. 

This will be detailed in the loki ops recipe once I'll have updated it.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
