### PR TITLE
Fix MimirHPAReachedMaxReplicas opsrecipe link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `MimirHPAReachedMaxReplicas` opsrecipe link
+
 ## [4.15.1] - 2024-09-16
 
 ### Removed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -143,7 +143,7 @@ spec:
     - alert: MimirHPAReachedMaxReplicas
       annotations:
         description: '{{`Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up.`}}'
-        opsrecipe: mimir-ingester/
+        opsrecipe: mimir-hpa/
       expr: |-
         (
           kube_horizontalpodautoscaler_status_desired_replicas{namespace="mimir"} >=

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -364,7 +364,7 @@ tests:
                namespace: mimir
              exp_annotations:
                description: "Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up."
-               opsrecipe: "mimir-ingester/"
+               opsrecipe: "mimir-hpa/"
       - alertname: MimirHPAReachedMaxReplicas
         eval_time: 246m
       - alertname: MimirHPAReachedMaxReplicas
@@ -383,7 +383,7 @@ tests:
                namespace: mimir
              exp_annotations:
                description: "Mimir ${ labels.horizontalpodautoscaler } HPA has reached maximum replicas and consume too much resources, it needs to be scaled up."
-               opsrecipe: "mimir-ingester/"
+               opsrecipe: "mimir-hpa/"
   # Test for MimirCompactorFailedCompaction alert
   - interval: 1m
     input_series:


### PR DESCRIPTION
Update the opsrecipe for MimirHPAReachedMaxReplicas to point to https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir-hpa/