### PR TITLE
update mixin files for loki and mimir

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -38,3 +38,12 @@ pint: install-tools template-chart ## Run pint
 pint-all: install-tools template-chart ## Run pint with extra checks
 	GENERATE_ONLY=true bash test/hack/bin/verify-rules.sh
 	./test/hack/bin/run-pint.sh test/conf/pint/pint-all.hcl ${PINT_TEAM_FILTER}
+
+##@ Mixins
+update-mimir-mixin: install-tools ##        Update Mimir mixins
+	./mimir/update.sh
+
+update-loki-mixin: install-tools ##        Update Loki mixins
+	./loki/update.sh
+
+update-mixin: update-mimir-mixin update-loki-mixin ##        Update all mixins

--- a/loki/mixin.libsonnet
+++ b/loki/mixin.libsonnet
@@ -1,22 +1,31 @@
-local loki = import 'loki-mixin/mixin-ssd.libsonnet';
-
-loki{
+(import 'loki-mixin/mixin-ssd.libsonnet') + {
   _config+:: {
     tags: [
-      "owner:team-atlas",
-      "topic:observability",
-      "component:loki"
+      'owner:team-atlas',
+      'topic:observability',
+      'component:loki',
     ],
 
     per_node_label: 'node',
     per_cluster_label: 'cluster_id',
 
+    blooms: {
+      enabled: false,
+    },
+
     canary+: {
       enabled: true,
     },
 
-    promtail+: {
-      enabled: true,
+    operational: {
+      memcached: false,
+      consul: false,
+      bigTable: false,
+      dynamo: false,
+      gcs: false,
+      s3: true,
+      azureBlob: true,
+      boltDB: false,
     },
   },
 }

--- a/mimir/mixin.libsonnet
+++ b/mimir/mixin.libsonnet
@@ -1,42 +1,62 @@
-local mimir = import 'mimir-mixin/mixin-compiled.libsonnet';
-
-mimir{
+(import 'mimir-mixin/mixin.libsonnet') + {
   _config+:: {
     tags: [
-      "owner:team-atlas",
-      "topic:observability",
-      "component:mimir"
+      'owner:team-atlas',
+      'topic:observability',
+      'component:mimir',
     ],
 
     per_cluster_label: 'cluster_id',
     // Not sure why the default is set to instance, but we want to set it to node
     per_node_label: 'node',
+    per_component_loki_label: 'component',
     // We marked it as disabled as this should be enabled only if the enterprise gateway is enabled
     gateway_enabled: false,
     // Whether alerts for experimental ingest storage are enabled.
     ingest_storage_enabled: false,
-    // Disable all autoscaling components because we currently do not use it
+    // Disable autoscaling components we do not use
+    autoscaling_hpa_prefix: 'mimir-',
+    // Whether autoscaling panels and alerts should be enabled for specific Mimir services.
     autoscaling: {
       query_frontend: {
         enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'query-frontend',
       },
       ruler_query_frontend: {
         enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'ruler-query-frontend',
       },
       querier: {
-        enabled: false,
+        enabled: true,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'querier',
       },
       ruler_querier: {
         enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'ruler-querier',
+      },
+      store_gateway: {
+        enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'store-gateway',
       },
       distributor: {
-        enabled: false,
+        enabled: true,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'distributor',
       },
       ruler: {
         enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'ruler',
       },
       gateway: {
+        enabled: true,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'gateway',
+      },
+      ingester: {
         enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'ingester',
+      },
+      compactor: {
+        enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'compactor',
       },
     },
   },


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---

This PR syncs the libsonnets with the one in dashboards. I'm not updating changelog because this has no impact on anything

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
