### PR TITLE
Add alert to monitor KubeadmConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert to monitor the `KubeadmConfig` CRs having trouble generating bootstrap data.
+
 ## [4.26.2] - 2024-11-27
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/capi-kubeadmconfig.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/capi-kubeadmconfig.rules.yml
@@ -1,0 +1,26 @@
+{{- if eq .Values.managementCluster.provider.flavor "capi" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels: {{- include "labels.common" . | nindent 4}}
+  name: capi-kubeadmconfig.rules
+  namespace: {{.Values.namespace}}
+spec:
+  groups:
+    - name: capi-kubeadmconfig
+      rules:
+        - alert: KubeadmConfigNotReady
+          expr: capi_kubeadmconfig_status_condition{type="Ready", status="False"} > 0
+          for: 1h
+          labels:
+            area: kaas
+            cancel_if_monitoring_agent_down: "true"
+            cancel_if_outside_working_hours: "true"
+            severity: page
+            team: {{ include "providerTeam" . }}
+            topic: managementcluster
+          annotations:
+            description: |-
+              {{`KubeadmConfig {{$labels.exported_namespace}}/{{$labels.name}} in cluster {{$labels.cluster_name}} encountered errors while generating a data secret`}}
+            opsrecipe: capi-kubeadmconfig/
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32111

CI failing due to missing ops-recipe that's getting [added here](https://github.com/giantswarm/giantswarm/pull/32188).

### Checklist

- [X] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
