### PR TITLE
MimirContinuousTestFailing alert - fix dashboard link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add alerts to monitor the `HelmReleases` for `cilium` and `coredns`.
 - Add alert to monitor the `HelmRelease` for the `vertical-pod-autoscaler-crd` app.
 
+### Fixed
+
+- Fix dashboard link for `MimirContinuousTestFailing` alert
+
 ## [4.26.1] - 2024-11-19
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -189,7 +189,7 @@ spec:
     rules:
     - alert: MimirContinuousTestFailingOnWrites
       annotations:
-        dashboard: mimir-continous-test/mimir-continous-test
+        dashboard: mimir-continuous-test/mimir-continuous-test
         description: '{{`Mimir continuous test {{ $labels.test }} in {{ $labels.cluster_id }}/{{ $labels.namespace }} is not effectively running because writes are failing.`}}'
         opsrecipe: mimir/
       # Query is based on the following upstream mixin alerting rule: https://github.com/grafana/mimir/blob/b873372adbf0996bff70de55934f3dd4a10c7b89/operations/mimir-mixin-compiled/alerts.yaml#L1196
@@ -206,7 +206,7 @@ spec:
         topic: observability
     - alert: MimirContinuousTestFailingOnReads
       annotations:
-        dashboard: mimir-continous-test/mimir-continous-test
+        dashboard: mimir-continuous-test/mimir-continuous-test
         description: '{{`Mimir continuous test {{ $labels.test }} in {{ $labels.cluster_id }}/{{ $labels.namespace }} is not effectively running because queries are failing.`}}'
         opsrecipe: mimir/
       # Query is based on the following upstream mixin alerting rule: https://github.com/grafana/mimir/blob/b873372adbf0996bff70de55934f3dd4a10c7b89/operations/mimir-mixin-compiled/alerts.yaml#L1185
@@ -223,7 +223,7 @@ spec:
         topic: observability
     - alert: MimirContinuousTestFailing
       annotations:
-        dashboard: mimir-continous-test/mimir-continous-test
+        dashboard: mimir-continuous-test/mimir-continuous-test
         description: '{{`Mimir continuous test {{ $labels.test }} in {{ $labels.cluster_id }}/{{ $labels.namespace }} is not effectively running because queries are failing.`}}'
         opsrecipe: mimir/
       # Query is based on the following upstream mixin alerting rule: https://github.com/grafana/mimir/blob/b873372adbf0996bff70de55934f3dd4a10c7b89/operations/mimir-mixin-compiled/alerts.yaml#L1205
@@ -240,7 +240,7 @@ spec:
         topic: observability
     - alert: MimirContinuousTestMissing
       annotations:
-        dashboard: mimir-continous-test/mimir-continous-test
+        dashboard: mimir-continuous-test/mimir-continuous-test
         description: '{{`Mimir continuous test {{ $labels.cluster_id }} is not producing metrics.`}}'
         opsrecipe: mimir/
       expr: |

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -441,7 +441,7 @@ tests:
               test: continuous-test
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because writes are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailingOnWrites
@@ -475,7 +475,7 @@ tests:
               test: continuous-test
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because queries are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailingOnReads
@@ -509,7 +509,7 @@ tests:
               topic: observability
               test: continuous-test
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because queries are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailing
@@ -541,7 +541,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestMissing
@@ -563,7 +563,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
 

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -441,7 +441,7 @@ tests:
               test: continuous-test
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because writes are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailingOnWrites
@@ -475,7 +475,7 @@ tests:
               test: continuous-test
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because queries are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailingOnReads
@@ -509,7 +509,7 @@ tests:
               topic: observability
               test: continuous-test
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test continuous-test in golem/mimir is not effectively running because queries are failing."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestFailing
@@ -541,7 +541,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
       - alertname: MimirContinuousTestMissing
@@ -563,7 +563,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: mimir-continous-test/mimir-continous-test
+              dashboard: mimir-continuous-test/mimir-continuous-test
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
 


### PR DESCRIPTION
Let's fix the link to the dashboard, because there was a typo in it.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
