### PR TITLE
add MimirCompactorFailedCompaction alerting rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MimirCompactorFailedCompaction` alert.
+
 ## [4.13.2] - 2024-09-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -137,4 +137,19 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirCompactorFailedCompaction
+      annotations:
+        description: 'Mimir compactor has been failing its compactions for 2 hours.'
+        opsrecipe: mimir/
+      expr: sum(increase(cortex_compactor_runs_failed_total[1h])) by (cluster_id, installation, namespace, pipeline, provider) > 0
+      for: 2h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
 {{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -141,6 +141,7 @@ spec:
       annotations:
         description: 'Mimir compactor has been failing its compactions for 2 hours.'
         opsrecipe: mimir/
+      # Query is based on the following upstream mixin alerting rule : https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/alerts.yaml#L858
       expr: sum(increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h])) by (cluster_id, installation, namespace, pipeline, provider) > 2
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -141,8 +141,7 @@ spec:
       annotations:
         description: 'Mimir compactor has been failing its compactions for 2 hours.'
         opsrecipe: mimir/
-      expr: sum(increase(cortex_compactor_runs_failed_total[1h])) by (cluster_id, installation, namespace, pipeline, provider) > 0
-      for: 2h
+      expr: sum(increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h])) by (cluster_id, installation, namespace, pipeline, provider) > 2
       labels:
         area: platform
         cancel_if_cluster_status_creating: "true"

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -318,3 +318,38 @@ tests:
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledDown
         eval_time: 280m 
+  # Test for MimirCompactorFailedCompaction alert
+  - interval: 1m
+    input_series:
+      # mimir-ingester real memory usage gradually decreases until it goes below 30% of the memory requests.
+      - series: 'cortex_compactor_runs_failed_total{reason="error", installation="golem", cluster_id="golem", namespace="mimir", pipeline="testing", provider="capa"}'
+        values: "8+0x20 1+0x40 0+0x20 4+0x130 0+0x190"                             
+    alert_rule_test:
+      - alertname: MimirCompactorFailedCompaction
+        eval_time: 15m 
+      - alertname: MimirCompactorFailedCompaction
+        eval_time: 55m 
+      - alertname: MimirCompactorFailedCompaction
+        eval_time: 120m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: golem
+              installation: "golem"
+              pipeline: "testing"
+              provider: "capa"
+              namespace: mimir
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: Mimir compactor has been failing its compactions for 2 hours.
+              opsrecipe: "mimir/"
+      - alertname: MimirCompactorFailedCompaction
+        eval_time: 205m 
+      - alertname: MimirCompactorFailedCompaction
+        eval_time: 350m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31557

This PR aims at providing a simple alerting rule for mimir's compactor so that we get alerted whenever the compactor has been failing its job for 2 hours straight.

Before spending time adding UTs, I'd like your opinion on this query. 

I was also thinking about adding another alerting rule for when the compactor hasn't **failed** but just didn't run for too long.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
