### PR TITLE
Set InhibitionControlPlaneUnhealthy for all CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set the `InhibitionControlPlaneUnhealthy` to be valid for all CAPI clusters, not just MCs.
+
 ## [4.20.0] - 2024-10-22
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.capi.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.capi.rules.yml
@@ -1,14 +1,11 @@
 {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-# This rule applies to all capi management clusters
+# This rule applies to all capi clusters
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-{{- if not .Values.mimir.enabled }}
-    cluster_type: "management_cluster"
-{{- end }}
   name: inhibit.capi.rules
   namespace: {{ .Values.namespace  }}
 spec:
@@ -19,12 +16,12 @@ spec:
       annotations:
         description: '{{`Control plane of cluster {{ $labels.cluster_id }} is not healthy.`}}'
       expr: |-
-        capi_kubeadmcontrolplane_status_condition{cluster_type="management_cluster", type="ControlPlaneComponentsHealthy", status="False"} == 1
-        or capi_kubeadmcontrolplane_status_condition{cluster_type="management_cluster", type="EtcdClusterHealthy", status="False"} == 1
-        or capi_kubeadmcontrolplane_status_condition{cluster_type="management_cluster", type="Available", status="False"} == 1
+        capi_kubeadmcontrolplane_status_condition{type="ControlPlaneComponentsHealthy", status="False"} == 1
+        or capi_kubeadmcontrolplane_status_condition{type="EtcdClusterHealthy", status="False"} == 1
+        or capi_kubeadmcontrolplane_status_condition{type="Available", status="False"} == 1
       labels:
         area: kaas
         cluster_control_plane_unhealthy: "true"
-        team: turtles
+        team: tenet
         topic: status
 {{- end }}


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/31534

This PR sets the `InhibitionControlPlaneUnhealthy` to be valid for all CAPI clusters, not just MCs.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
