### PR TITLE
Add CAPI cluster namespace to recording rule `aggregation:giantswarm:cluster_info` for use by `resource-police` to find out to whom each test cluster belongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CAPI cluster namespace to recording rule `aggregation:giantswarm:cluster_info` for use by [`resource-police`](https://github.com/giantswarm/resource-police/) to find out to whom each test cluster belongs
+
 ### Changed
 
 - Remove Linkerd alerts.

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -63,7 +63,7 @@ spec:
     rules:
     # This recording rule is used to list all clusters. The last expression is used to list vintage MCs
     - expr: |-
-        avg by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) (
+        avg by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, exported_namespace) (
           label_replace(
             capi_cluster_info,
             "cluster_id",
@@ -76,7 +76,7 @@ spec:
           or label_replace(cluster_service_cluster_info, "cluster_type", "workload_cluster", "", "") >= 1
           or
             label_replace(
-              label_replace( 
+              label_replace(
                 label_replace(
                   label_replace(
                     label_replace(
@@ -134,7 +134,7 @@ spec:
     rules:
     - expr: sum(engine_daemon_image_actions_seconds_count) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, action)
       record: aggregation:docker:action_count
-    - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) 
+    - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:docker:containers_using_dockerhub_image
     - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) / sum(kube_pod_container_info{} or kube_pod_init_container_info{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:docker:containers_using_dockerhub_image_relative
@@ -361,7 +361,7 @@ spec:
       record: aggregation:mimir:scrape_series_added
   {{- end }}
   - name: dex.grafana-cloud.recording
-    rules:    
+    rules:
     # Dex activity and status based on ingress controller data
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"5.."}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:dex_requests_status_5xx
@@ -369,7 +369,7 @@ spec:
       record: aggregation:dex_requests_status_4xx
     - expr: sum(nginx_ingress_controller_requests{namespace="giantswarm",ingress="dex",status=~"[23].."}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:dex_requests_status_ok
-    # Dex operator metrics for expiry time of identity provider oauth app secrets 
+    # Dex operator metrics for expiry time of identity provider oauth app secrets
     - expr: dex_operator_idp_secret_expiry_time
       record: aggregation:dex_operator_idp_secret_expiry_time
     # Requests to the deprecated k8s authenticator. TODO(@team-bigmac): Get rid of this recording rule when the component is no longer used.


### PR DESCRIPTION
Team Atlas, please check if this can work as-is, and makes sense. The `resource-police` app queries this aggregated metric and I'd like it to post the namespace (`org-xxx`) to chat as well (see Slack channel `#noise-resource-police`).

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
