### PR TITLE
Split kong alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `KongProductionDeploymentNotSatisfied` to alert on clusters starting with `p`.
+
+### Changed
+
+- `KongDeploymentNotSatisfied` to alert on clusters not starting with `p` and not outside business hours.
+
 ## [4.26.2] - 2024-11-27
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -30,7 +30,7 @@ spec:
       annotations:
         description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"^p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"^p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id!~"^p.*"}) < 0.6
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id!~"p.*"}) < 0.6
       for: 30m
       labels:
         area: platform
@@ -44,7 +44,7 @@ spec:
       annotations:
         description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"^p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"^p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id=~"^p.*"}) < 0.6
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id=~"p.*"}) < 0.6
       for: 30m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -30,7 +30,21 @@ spec:
       annotations:
         description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: workload-cluster-managed-deployment-not-satisfied/
-      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*"}) < 0.6
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"^p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"^p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id!~"^p.*"}) < 0.6
+      for: 30m
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: cabbage
+        topic: kong
+    - alert: KongProductionDeploymentNotSatisfied
+      annotations:
+        description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-managed-deployment-not-satisfied/
+      expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"^p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"^p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id=~"^p.*"}) < 0.6
       for: 30m
       labels:
         area: platform


### PR DESCRIPTION
This PR tries to make area oncall a little more bearable until things can be fixed on other places

Split the existing `KongProductionDeploymentNotSatisfied` into prod and non-prod. The one for non-prod does not alert during nights any more