### PR TITLE
Objectstorage access alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - new MimirObjectStorageLowRate alert
+- new LokiObjectStorageLowRate alert
 
 ## [4.25.0] - 2024-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump alloy-rules app version to 0.7.0
   - Upgrades alloy to 1.4.2 to 1.5.0
 
+### Added
+
+- new MimirObjectStorageLowRate alert
+
 ## [4.25.0] - 2024-11-18
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -202,6 +202,7 @@ spec:
         opsrecipe: loki/
       expr: |
         irate(loki_rate_store_stream_rate_bytes_count[5m]) == 0
+        # This part will fire the alert when the metric does not exist
         or (
             label_replace(
               capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -195,3 +195,31 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: LokiObjectStorageLowRate
+      annotations:
+        dashboard: loki-operational/loki-operational
+        description: '{{`Loki object storage write rate is down.`}}'
+        opsrecipe: loki/
+      expr: |
+        irate(loki_rate_store_stream_rate_bytes_count[5m]) == 0
+        or (
+            label_replace(
+              capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},
+              "cluster_id",
+              "$1",
+              "name",
+              "(.*)"
+            ) == 1
+          ) unless on (cluster_id) (
+            count(loki_rate_store_stream_rate_bytes_count) by (cluster_id)
+          )
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -266,4 +266,32 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirObjectStorageLowRate
+      annotations:
+        dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+        description: '{{`Mimir object storage write rate is down.`}}'
+        opsrecipe: mimir/
+      expr: |
+        irate(cortex_bucket_store_sent_chunk_size_bytes_count[5m]) == 0
+        or (
+            label_replace(
+              capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},
+              "cluster_id",
+              "$1",
+              "name",
+              "(.*)"
+            ) == 1
+          ) unless on (cluster_id) (
+            count(cortex_bucket_store_sent_chunk_size_bytes_count) by (cluster_id)
+          )
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
 {{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -273,6 +273,7 @@ spec:
         opsrecipe: mimir/
       expr: |
         irate(cortex_bucket_store_sent_chunk_size_bytes_count[5m]) == 0
+        # This part will fire the alert when the metric does not exist
         or (
             label_replace(
               capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -566,3 +566,66 @@ tests:
               dashboard: mimir-continous-test/mimir-continous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
+
+  # Test for MimirObjectStorageLowRate alert
+  - interval: 1m
+    input_series:
+      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "_x90 1+1x90 90+0x90"
+      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa", name="myinstall", type="ControlPlaneReady", status="True"}'
+        values: "1+0x270"
+    alert_rule_test:
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 40m
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              name: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capa
+              severity: page
+              status: "True"
+              team: atlas
+              topic: observability
+              type: ControlPlaneReady
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 100m
+      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 200m
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 250m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -566,3 +566,66 @@ tests:
               dashboard: mimir-continous-test/mimir-continous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
+
+  # Test for MimirObjectStorageLowRate alert
+  - interval: 1m
+    input_series:
+      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capz"}'
+        values: "_x90 1+1x90 90+0x90"
+      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capz", name="myinstall", type="ControlPlaneReady", status="True"}'
+        values: "1+0x270"
+    alert_rule_test:
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 40m
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              name: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capz
+              severity: page
+              status: "True"
+              team: atlas
+              topic: observability
+              type: ControlPlaneReady
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 100m
+      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 200m
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 250m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capz
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -324,3 +324,63 @@ tests:
               opsrecipe: "loki/"
       - alertname: LokiMissingLogs
         eval_time: 300m
+
+  # Test for LokiObjectStorageLowRate alert
+  - interval: 1m
+    input_series:
+      - series: 'loki_rate_store_stream_rate_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="loki", pipeline="stable"}'
+        values: "_x90 1+1x90 90+0x90"
+      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="loki", pipeline="stable", name="myinstall", type="ControlPlaneReady", status="True"}'
+        values: "1+0x270"
+    alert_rule_test:
+      - alertname: LokiObjectStorageLowRate
+        eval_time: 40m
+      - alertname: LokiObjectStorageLowRate
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              name: myinstall
+              namespace: loki
+              pipeline: stable
+              severity: page
+              status: "True"
+              team: atlas
+              topic: observability
+              type: ControlPlaneReady
+            exp_annotations:
+              dashboard: loki-operational/loki-operational
+              description: "Loki object storage write rate is down."
+              opsrecipe: "loki/"
+      - alertname: LokiObjectStorageLowRate
+        eval_time: 100m
+      - alertname: LokiObjectStorageLowRate
+        eval_time: 200m
+      - alertname: LokiObjectStorageLowRate
+        eval_time: 250m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              namespace: loki
+              pipeline: stable
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              dashboard: loki-operational/loki-operational
+              description: "Loki object storage write rate is down."
+              opsrecipe: "loki/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3705

This PR adds some alerts to loki and mimir that check object storage access.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
