### PR TITLE
add MimirHPANeedsToBeScaledUp alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `MimirHPANeedsToBeScaledUp` alert, to detect when Mimir's HPAs have reached maximum capacity.
+- Add `MimirHPAReachedMaxReplicas` alert, to detect when Mimir's HPAs have reached maximum capacity.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MimirHPANeedsToBeScaledUp` alert, to detect when Mimir's HPAs have reached maximum capacity.
+
 ### Changed
 
 - alertmanager alerts: add link to dashboard

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -143,9 +143,9 @@ spec:
         opsrecipe: mimir-ingester/
       expr: |-
         (
-          kube_horizontalpodautoscaler_status_desired_replicas{namespace="mimir"} /
+          kube_horizontalpodautoscaler_status_desired_replicas{namespace="mimir"} >=
           on(cluster_id, customer, installation, namespace, horizontalpodautoscaler)
-          kube_horizontalpodautoscaler_spec_max_replicas{namespace="mimir"} >= 1.0
+          kube_horizontalpodautoscaler_spec_max_replicas{namespace="mimir"}
         )
         and on(cluster_id, customer, installation, namespace, horizontalpodautoscaler)
         (

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -137,7 +137,7 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    - alert: MimirHPANeedsToBeScaledUp
+    - alert: MimirHPAReachedMaxReplicas
       annotations:
         description: '{{`Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up.`}}'
         opsrecipe: mimir-ingester/

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -137,4 +137,30 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirHPANeedsToBeScaledUp
+      annotations:
+        description: '{{`Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up.`}}'
+        opsrecipe: mimir-ingester/
+      expr: |-
+        (
+          kube_horizontalpodautoscaler_status_desired_replicas{namespace="mimir"} /
+          on(cluster_id, customer, installation, namespace, horizontalpodautoscaler)
+          kube_horizontalpodautoscaler_spec_max_replicas{namespace="mimir"} >= 1.0
+        )
+        and on(cluster_id, customer, installation, namespace, horizontalpodautoscaler)
+        (
+          kube_horizontalpodautoscaler_status_target_metric{namespace="mimir"} >
+          on(cluster_id, customer, installation, namespace, horizontalpodautoscaler, metric_name, metric_target_type)
+          kube_horizontalpodautoscaler_spec_target_metric{namespace="mimir"}
+        )
+      for: 30m
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
 {{- end }}

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -321,6 +321,7 @@ tests:
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledDown
         eval_time: 280m 
+  # Test for MimirHPAReachedMaxReplicas alert
   - interval: 1m
     input_series:
       # HPA max replicas = 3 for the whole test

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -318,3 +318,65 @@ tests:
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledDown
         eval_time: 280m 
+  - interval: 1m
+    input_series:
+      # HPA max replicas = 3 for the whole test
+      # HPA target metric = 90% for the whole test
+      # Cases:
+      #   desired_replicas < max_replicas AND current_utilization < target_utilization does not fire
+      #   desired_replicas < max_replicas AND current_utilization = target_utilization does not fire
+      #   desired_replicas < max_replicas AND current_utilization > target_utilization does not fire
+      #   desired_replicas = max_replicas AND current_utilization < target_utilization does not fire
+      #   desired_replicas = max_replicas AND current_utilization = target_utilization does not fire
+      #   desired_replicas = max_replicas AND current_utilization > target_utilization does fire
+      #   desired_replicas > max_replicas AND current_utilization < target_utilization does not fire
+      #   desired_replicas > max_replicas AND current_utilization = target_utilization does not fire
+      #   desired_replicas > max_replicas AND current_utilization > target_utilization does fire
+      - series: 'kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="mimir-distributor", namespace="mimir"}'
+        values: '3+0x360'
+      - series: 'kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="mimir-distributor", namespace="mimir"}'
+        values: '2+0x120 3+0x120 4+0x120'
+      - series: 'kube_horizontalpodautoscaler_spec_target_metric{horizontalpodautoscaler="mimir-distributor", namespace="mimir", metric_name="cpu", metric_target_type="utilization"}'
+        values: '90+0x360'
+      # HPA current metric = 80% for 10mn, then increase to 90% for 10mn
+      - series: 'kube_horizontalpodautoscaler_status_target_metric{horizontalpodautoscaler="mimir-distributor", namespace="mimir", metric_name="cpu", metric_target_type="utilization"}'
+        values: '80+0x40 90+0x40 100+0x40 80+0x40 90+0x40 100+0x40 80+0x40 90+0x40 100+0x40'
+    alert_rule_test:
+      - alertname: MimirHPAReachedMaxReplicas
+        eval_time: 234m
+      - alertname: MimirHPAReachedMaxReplicas
+        eval_time: 235m
+        exp_alerts:
+          -  exp_labels:
+               area: platform
+               cancel_if_cluster_status_creating: "true"
+               cancel_if_cluster_status_deleting: "true"
+               cancel_if_cluster_status_updating: "true"
+               cancel_if_outside_working_hours: "true"
+               severity: page
+               team: atlas
+               topic: observability
+               horizontalpodautoscaler: mimir-distributor
+               namespace: mimir
+             exp_annotations:
+               description: "Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up."
+               opsrecipe: "mimir-ingester/"
+      - alertname: MimirHPAReachedMaxReplicas
+        eval_time: 246m
+      - alertname: MimirHPAReachedMaxReplicas
+        eval_time: 360m
+        exp_alerts:
+          -  exp_labels:
+               area: platform
+               cancel_if_cluster_status_creating: "true"
+               cancel_if_cluster_status_deleting: "true"
+               cancel_if_cluster_status_updating: "true"
+               cancel_if_outside_working_hours: "true"
+               severity: page
+               team: atlas
+               topic: observability
+               horizontalpodautoscaler: mimir-distributor
+               namespace: mimir
+             exp_annotations:
+               description: "Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up."
+               opsrecipe: "mimir-ingester/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31385

This PR adds `MimirHPANeedsToBeScaledUp` alert in order to detect when an HorizontalPodAutoscaler in the mimir namespace has reached its maximum capacity; meaning replicas are maxed out and resources usage is above targets.

For this alert I used the `kube_horizontalpodautoscaler_*` metrics provided by Kubernetes:
* first part of the query detects when the current desired replicas has reached the maximum allowed replicas
* second part of the query detects when the current metrics value used for autscaling (cpu or memory) is above target. When both conditions are met the alert fires.