### PR TITLE
Change IRSAACMCertificateExpiringInLessThan60Days to 45 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added dashboards to several mimir alerts
+- Change `IRSAACMCertificateExpiringInLessThan60Days` to
+  `IRSAACMCertificateExpiringInLessThan45Days`. The ACM certificate is renewed
+  60 days before expiration and the alert can fire prematurely.
 
 ## [4.14.0] - 2024-09-05
 

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/irsa.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/irsa.rules.yml
@@ -31,11 +31,11 @@ spec:
         severity: page
         team: phoenix
         topic: aws
-    - alert: IRSAACMCertificateExpiringInLessThan60Days
+    - alert: IRSAACMCertificateExpiringInLessThan45Days
       annotations:
         description: '{{`IRSA ACM certificate for Cluster {{ $labels.cluster_id }} ({{ $labels.certificate_name }}) will expire in less than 2 months.`}}'
         opsrecipe: irsa-acm-certificate-expiring/
-      expr: min(irsa_operator_acm_certificate_not_after{cluster_type="management_cluster"}) by (cluster_id, installation, pipeline, provider, certificate_name) - time() < 5184000
+      expr: min(irsa_operator_acm_certificate_not_after{cluster_type="management_cluster"}) by (cluster_id, installation, pipeline, provider, certificate_name) - time() < 3888000
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
The certificate will be renewed 60 days before expiration so this alert may fire prematurely. 

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
