### PR TITLE
alertmanager: add link to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- alertmanager alerts: add link to dashboard
+
 ### Fixed
 
 - Fix PromtailRequestError to also account for 4xx and -1 errors (https://github.com/giantswarm/giantswarm/issues/31387).

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alertmanager.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alertmanager.rules.yml
@@ -21,6 +21,7 @@ spec:
       for: 45m
       labels:
         area: platform
+        dashboard: alertmanager-overview/alertmanager-overview
         severity: page
         team: atlas
         topic: monitoring
@@ -34,6 +35,7 @@ spec:
       for: 30m
       labels:
         area: platform
+        dashboard: alertmanager-overview/alertmanager-overview
         severity: notify
         team: atlas
         topic: monitoring

--- a/test/tests/providers/global/platform/atlas/alerting-rules/alertmanager.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/alertmanager.rules.test.yml
@@ -25,6 +25,7 @@ tests:
               area: platform
               cancel_if_outside_working_hours: "true"
               cluster_type: management_cluster
+              dashboard: alertmanager-overview/alertmanager-overview
               integration: slack
               severity: page
               team: atlas
@@ -51,6 +52,7 @@ tests:
           - exp_labels:
               area: platform
               cluster_type: management_cluster
+              dashboard: alertmanager-overview/alertmanager-overview
               integration: opsgenie
               severity: notify
               team: atlas


### PR DESCRIPTION
This PR adds a link to alertmanager dashboard for alertmanager alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
