### PR TITLE
Update sensitivity of PrometheusAgentShardsMissing alert

### DIFF
--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
@@ -112,7 +112,7 @@ spec:
             or prometheus_operator_spec_replicas{controller="prometheus",name="prometheus-agent"}
           ) by (cluster_id, installation, provider, pipeline)
         )[5m:])
-      for: 20m
+      for: 40m
       labels:
         area: platform
         severity: page

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -143,7 +143,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -247,7 +247,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -113,7 +113,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -217,7 +217,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -113,7 +113,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -217,7 +217,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -113,7 +113,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -217,7 +217,7 @@ tests:
       - alertname: PrometheusAgentShardsMissingInhibition
         eval_time: 40m
       - alertname: PrometheusAgentShardsMissing
-        eval_time: 100m
+        eval_time: 120m
         exp_alerts:
           - exp_labels:
               area: platform


### PR DESCRIPTION
towards multiple alerts due to sensitivity of the rules:
https://gigantic.slack.com/archives/C04UMF3KV3K/p1722414826013869

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
