### PR TITLE
Remove slo:period_error_budget_remaining:ratio slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove aggregation of slo:period_error_budget_remaining:ratio` as this value can be easily computed and creates a lot of time series in Grafana Cloud
+
 ## [4.15.0] - 2024-09-16
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -607,23 +607,6 @@ spec:
           sum(
             label_replace(
               label_replace(
-                slo:period_error_budget_remaining:ratio,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
-              "$1",
-              "sloth_service",
-              "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
-        record: aggregation:slo:period_error_budget_remaining:ratio
-      - expr: |-
-          sum(
-            label_replace(
-              label_replace(
                 slo:sli_error:ratio_rate5m,
                 "slo",
                 "$1",


### PR DESCRIPTION


Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR removes the slo for `slo:period_error_budget_remaining:ratio` as this value creates 18k timeseries just to compute `1 - slo:error_budget:ratio` which makes no sense

![image](https://github.com/user-attachments/assets/9030c789-bc90-4054-bd3c-31eac82fdfd4)

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
