### PR TITLE
replace removed app labels for external-dns and ingress-nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Dashboard links in alertmanager and mimir rules
+- Remove useless app labels for external-dns and ingress-nginx alerts.
 
 ## [4.15.2] - 2024-09-17
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
@@ -47,7 +47,7 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: external-dns-down/
-      expr: label_replace(up{container=~"external-dns", provider=~"aws|capa|capz|eks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
+      expr: label_replace(up{container="external-dns", provider=~"aws|capa|capz|eks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
@@ -17,7 +17,7 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access registry (cloud service provider DNS service).`}}'
         opsrecipe: external-dns-cant-access-registry/
-      expr: rate(external_dns_registry_errors_total{provider="aws|capa|capz|eks"}[2m]) > 0
+      expr: rate(external_dns_registry_errors_total{provider=~"aws|capa|capz|eks"}[2m]) > 0
       for: 15m
       labels:
         area: platform
@@ -32,7 +32,7 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access source (Service or Ingress resource).`}}'
         opsrecipe: external-dns-cant-access-source/
-      expr: rate(external_dns_source_errors_total{provider="aws|capa|capz|eks"}[2m]) > 0
+      expr: rate(external_dns_source_errors_total{provider=~"aws|capa|capz|eks"}[2m]) > 0
       for: 15m
       labels:
         area: platform
@@ -47,7 +47,7 @@ spec:
       annotations:
         description: '{{`external-dns in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: external-dns-down/
-      expr: label_replace(up{app=~"external-dns-(app|monitoring)", provider="aws|capa|capz|eks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
+      expr: label_replace(up{container=~"external-dns", provider=~"aws|capa|capz|eks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -66,7 +66,7 @@ spec:
       annotations:
         description: '{{`Ingress Controller in namespace {{ $labels.namespace }}) is down.`}}'
         opsrecipe: managed-app-nginx-ic/
-      expr: label_replace(up{app=~".*(ingress-nginx|nginx-ingress-controller).*"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
+      expr: label_replace(up{pod=~".*(ingress-nginx|nginx-ingress-controller).*"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m
       labels:
         area: platform


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/27622#issuecomment-2361520576

This PR removes the deprecated app labels and fixes the external dns provider label 

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
