### PR TITLE
Prepare removal of chart-operator

### DIFF
--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.workload-cluster.rules.yml
@@ -13,6 +13,7 @@ spec:
   groups:
   - name: deployment
     rules:
+    # TODO - This is only used by the chart-operator, let's get rid of it when the chart operator is gone.
     - alert: WorkloadClusterDeploymentNotSatisfied
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/chart.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/chart.rules.yml
@@ -1,3 +1,4 @@
+# TODO - This is only used by the chart-operator, let's get rid of it when the chart operator is gone.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/helm.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/helm.rules.yml
@@ -1,3 +1,4 @@
+# TODO - This is only used by the chart-operator, let's get rid of it when the chart operator is gone.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helm/prometheus-rules/templates/platform/honeybadger/recording-rules/helm-operations.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/recording-rules/helm-operations.rules.yml
@@ -1,3 +1,4 @@
+# TODO - This is only used by the chart-operator, let's get rid of it when the chart operator is gone.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/test/tests/providers/global/platform/honeybadger/alerting-rules/helm-operations.rules.test.yml
+++ b/test/tests/providers/global/platform/honeybadger/alerting-rules/helm-operations.rules.test.yml
@@ -1,3 +1,4 @@
+# TODO - This is only used by the chart-operator, let's get rid of it when the chart operator is gone.
 ---
 rule_files:
   - helm-operations.rules.yml


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---

This PR adds TODO comments to remember that we need to get rid of some alerts when the chart-operator is gone

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
