### PR TITLE
Added useful labels in some alert descriptions

### DIFF
--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -33,7 +33,7 @@ spec:
 
     - alert: WorkloadClusterAPIServerAdmissionWebhookErrors
       annotations:
-        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'
+        description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors (webhook: {{ $labels.name }}).`}}'
         opsrecipe: apiserver-admission-webhook-errors/
       expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="workload_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
       for: 5m

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.management-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
     rules:
     - alert: ManagementClusterEtcdDown
       annotations:
-        description: '{{`Etcd ({{ $labels.ip }}) is down.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} is down.`}}'
         opsrecipe: etcd-down/
       expr: up{app="etcd", cluster_type="management_cluster"} == 0
       for: 10m
@@ -30,7 +30,7 @@ spec:
         topic: etcd
     - alert: ManagementClusterEtcdCommitDurationTooHigh
       annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high commit duration.`}}'
         opsrecipe: etcd-high-commit-duration/
       expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider!="eks"}[5m])) > 1.0
       for: 15m
@@ -42,7 +42,7 @@ spec:
         topic: etcd
     - alert: ManagementClusterEtcdDBSizeTooLarge
       annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
       expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="management_cluster", provider!="eks"} / etcd_server_quota_backend_bytes{cluster_type="management_cluster", provider!="eks"}) * 100 > 80
       for: 90m
@@ -54,7 +54,7 @@ spec:
         topic: etcd
     - alert: ManagementClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
-        description: '{{`Etcd has too many leader changes.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has too many leader changes.`}}'
       expr: increase(etcd_server_leader_changes_seen_total{cluster_type="management_cluster", provider!="eks"}[1h]) > 8
       labels:
         area: kaas
@@ -64,7 +64,7 @@ spec:
         topic: etcd
     - alert: ManagementClusterEtcdHasNoLeader
       annotations:
-        description: '{{`Etcd has no leader.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
       expr: etcd_server_has_leader{cluster_type="management_cluster", provider!="eks"} == 0
       for: 5m

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.workload-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
     rules:
     - alert: WorkloadClusterEtcdDown
       annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) on workload cluster {{ $labels.cluster_id }} is down.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} is down.`}}'
         opsrecipe: etcd-down/
       expr: up{cluster_type="workload_cluster", app="etcd", provider!="eks"} == 0
       for: 20m
@@ -31,7 +31,7 @@ spec:
         topic: etcd
     - alert: WorkloadClusterEtcdCommitDurationTooHigh
       annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high commit duration.`}}'
         opsrecipe: etcd-high-commit-duration/
       expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider!="eks"}[5m])) > 1.0
       for: 15m
@@ -43,7 +43,7 @@ spec:
         topic: etcd
     - alert: WorkloadClusterEtcdDBSizeTooLarge
       annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
       expr: (etcd_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster", provider!="eks"} / etcd_server_quota_backend_bytes{cluster_type="workload_cluster", provider!="eks"}) * 100 > 80
       for: 15m
@@ -55,7 +55,7 @@ spec:
         topic: etcd
     - alert: WorkloadClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
-        description: '{{`Etcd has too many leader changes.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has too many leader changes.`}}'
       expr: increase(etcd_server_leader_changes_seen_total{cluster_type="workload_cluster", provider!="eks"}[1h]) > 8
       labels:
         area: kaas
@@ -64,7 +64,7 @@ spec:
         topic: etcd
     - alert: WorkloadClusterEtcdHasNoLeader
       annotations:
-        description: '{{`Etcd has no leader.`}}'
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
       expr: etcd_server_has_leader{cluster_type="workload_cluster", container!~"loki|promtail", provider!="eks"} == 0
       for: 35m
@@ -76,7 +76,7 @@ spec:
         topic: etcd
     - alert: WorkloadClusterEtcdMetricsMissing
       annotations:
-        description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'
+        description: '{{`Etcd metrics missing for cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
         opsrecipe: etcd-metrics-missing/
       expr: count(up{cluster_type="workload_cluster", provider!="eks"}) by (cluster_id, installation, pipeline, provider) unless count(etcd_server_id{cluster_type="workload_cluster", provider!="eks"}) by (cluster_id, installation, pipeline, provider)
       for: 1h

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node.workload-cluster.rules.yml
@@ -15,7 +15,7 @@ spec:
     rules:
     - alert: WorkloadClusterNodeIsUnschedulable
       annotations:
-        description: '{{`Node {{ $labels.node }} is unschedulable.`}}'
+        description: '{{`Node {{ $labels.node }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} is unschedulable.`}}'
         opsrecipe: node-is-unschedulable/
       expr: kube_node_spec_unschedulable != 0
       for: 45m
@@ -29,7 +29,7 @@ spec:
         topic: kubernetes
     - alert: WorkloadClusterControlPlaneNodeMissing
       annotations:
-        description: '{{`Control plane node is missing.`}}'
+        description: '{{`Control plane node in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} is missing.`}}'
         opsrecipe: master-node-missing/
       expr: count by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} unless on (node) kube_node_role{role!~"control-plane|master"}) == 0
       for: 30m
@@ -43,7 +43,7 @@ spec:
         topic: kubernetes
     - alert: WorkloadClusterHAControlPlaneDownForTooLong
       annotations:
-        description: '{{`Control plane node in HA setup is down for a long time.`}}'
+        description: '{{`Control plane node in HA cluster {{ $labels.installation }}/{{ $labels.cluster_id }} is down for a long time.`}}'
         opsrecipe: master-node-missing/
       expr: sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (cluster_id, node) group_left kube_node_role{role="control-plane"}) == 2 or sum by (cluster_id, installation, pipeline, provider) (kubernetes_build_info{app="kubelet"} * on (cluster_id, node) group_left kube_node_role{role="master"}) == 2
       for: 30m
@@ -66,7 +66,7 @@ spec:
       # unless,
       # the load over 15 minutes divided by number of CPUs is higher than 2 (the node is overloaded).
       annotations:
-        description: '{{`Node {{ $labels.node }} status is flapping under load.`}}'
+        description: '{{`Node {{ $labels.node }} status is flapping under load in cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
       expr: |
         (
           sum(node_load15{cluster_type="workload_cluster"})
@@ -92,7 +92,7 @@ spec:
       # Check if a core component is restarted because memory reasons
       # in the last hour.
       annotations:
-        description: '{{`Node {{ $labels.ip }} has constant OOM kills.`}}'
+        description: '{{`Node {{ $labels.ip }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has constant OOM kills.`}}'
       expr: kube_pod_container_status_restarts_total{cluster_type="workload_cluster", namespace=~"(giantswarm|kube-system)"} - kube_pod_container_status_restarts_total{cluster_type="workload_cluster"} offset 1h >= 1 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{cluster_type="workload_cluster", reason="OOMKilled"} > 0
       for: 10m
       labels:
@@ -105,7 +105,7 @@ spec:
         topic: kubernetes
     - alert: NodeConnTrackAlmostExhausted
       annotations:
-        description: '{{`Node {{ $labels.node }} reports a connection usage above 85% for the last 15 minutes.`}}'
+        description: '{{`Node {{ $labels.node }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} reports a connection usage above 85% for the last 15 minutes.`}}'
         opsrecipe: node-conntrack-limits/
       expr: node_nf_conntrack_entries{cluster_type="workload_cluster"} / node_nf_conntrack_entries_limit{cluster_type="workload_cluster"} >= 0.85
       for: 15m
@@ -117,7 +117,7 @@ spec:
         topic: kubernetes
     - alert: MachineEntropyTooLow
       annotations:
-        description: '{{`Machine {{ $labels.instance }} entropy is too low.`}}'
+        description: '{{`Machine {{ $labels.instance }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} entropy is too low.`}}'
         opsrecipe: low-entropy/
       expr: node_entropy_available_bits{cluster_type="workload_cluster"} < 250
       for: 10m
@@ -129,7 +129,7 @@ spec:
         topic: infrastructure
     - alert: MachineAllocatedFileDescriptorsTooHigh
       annotations:
-        description: '{{`Machine {{ $labels.instance }} has too many allocated file descriptors.`}}'
+        description: '{{`Machine {{ $labels.instance }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has too many allocated file descriptors.`}}'
         opsrecipe: high-number-file-descriptors/
       expr: node_filefd_allocated{cluster_type="workload_cluster"} / node_filefd_maximum{cluster_type="workload_cluster"} * 100 > 80
       for: 15m
@@ -141,7 +141,7 @@ spec:
         topic: infrastructure
     - alert: WorkloadClusterMasterMemoryUsageTooHigh
       annotations:
-        description: '{{`Machine {{ $labels.instance }} memory usage is too high (less than 10% and 2G of allocatable memory).`}}'
+        description: '{{`Machine {{ $labels.instance }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} memory usage is too high (less than 10% and 2G of allocatable memory).`}}'
         opsrecipe: master-machine-usage-too-high/
       expr: |-
         ( ( (

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/pods.core.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/pods.core.rules.yml
@@ -15,7 +15,7 @@ spec:
     rules:
     - alert: ContainerIsRestartingTooFrequently
       annotations:
-        description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
+        description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often in cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
         opsrecipe: container-is-restarting-too-often/
       expr: label_join(increase(kube_pod_container_status_restarts_total{container=~"cluster-autoscaler.*|etcd-kubernetes-resources-count-exporter.*"}[1h]), "service", "/", "namespace", "pod") > 10
       for: 10m
@@ -31,7 +31,7 @@ spec:
         topic: kubernetes
     - alert: PodPending
       annotations:
-        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
+        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending in cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
         opsrecipe: pod-stuck-in-pending/
       expr: kube_pod_status_phase{namespace="kube-system",pod=~"(cluster-autoscaler.*)",phase="Pending"} == 1
       for: 15m


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/2728

This PR changes description of some alerts adding useful labels.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
