### PR TITLE
update grafana cloud's clusters recording rules to work with capi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `clusters.grafana-cloud.recording` recording rules to work with capi.
+
 ## [4.9.1] - 2024-08-06
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -121,19 +121,27 @@ spec:
           {{- end }}
         )
       record: aggregation:giantswarm:cluster_info
+    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
     - expr: sum(cluster_service_cluster_info) by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region) / 2 or sum(cluster_operator_cluster_status{release_version!=""}) by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:giantswarm:cluster_release_version
     - expr: avg_over_time(cluster_operator_cluster_create_transition[1w])
       record: aggregation:giantswarm:cluster_transition_create
     - expr: avg_over_time(cluster_operator_cluster_update_transition[1w])
       record: aggregation:giantswarm:cluster_transition_update
+    {{- else }}
+    # TODO
+    {{- end }}
     # Scheduled cluster upgrade times
     - expr: upgrade_schedule_operator_cluster_scheduled_upgrades_time
       record: aggregation:giantswarm:cluster_scheduled_upgrades_time
   - name: docker.grafana-cloud.recording
     rules:
+    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
     - expr: sum(engine_daemon_image_actions_seconds_count) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, action)
       record: aggregation:docker:action_count
+    {{- else }}
+    # TODO
+    {{- end }}
     - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) 
       record: aggregation:docker:containers_using_dockerhub_image
     - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) / sum(kube_pod_container_info{} or kube_pod_init_container_info{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3634

This PR updates the `clusters.grafana-cloud.recording` recording rules to work with CAPI so that the dashboards mentioned in the issue can have CAPI clusters' data .

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
