### PR TITLE
Send sloth slos to grafana cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add aggregations for slo metrics to export them to grafana cloud
+
 ## [4.13.1] - 2024-09-03
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -549,7 +549,7 @@ spec:
 {{- end }}
   - name: slos.grafana-cloud.recording
     rules:
-      # Let's not send the slo:sli_error:ratio_rate30d rule to Grafana Cloud as it's not useful for the SLOs dashboard.
+      # Let's not send the slo:sli_error:ratio_rate30d nor the slo:sli_error:ratio_rate3d rule to Grafana Cloud as it's not useful for the SLOs dashboard.
       - expr: sum(slo:current_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
         record: aggregation:slo:current_burn_rate:ratio
       - expr: |-
@@ -688,23 +688,6 @@ spec:
             )
           ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
         record: aggregation:slo:sli_error:ratio_rate30m
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
-                slo:sli_error:ratio_rate3d,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate3d
       - expr: |-
           sum(
             label_replace(

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -549,7 +549,7 @@ spec:
 {{- end }}
   - name: slos.grafana-cloud.recording
     rules:
-      # Let's not send the slo:sli_error:ratio_rate30d nor the slo:sli_error:ratio_rate3d rule to Grafana Cloud as it's not useful for the SLOs dashboard.
+      # Let's not send any of the slo:sli_error:ratio_ratexxx metrics but the slo:sli_error:ratio_rate5m rule to Grafana Cloud as it's not useful for the SLOs dashboard.
       - expr: sum(slo:current_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
         record: aggregation:slo:current_burn_rate:ratio
       - expr: |-
@@ -624,74 +624,6 @@ spec:
           sum(
             label_replace(
               label_replace(
-                slo:sli_error:ratio_rate1d,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate1d
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
-                sli_error:ratio_rate1h,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate1h
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
-                sli_error:ratio_rate2h,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate2h
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
-                sli_error:ratio_rate30m,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate30m
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
                 slo:sli_error:ratio_rate5m,
                 "slo",
                 "$1",
@@ -705,23 +637,6 @@ spec:
             )
           ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
         record: aggregation:slo:sli_error:ratio_rate5m
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
-                slo:sli_error:ratio_rate6h,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:sli_error:ratio_rate6h
       - expr: |-
           sum(
             label_replace(

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -547,3 +547,212 @@ spec:
       - expr: sum(capi_crd_info{resource_name=~".*infrastructure.cluster.x-k8s.io.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, version)
         record: aggregation:capi_infrastructure_crd_versions
 {{- end }}
+  - name: slos.grafana-cloud.recording
+    rules:
+      # Let's not send the slo:sli_error:ratio_rate30d rule to Grafana Cloud as it's not useful for the SLOs dashboard.
+      - expr: sum(slo:current_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:current_burn_rate:ratio
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:error_budget:ratio,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:error_budget:ratio
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:objective:ratio,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:objective:ratio
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:period_burn_rate:ratio,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:period_burn_rate:ratio
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:period_error_budget_remaining:ratio,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:period_error_budget_remaining:ratio
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:sli_error:ratio_rate1d,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate1d
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                sli_error:ratio_rate1h,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate1h
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                sli_error:ratio_rate2h,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate2h
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                sli_error:ratio_rate30m,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate30m
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:sli_error:ratio_rate3d,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate3d
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:sli_error:ratio_rate5m,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate5m
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:sli_error:ratio_rate6h,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:sli_error:ratio_rate6h
+      - expr: |-
+          sum(
+            label_replace(
+              label_replace(
+                slo:time_period:days,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+        record: aggregation:slo:time_period:days


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/31098
This PR creates aggretation for sloth slos so we do not have too high cardinality based on pod, node and instance labels for instance. I will try them out on a test installation first to see the load

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
