### PR TITLE
fix slo_current_burn_rate_ratio slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update `MimirHPAReachedMaxReplicas` opsrecipe link
+- Fix aggregation rule of the `slo:current_burn_rate:ratio` slo.
 
 ## [4.15.1] - 2024-09-16
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -550,7 +550,21 @@ spec:
   - name: slos.grafana-cloud.recording
     rules:
       # Let's not send any of the slo:sli_error:ratio_ratexxx metrics but the slo:sli_error:ratio_rate5m rule to Grafana Cloud as it's not useful for the SLOs dashboard.
-      - expr: sum(slo:current_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+      - expr: sum(
+            label_replace(
+              label_replace(
+                slo:current_burn_rate:ratio,
+                "slo",
+                "$1",
+                "sloth_id",
+                "(.*)"
+              ),
+              "service",
+              "$1",
+              "sloth_service",
+              "(.*)"
+            )
+          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
         record: aggregation:slo:current_burn_rate:ratio
       - expr: |-
           sum(


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the slo_current_burn_rate_ratio  recording rules to grafana cloud as I forgot to relabel the sloth_id and sloth_service in this rules and this lead to some bad data on grafana cloud.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
