### PR TITLE
tests break if some helm template fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix dashboard link for `MimirContinuousTestFailing` alert
+- Fix tests so they fail if some helm template fails to render
 
 ## [4.26.1] - 2024-11-19
 

--- a/test/hack/bin/template-chart.sh
+++ b/test/hack/bin/template-chart.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 main() {
   local GIT_WORKDIR


### PR DESCRIPTION
Related to: https://github.com/giantswarm/prometheus-rules/pull/1432

We noticed that tests were not failing when a helm template was failing to render, which made spotting the issue harder.
With this change the tests would have failed right when the `YAML parse error` happens, making the root cause of the failure obvious.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
