### PR TITLE
Inhibit prometheus-agent alerts when a cluster has no worker nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Modify `KyvernoWebhookHasNoAvailableReplicas` to check specifically for Kyverno resource webhook.
+- Inhibit prometheas-agent alerts when a cluster has no worker nodes (AWS vintage only for now)
 
 ## [4.19.0] - 2024-10-15
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-agent.rules.yml
@@ -51,6 +51,7 @@ spec:
         cancel_if_cluster_is_not_running_prometheus_agent: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_has_no_workers: "true"
     ## Same as PrometheusAgentFailing, but triggers inhibition earlier and does not page.
     - alert: PrometheusAgentFailingInhibition
       annotations:

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -21,6 +21,7 @@ tests:
               team: atlas
               topic: observability
               inhibit_prometheus_agent_down: "true"
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -79,6 +79,7 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -62,6 +62,7 @@ tests:
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -22,6 +22,7 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -62,6 +62,7 @@ tests:
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -22,6 +22,7 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -62,6 +62,7 @@ tests:
               inhibit_prometheus_agent_down: "true"
               installation: myinstall
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/prometheus-agent.rules.test.yml
@@ -22,6 +22,7 @@ tests:
               topic: observability
               inhibit_prometheus_agent_down: "true"
               instance: prometheus-agent
+              cancel_if_cluster_has_no_workers: "true"
               cancel_if_cluster_is_not_running_prometheus_agent: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31390

This PR prevents prometheus-agent alerts to fire when the WC has no worker nodes.
But the inhibition alert only works for AWS vintage for now.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
