### PR TITLE
fix loki compactor alert dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- loki compactor alert dashboard
+
 ## [4.16.0] - 2024-09-26
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -139,7 +139,7 @@ spec:
     rules:
     - alert: LokiCompactorFailedCompaction
       annotations:
-        dashboard: loki-retention/loki-retention
+        dashboard: retention/loki-retention
         description: 'Loki compactor has been failing compactions for more than 2 hours since last compaction.'
         opsrecipe: loki#lokicompactorfailedcompaction
       # This alert checks if Loki's the last successful compaction run is older than 2 hours
@@ -156,7 +156,7 @@ spec:
         topic: observability
     - alert: LokiCompactorFailedCompaction
       annotations:
-        dashboard: loki-retention/loki-retention
+        dashboard: retention/loki-retention
         description: 'Loki compactor has been failing compactions for more than 2 hours since start-up.'
         opsrecipe: loki#lokicompactorfailedcompaction
       # This alert covers the special case at compactor startup, where the "normal" alert would always consider time `0` is more than 2 hours ago, yet we want to let it 2 hours + `for` duration.

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -253,7 +253,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: loki-retention/loki-retention
+              dashboard: retention/loki-retention
               description: Loki compactor has been failing compactions for more than 2 hours since last compaction.
               opsrecipe: "loki#lokicompactorfailedcompaction"
       - alertname: LokiCompactorFailedCompaction
@@ -284,7 +284,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: loki-retention/loki-retention
+              dashboard: retention/loki-retention
               description: Loki compactor has been failing compactions for more than 2 hours since start-up.
               opsrecipe: "loki#lokicompactorfailedcompaction"
       - alertname: LokiCompactorFailedCompaction


### PR DESCRIPTION
This PR fixes the dashboard link for `LokiCompactorFailedCompaction` alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
