### PR TITLE
Alert StatefulsetNotSatisfiedAtlas alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alert `StatefulsetNotSatisfiedAtlas`
+
 ### Changed
 
 - Update alloy-app to 0.6.1. This includes:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/statefulset.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/statefulset.management-cluster.rules.yml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+{{- if not .Values.mimir.enabled }}
+    cluster_type: "management_cluster"
+{{- end }}
+  name: deployment.management-cluster.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: statefulset
+    rules:
+    - alert: StatefulsetNotSatisfiedAtlas
+      annotations:
+        description: '{{`Statefulset {{ $labels.namespace}}/{{ $labels.statefulset }} is not satisfied.`}}'
+        opsrecipe: deployment-not-satisfied/
+      expr: |-
+        kube_statefulset_status_replicas{cluster_type="management_cluster", statefulset=~"loki.*|mimir.*"}
+        - kube_statefulset_status_replicas_ready{cluster_type="management_cluster", statefulset=~"loki.*|mimir.*"}
+        > 0
+      for: 30m
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: atlas
+        topic: managementcluster

--- a/test/tests/providers/global/platform/atlas/alerting-rules/statefulset.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/statefulset.management-cluster.rules.test.yml
@@ -1,0 +1,45 @@
+---
+rule_files:
+  - statefulset.management-cluster.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'kube_statefulset_status_replicas{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", customer="giantswarm", installation="gauss", namespace="loki", organization="giantswarm", pipeline="testing", region="westeurope", statefulset="loki-write"}'
+        values: "3+0x180"
+      - series: 'kube_statefulset_status_replicas_ready{app="kube-state-metrics", cluster_id="gauss", cluster_type="management_cluster", customer="giantswarm", installation="gauss", namespace="loki", organization="giantswarm", pipeline="testing", region="westeurope", statefulset="loki-write"}'
+        values: "3+0x60 2+0x60 3+0x60"
+    alert_rule_test:
+      - alertname: StatefulsetNotSatisfiedAtlas
+        eval_time: 30m
+      - alertname: StatefulsetNotSatisfiedAtlas
+        eval_time: 60m
+      - alertname: StatefulsetNotSatisfiedAtlas
+        eval_time: 90m
+      - alertname: StatefulsetNotSatisfiedAtlas
+        eval_time: 100m
+        exp_alerts:
+          - exp_labels:
+              app: kube-state-metrics
+              area: platform
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "false"
+              cluster_id: "gauss"
+              cluster_type: management_cluster
+              customer: giantswarm
+              installation: "gauss"
+              namespace: loki
+              organization: giantswarm
+              pipeline: "testing"
+              region: westeurope
+              severity: page
+              statefulset: loki-write
+              team: atlas
+              topic: managementcluster
+            exp_annotations:
+              description: "Statefulset loki/loki-write is not satisfied."
+              opsrecipe: "deployment-not-satisfied/"
+      - alertname: StatefulsetNotSatisfiedAtlas
+        eval_time: 150m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3719

This PR an alert when a deployment has not all the expected pods running.

Related opsrecipe change here: https://github.com/giantswarm/giantswarm/pull/31903

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
