### PR TITLE
increase MimirIngesterNeedsToBeScaledUp alert's time to trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase `MimirIngesterNeedsToBeScaledUp` alert's time to trigger from 30m to 1h.
+
 ## [4.13.2] - 2024-09-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -103,7 +103,7 @@ spec:
           / 
         sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="ingester", namespace="mimir", unit="core"}) 
           >= 0.90
-      for: 30m
+      for: 1h
       labels:
         area: platform
         cancel_if_cluster_status_creating: "true"

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -175,29 +175,29 @@ tests:
     input_series:
       # mimir-ingester real memory usage gradually increases until it goes beyond 90% of the memory requests.
       - series: 'container_memory_working_set_bytes{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "8+0x20 11+0x40 8+0x140 11+0x40 8+0x60"
+        values: "8+0x20 11+0x70 8+0x140 11+0x70 8+0x60"
       - series: 'container_memory_working_set_bytes{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "8+0x20 11+0x40 8+0x140 11+0x40 8+0x60"
+        values: "8+0x20 11+0x70 8+0x140 11+0x70 8+0x60"
       # mimir-ingester memory requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "12+0x300"
+        values: "12+0x400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "12+0x300"
+        values: "12+0x400"
       # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "0+60x100 6000+110x40 10400+60x60 14000+110x40 18400+60x60"
+        values: "0+60x100 6000+110x70 10400+60x60 14000+110x70 18400+60x60"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "0+60x300"
+        values: "0+60x400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "1.5+0x300"                                 
+        values: "1.5+0x400"                                 
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "1.5+0x300"                                 
+        values: "1.5+0x400"                                 
     alert_rule_test:
       - alertname: MimirIngesterNeedsToBeScaledUp
         eval_time: 15m
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 55m
+        eval_time: 85m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -217,9 +217,9 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 100m
+        eval_time: 130m
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 140m 
+        eval_time: 170m 
         exp_alerts:
           - exp_labels:
               area: platform
@@ -239,9 +239,9 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 180m
+        eval_time: 210m
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 235m
+        eval_time: 295m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -261,7 +261,7 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               opsrecipe: "mimir-ingester/"
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 280m
+        eval_time: 350m
   # Test for MimirIngesterNeedsToBeScaledDown alert
   - interval: 1m
     input_series:


### PR DESCRIPTION
This PR increase the MimirIngesterNeedsToBeScaledUp alert's time to trigger from 30m to 1h to avoid getting paged too often when it's not needed (for example with grizzly when e2e clusters are created). 

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
