### PR TITLE
Fix prometheus agent failing alert for multi-provider mcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Alloy to 0.3.1
 
+### Fixed
+
+- Fix Prometheus Agent Failing alert for Multi-provider MCs.
+
 ## [4.9.1] - 2024-08-06
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/kube-state-metrics.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/kube-state-metrics.rules.yml
@@ -30,16 +30,16 @@ spec:
       expr: |-
         count by (cluster_id, installation, provider, pipeline) (label_replace(up{job="kube-state-metrics", instance=~".*:8080"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*")) == 0
         or (
-              label_replace(
-                  capi_cluster_status_condition{type="ControlPlaneReady", status="True"},
-                  "cluster_id",
-                  "$1",
-                  "name",
-                  "(.*)"
-                ) == 1
-              ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-                count(up{job="kube-state-metrics", instance=~".*:8080"} == 1) by (cluster_id, customer, installation, pipeline, provider, region)
-          )
+          label_replace(
+            capi_cluster_status_condition{type="ControlPlaneReady", status="True"},
+            "cluster_id",
+            "$1",
+            "name",
+            "(.*)"
+          ) == 1
+        ) unless on (cluster_id) (
+          count(up{job="kube-state-metrics", instance=~".*:8080"} == 1) by (cluster_id)
+        )
       {{- end }}
       for: 15m
       labels:
@@ -112,8 +112,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_configmap_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_configmap_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -140,8 +140,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_daemonset_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_daemonset_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -168,8 +168,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_deployment_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_deployment_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -196,8 +196,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_endpoint_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_endpoint_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -224,8 +224,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_namespace_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_namespace_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -252,8 +252,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_node_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_node_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -280,8 +280,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_pod_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_pod_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -308,8 +308,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_replicaset_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_replicaset_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -336,8 +336,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_secret_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_secret_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m
@@ -364,8 +364,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(kube_secret_created{}) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(kube_service_created{}) by (cluster_id)
         )
       {{- end }}
       for: 30m

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
@@ -37,8 +37,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(up{job="prometheus-agent"} > 0) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(up{job="prometheus-agent"} > 0) by (cluster_id)
         )
       {{- end }}
       for: 20m
@@ -78,8 +78,8 @@ spec:
             "name",
             "(.*)"
           ) == 1
-        ) unless on (cluster_id, customer, installation, pipeline, provider, region) (
-          count(up{job="prometheus-agent"} > 0) by (cluster_id, customer, installation, pipeline, provider, region)
+        ) unless on (cluster_id) (
+          count(up{job="prometheus-agent"} > 0) by (cluster_id)
         )
       {{- end }}
       for: 2m

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 
 # let's have reproducable tests - pin to specific versions
-ARCHITECT_VERSION="6.8.0"
-PROMETHEUS_VERSION="2.41.0"
-HELM_VERSION="3.9.0"
-YQ_VERSION="4.26.1"
+ARCHITECT_VERSION="6.17.0"
+PROMETHEUS_VERSION="2.54.0"
+HELM_VERSION="3.1.0"
+YQ_VERSION="4.44.3"
 JQ_VERSION="1.7.1"
-PINT_VERSION="0.58.1"
+PINT_VERSION="0.64.0"
 
 GIT_WORKDIR=$(git rev-parse --show-toplevel)
 

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -9,7 +9,7 @@ tests:
     input_series:
       - series: 'up{instance="prometheus-agent",cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", job="prometheus-agent"}'
         values: "_x60  0+0x60 1+0x60"
-      - series: 'capi_cluster_status_condition{ cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
+      - series: 'capi_cluster_status_condition{cluster_id="gauss", cluster_type="workload_cluster", installation="myinstall", customer="giantswarm", pipeline="testing", provider="capa", region="eu-west-2", status="True", type="ControlPlaneReady", name="gauss"}'
         values: "1+0x180"
     alert_rule_test:
       - alertname: PrometheusAgentFailing


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes issues with prometheus-agent-failing alert on multi-provider MCs because the provider label is not the same between cluster-api-monitoring metrics and the WC metrics.

@giantswarm/team-atlas if you find a better solution, we can definitely revert it :)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
