### PR TITLE
Add alert to monitor the HelmRelease for vertical-pod-autoscaler-crd app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert to monitor the HelmRelease for vertical-pod-autoscaler-crd app.
+
 ## [4.26.1] - 2024-11-19
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vertical-pod-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/vertical-pod-autoscaler.rules.yml
@@ -28,3 +28,20 @@ spec:
         severity: page
         team: turtles
         topic: autoscaling
+    - alert: FluxHelmReleaseFailed
+      annotations:
+        description: |-
+          {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
+        opsrecipe: fluxcd-failing-helmrelease/
+      expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", name=~".*(vertical-pod-autoscaler-crd)"} > 0
+      for: 20m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_monitoring_agent_down: "true"
+        severity: page
+        team: turtles
+        topic: autoscaling
+        namespace: |-
+          {{`{{ $labels.exported_namespace }}`}}


### PR DESCRIPTION
We currently deploy the vpa-crd app using HelmReleases but we don't have alerts to notify us when something is wrong. What do you think @giantswarm/team-tenet  ? The alerts won't page outside of business hours.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
