### PR TITLE
Add `MimirRulerTooManyFailedQueries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `cloud-provider-controller.rules` to monitor the cloud-provider-controller components across providers.
 - Add alerts to monitor the `HelmReleases` for `cilium` and `coredns`.
 - Add alert to monitor the `HelmRelease` for the `vertical-pod-autoscaler-crd` app.
+- Add `MimirRulerTooManyFailedQueries` alert to detect when Mimir ruler is failing to evaluate rules
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -151,6 +151,27 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirRulerTooManyFailedQueries
+      annotations:
+        dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
+        description: '{{`Mimir Ruler {{ $labels.pod }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.`}}'
+        opsrecipe: mimir/
+      expr: |
+        100 * (
+        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+          /
+        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
+        ) > 1
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
   - name: mimir.compactor
     rules:
     - alert: MimirCompactorFailedCompaction
@@ -285,27 +306,6 @@ spec:
           ) unless on (cluster_id) (
             count(cortex_bucket_store_sent_chunk_size_bytes_count{cluster_type="management_cluster"}) by (cluster_id)
           )
-      for: 1h
-      labels:
-        area: platform
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
-    - alert: MimirRulerTooManyFailedQueries
-      annotations:
-        dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
-        description: '{{`Mimir Ruler {{ $labels.pod }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.`}}'
-        opsrecipe: mimir/
-      expr: |
-        100 * (
-        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
-          /
-        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
-        ) > 1
       for: 1h
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -298,13 +298,13 @@ spec:
     - alert: MimirRulerTooManyFailedQueries
       annotations:
         dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
-        description: '{{`Mimir Ruler {{ $labels.pod }} in ${{ $labels.cluster_id }} cluster is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
+        description: '{{`Mimir Ruler {{ $labels.pod }} is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
         opsrecipe: mimir/
       expr: |
         100 * (
-        sum by (cluster_id, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+        sum by (installation, cluster_id, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
           /
-        sum by (cluster_id, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
+        sum by (installation, cluster_id, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
         ) > 1
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -298,7 +298,7 @@ spec:
     - alert: MimirRulerTooManyFailedQueries
       annotations:
         dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
-        description: '{{`Mimir Ruler {{ $labels.pod }} in ${{ labels.cluster_id }} cluster is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
+        description: '{{`Mimir Ruler {{ $labels.pod }} in ${{ $labels.cluster_id }} cluster is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
         opsrecipe: mimir/
       expr: |
         100 * (

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -295,4 +295,25 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirRulerTooManyFailedQueries
+      annotations:
+        dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
+        description: '{{`Mimir Ruler {{ $labels.pod }} in ${{ labels.cluster_id }} cluster is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
+        opsrecipe: mimir/
+      expr: |
+        100 * (
+        sum by (cluster_id, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+          /
+        sum by (cluster_id, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
+        ) > 1
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
 {{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -302,9 +302,9 @@ spec:
         opsrecipe: mimir/
       expr: |
         100 * (
-        sum by (installation, cluster_id, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
           /
-        sum by (installation, cluster_id, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
+        sum by (installation, cluster_id, pipeline, provider, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
         ) > 1
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -298,7 +298,7 @@ spec:
     - alert: MimirRulerTooManyFailedQueries
       annotations:
         dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
-        description: '{{`Mimir Ruler {{ $labels.pod }} is experiencing {{ printf "%.2f" $value }}$ errors while evaluating rules.`}}'
+        description: '{{`Mimir Ruler {{ $labels.pod }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.`}}'
         opsrecipe: mimir/
       expr: |
         100 * (

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -633,15 +633,19 @@ tests:
   # Test for MimirRulerTooManyFailedQueries alert
   - interval: 1m
     input_series:
-      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
-        values: "_x90 1+1x90 90+0x200"
-      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa", name="myinstall", type="ControlPlaneReady", status="True"}'
-        values: "1+0x380"
+      - series: 'cortex_ruler_queries_total{cluster_id="myinstall", installation="myinstall", namespace="mimir", pipeline="stable", pod="mimir-ruler-aaaaaaaaaa-bbbbb", provider="capa"}'
+        values: "0x90 0+1x90 90+100x90"
+      - series: 'cortex_ruler_queries_failed_total{cluster_id="myinstall", installation="myinstall", namespace="mimir", pipeline="stable", pod="mimir-ruler-aaaaaaaaaa-bbbbb", provider="capa", name="myinstall", type="ControlPlaneReady", status="True"}'
+        values: "0x180 0+2x90"
     alert_rule_test:
       - alertname: MimirRulerTooManyFailedQueries
-        eval_time: 40m
+        eval_time: 90m
       - alertname: MimirRulerTooManyFailedQueries
-        eval_time: 70m
+        eval_time: 180m
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 240m
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 242m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -650,45 +654,13 @@ tests:
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
-              cluster_type: management_cluster
-              installation: myinstall
-              name: myinstall
-              namespace: mimir
-              pipeline: stable
-              provider: capa
-              severity: page
-              status: "True"
-              team: atlas
-              topic: observability
-              type: ControlPlaneReady
-            exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
-              description: "Mimir object storage write rate is down."
-              opsrecipe: "mimir/"
-      - alertname: MimirRulerTooManyFailedQueries
-        eval_time: 100m
-      - alertname: MimirRulerTooManyFailedQueries
-      - alertname: MimirRulerTooManyFailedQueries
-        eval_time: 200m
-      - alertname: MimirRulerTooManyFailedQueries
-        eval_time: 300m
-        exp_alerts:
-          - exp_labels:
-              area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cluster_id: myinstall
-              cluster_type: management_cluster
               installation: myinstall
               namespace: mimir
-              pipeline: stable
-              provider: capa
+              pod: mimir-ruler-aaaaaaaaaa-bbbbb
               severity: page
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
-              description: "Mimir object storage write rate is down."
+              dashboard: 631e15d5d85afb2ca8e35d62984eeaa0/mimir-ruler
+              description: "Mimir Ruler mimir-ruler-aaaaaaaaaa-bbbbb is experiencing 2.00% errors while evaluating rules."
               opsrecipe: "mimir/"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -629,3 +629,66 @@ tests:
               dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
               description: "Mimir object storage write rate is down."
               opsrecipe: "mimir/"
+
+  # Test for MimirRulerTooManyFailedQueries alert
+  - interval: 1m
+    input_series:
+      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "_x90 1+1x90 90+0x200"
+      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa", name="myinstall", type="ControlPlaneReady", status="True"}'
+        values: "1+0x380"
+    alert_rule_test:
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 40m
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 70m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              name: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capa
+              severity: page
+              status: "True"
+              team: atlas
+              topic: observability
+              type: ControlPlaneReady
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 100m
+      - alertname: MimirRulerTooManyFailedQueries
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 200m
+      - alertname: MimirRulerTooManyFailedQueries
+        eval_time: 300m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: myinstall
+              cluster_type: management_cluster
+              installation: myinstall
+              namespace: mimir
+              pipeline: stable
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+              description: "Mimir object storage write rate is down."
+              opsrecipe: "mimir/"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -656,7 +656,9 @@ tests:
               cluster_id: myinstall
               installation: myinstall
               namespace: mimir
+              pipeline: stable
               pod: mimir-ruler-aaaaaaaaaa-bbbbb
+              provider: capa
               severity: page
               team: atlas
               topic: observability


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32042

Adding a new rule to detect failure in Mimir ruler evaluation

<details>
<summary>Here is how this alert would have been triggered on various installations over the last 30 days</summary>

#### alba
![image](https://github.com/user-attachments/assets/46082908-e428-4ba0-bdcd-1d72fd525c13)

#### wallaby
![image](https://github.com/user-attachments/assets/5f347bce-4d0c-412e-ac48-c2b38a6da074)

#### gazelle
![image](https://github.com/user-attachments/assets/092ad2e0-300e-4610-8046-000273966a7d)

#### armadillo

![image](https://github.com/user-attachments/assets/7b9a483e-86b4-4988-8138-0a0b5da97b4d)

</details>