### PR TITLE
Update app.rules.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixes the statefulset.rules name as it is currently replacing the deployment.rules alerts.
+- Extends AppCR-related alerts with cancelation for CAPI clusters with unavailable control plane.
 
 ## [4.22.0] - 2024-10-29
 

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -21,6 +21,7 @@ spec:
       for: 30m
       labels:
         area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -55,6 +56,7 @@ spec:
       for: 30m
       labels:
         area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
@@ -75,6 +77,7 @@ spec:
       for: 30m
       labels:
         area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
+++ b/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
@@ -17,6 +17,7 @@ tests:
               app: cilium
               app_version: 1.11.2
               area: platform
+              cancel_if_cluster_control_plane_unhealthy: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/31474

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
