### PR TITLE
Add InhibitionClusterWithoutWorkerNodes for CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added InhibitionClusterWithoutWorkerNodes for CAPA
+
 ### Changed
 
 - Modify `KyvernoWebhookHasNoAvailableReplicas` to check specifically for Kyverno resource webhook.

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.inhibition.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.inhibition.rules.yml
@@ -1,0 +1,34 @@
+{{- if eq .Values.managementCluster.provider.kind "capa" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: capa.inhibitions.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: capa.inhibitions
+    rules:
+    - alert: InhibitionClusterWithoutWorkerNodes
+      annotations:
+        description: '{{`Cluster ({{ $labels.cluster_id }}) has no worker nodes.`}}'
+      expr: |-
+        label_replace(
+            capi_cluster_status_condition{type="ControlPlaneReady", status="True"},
+                "cluster_id",
+                "$1",
+                "name",
+                "(.*)"
+            ) == 1
+        unless on (cluster_id) (
+            sum(capi_machinepool_spec_replicas{} > 0) by (cluster_id)
+        )
+      labels:
+        area: kaas
+        has_worker_nodes: "false"
+        team: phoenix
+        topic: status
+{{- end }}

--- a/test/tests/providers/capi/capa-mimir/kaas/phoenix/alerting-rules/capa.inhibition.rules.test.yml
+++ b/test/tests/providers/capi/capa-mimir/kaas/phoenix/alerting-rules/capa.inhibition.rules.test.yml
@@ -1,0 +1,47 @@
+---
+rule_files:
+- capa.inhibition.rules.yml
+
+tests:
+  # Tests for `InhibitionClusterWithoutWorkerNodes` inhibition alert
+  - interval: 1m
+    input_series:
+      - series: 'capi_cluster_status_condition{cluster_id="golem", cluster_type="management_cluster", name="golem", pipeline="testing", status="True", type="ControlPlaneReady"}'
+        values: "1+0x300"
+      - series: 'capi_machinepool_spec_replicas{cluster_id="golem", cluster_name="golem", cluster_type="management_cluster", customer="giantswarm", installation="golem", organization="giantswarm", pipeline="testing", provider="capa"}'
+        values: "_x60 0x60 3x60"
+    alert_rule_test:
+      - alertname: InhibitionClusterWithoutWorkerNodes
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cluster_id: "golem"
+              cluster_type: "management_cluster"
+              has_worker_nodes: "false"
+              name: "golem"
+              pipeline: "testing"
+              status: "True"
+              team: "phoenix"
+              topic: "status"
+              type: "ControlPlaneReady"
+            exp_annotations:
+              description: "Cluster (golem) has no worker nodes."
+      - alertname: InhibitionClusterWithoutWorkerNodes
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cluster_id: "golem"
+              cluster_type: "management_cluster"
+              has_worker_nodes: "false"
+              name: "golem"
+              pipeline: "testing"
+              status: "True"
+              team: "phoenix"
+              topic: "status"
+              type: "ControlPlaneReady"
+            exp_annotations:
+              description: "Cluster (golem) has no worker nodes."
+      - alertname: InhibitionClusterWithoutWorkerNodes
+        eval_time: 150m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31390

This PR adds an inhibition for clusters that have no worker nodes.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
