### PR TITLE
Ignore new `watchdog` collector of node-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Assign alerts on core components directly to turtles.
 
+### Fixed
+
+- Ignore new `watchdog` collector of node-exporter since our clusters will not have data for these devices and therefore the `node_scrape_collector_success` metric would be 0
+
 ## [4.10.0] - 2024-08-20
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/node-exporter.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`NodeExporter Collector {{ $labels.collector }} on {{ $labels.instance }} is failed.`}}'
         opsrecipe: node-exporter-device-error/
-      expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme"} == 0
+      expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme|watchdog"} == 0
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
I got alerted about this. The problem exists since we [bumped node-exporter](https://github.com/giantswarm/node-exporter-app/releases/tag/v1.20.0) to a newer upstream version that has a new exporter for _watchdog_. Neither vintage nor CAPA cluster nodes have `/sys/classes/watchdog` – I guess because there are no hardware – so the exporter can't collect data. Ignore it, just like other hardware stuff.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
