### PR TITLE
mimir: add dashboards to alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added dashboards to several mimir alerts
+
 ## [4.14.0] - 2024-09-05
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -41,6 +41,7 @@ spec:
         # This label is used to ensure the alert go through even for non-stable installations
         all_pipelines: "true"
         cancel_if_outside_working_hours: "true"
+        dashboard: ffcd83628d7d4b5a03d1cafd159e6c9c/mimir-overview
         severity: page
         team: atlas
         topic: observability
@@ -56,6 +57,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        dashboard: ffcd83628d7d4b5a03d1cafd159e6c9c/mimir-overview
         severity: page
         team: atlas
         topic: observability
@@ -86,6 +88,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
         severity: page
         team: atlas
         topic: observability
@@ -149,6 +152,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
+        dashboard: 09a5c49e9cdb2f2b24c6d184574a07fd/mimir-compactor-resources
         severity: page
         team: atlas
         topic: observability

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -79,6 +79,7 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
               cluster_id: gauss
+              dashboard: ffcd83628d7d4b5a03d1cafd159e6c9c/mimir-overview
               installation: gauss
               provider: aws
               pipeline: testing
@@ -133,6 +134,7 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: golem
               cluster_type: management_cluster
+              dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
               installation: golem
               namespace: mimir
               severity: page
@@ -161,6 +163,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_type: management_cluster
               container: mimir-ingester
+              dashboard: ffcd83628d7d4b5a03d1cafd159e6c9c/mimir-overview
               namespace: mimir
               severity: page
               team: atlas
@@ -339,6 +342,7 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cancel_if_outside_working_hours: "true"
               cluster_id: golem
+              dashboard: 09a5c49e9cdb2f2b24c6d184574a07fd/mimir-compactor-resources
               installation: "golem"
               pipeline: "testing"
               provider: "capa"


### PR DESCRIPTION
During incident [#inc-2024-09-05-several-installations-mimircompactorfailedcompaction](https://gigantic.slack.com/archives/C07KP0K3PEK) I noticed the alert did not have a dashboard.
So I added some dashboards to mimir alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
