### PR TITLE
increase time to trigger promtailrequestserrors alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase time to trigger `PromtailRequestsErrors` alert from 15 to 25m.
+
 ## [4.28.0] - 2024-12-02
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -38,7 +38,7 @@ spec:
             opsrecipe: promtail/
           expr: |
             100 * (sum(rate(promtail_request_duration_seconds_count{status_code!~"2.."}[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance) / sum(rate(promtail_request_duration_seconds_count[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)) > 10
-          for: 15m
+          for: 25m
           labels:
             area: platform
             severity: page


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32214

This PR increases the time threshold for the `PromtailRequestsErrors` alert which is currently too sensitive.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
