### PR TITLE
Assign alerts on core components directly to turtles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Assign alerts on core components directly to turtles.
+
 ## [4.10.0] - 2024-08-20
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.management-cluster.rules.yml
@@ -30,7 +30,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: managementcluster
     - alert: ManagementClusterAPIServerAdmissionWebhookErrors
       annotations:
@@ -42,7 +42,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: managementcluster
     - alert: ManagementClusterWebhookDurationExceedsTimeout
       annotations:
@@ -54,5 +54,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: managementcluster

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -28,7 +28,7 @@ spec:
         cancel_if_cluster_with_notready_nodepools: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes
 
     - alert: WorkloadClusterAPIServerAdmissionWebhookErrors
@@ -41,7 +41,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes
 
     # Webhooks that are not explicitely owner by any team (customer owned ones).

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.management-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: ManagementClusterEtcdCommitDurationTooHigh
       annotations:
@@ -38,7 +38,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: ManagementClusterEtcdDBSizeTooLarge
       annotations:
@@ -50,7 +50,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: ManagementClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
@@ -60,7 +60,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: ManagementClusterEtcdHasNoLeader
       annotations:
@@ -72,7 +72,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: ManagementClusterEtcdMetricsMissing
       annotations:
@@ -84,6 +84,6 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
 

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcd.workload-cluster.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_control_plane_node_down: "true"
         cancel_if_kubelet_down: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: WorkloadClusterEtcdCommitDurationTooHigh
       annotations:
@@ -39,7 +39,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: WorkloadClusterEtcdDBSizeTooLarge
       annotations:
@@ -51,7 +51,7 @@ spec:
         area: kaas
         severity: page
         cancel_if_outside_working_hours: "true"
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: WorkloadClusterEtcdNumberOfLeaderChangesTooHigh
       annotations:
@@ -60,7 +60,7 @@ spec:
       labels:
         area: kaas
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: WorkloadClusterEtcdHasNoLeader
       annotations:
@@ -72,7 +72,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd
     - alert: WorkloadClusterEtcdMetricsMissing
       annotations:
@@ -84,5 +84,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/etcdbackup.rules.yml
@@ -23,7 +23,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd-backup
     - alert: LatestETCDBackup2DaysOld
       annotations:
@@ -42,7 +42,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd-backup
     - alert: ETCDBackupMetricsMissing
       annotations:
@@ -54,5 +54,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: etcd-backup

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/fairness.rules.yml
@@ -19,7 +19,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{include "providerTeam" .}}
+        team: turtles
         topic: kubernetes
     - alert: FlowcontrolTooManyRequests
       annotations:
@@ -31,5 +31,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{include "providerTeam" .}}
+        team: turtles
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/kubelet.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/kubelet.rules.yml
@@ -25,7 +25,7 @@ spec:
           cancel_if_outside_working_hours: "true"
           cancel_if_prometheus_agent_down: "true"
           severity: page
-          team: {{ include "providerTeam" . }}
+          team: turtles
           topic: kubernetes
   - name: kubelet
     rules:
@@ -56,7 +56,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
@@ -70,7 +70,7 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
@@ -84,5 +84,5 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         cancel_if_kubelet_down: "true"
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/net-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/net-exporter.rules.yml
@@ -19,5 +19,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: observability

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node-exporter.rules.yml
@@ -20,5 +20,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: observability

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/pods.core.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/pods.core.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: kubernetes
     - alert: PodPending
       annotations:
@@ -44,5 +44,5 @@ spec:
         cancel_if_kube_state_metrics_down: "true"
         cancel_if_cluster_has_no_workers: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
 

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/storage.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/storage.management-cluster.rules.yml
@@ -23,7 +23,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: ContainerdVolumeSpaceTooLow
       annotations:
@@ -37,7 +37,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -49,7 +49,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -66,7 +66,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -80,7 +80,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -92,7 +92,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: PersistentVolumeSpaceTooLow
       annotations:
@@ -131,5 +131,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/storage.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/storage.workload-cluster.rules.yml
@@ -22,7 +22,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
       annotations:
@@ -34,7 +34,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: KubeletVolumeSpaceTooLow
       annotations:
@@ -50,7 +50,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: LogVolumeSpaceTooLow
       annotations:
@@ -63,7 +63,7 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
@@ -74,5 +74,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: storage

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/systemd.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/systemd.rules.yml
@@ -21,7 +21,7 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: infrastructure
     - alert: ClusterDisabledSystemdUnitActive
       annotations:
@@ -33,5 +33,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: {{ include "providerTeam" . }}
+        team: turtles
         topic: infrastructure


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2728 / https://github.com/giantswarm/giantswarm/issues/31439

This PR assigns alerts on basic components to turtles directly. 

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
