### PR TITLE
Fix duplicate series in PromtailDown alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix duplicate series in `PromtailDown` alert.
+
 ## [4.30.0] - 2024-12-10
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -16,10 +16,10 @@ spec:
             description: '{{`Scraping of all promtail pods to check if one failed every 30 minutes.`}}'
             opsrecipe: promtail/
           expr: |-
-            kube_pod_info{pod=~"promtail.*"}
+            kube_pod_info{pod=~"promtail.*", namespace="kube-system"}
             * on(cluster_id, pod)
               group_left ()
-              up{container="promtail"} == 0
+              up{container="promtail", namespace="kube-system"} == 0
           for: 30m
           labels:
             area: platform

--- a/test/tests/providers/global/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -6,18 +6,18 @@ tests:
   - interval: 1m
     input_series:
       # For the first 60min: test with 1 pod: none, up, down
-      - series: 'up{container="promtail", cluster_id="gauss", cluster_type="management_cluster", installation="gauss", pod="promtail-1xxxx", provider="aws", pipeline="testing"}'
+      - series: 'up{container="promtail", cluster_id="gauss", cluster_type="management_cluster", installation="gauss", namespace="kube-system", pod="promtail-1xxxx", provider="aws", pipeline="testing"}'
         values: "_x20 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", pod="promtail-1xxxx", node="ip-10-0-5-1.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
+      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", namespace="kube-system", pod="promtail-1xxxx", node="ip-10-0-5-1.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
         values: "1x180"
       # From 60min: test with 2 pods: 1 up and 1 down, 2 up, 2 down.
-      - series: 'up{container="promtail", cluster_id="gauss", cluster_type="management_cluster", installation="gauss", pod="promtail-2xxxx", provider="aws", pipeline="testing"}'
+      - series: 'up{container="promtail", cluster_id="gauss", cluster_type="management_cluster", installation="gauss", namespace="kube-system", pod="promtail-2xxxx", provider="aws", pipeline="testing"}'
         values: "_x80 1+0x40 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", pod="promtail-2xxxx", node="ip-10-0-5-2.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
+      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", namespace="kube-system", pod="promtail-2xxxx", node="ip-10-0-5-2.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
         values: "1x180"
-      - series: 'up{container="promtail", cluster_type="management_cluster", cluster_id="gauss", installation="gauss", pod="promtail-3xxxx", provider="aws", pipeline="testing"}'
+      - series: 'up{container="promtail", cluster_type="management_cluster", cluster_id="gauss", installation="gauss", namespace="kube-system", pod="promtail-3xxxx", provider="aws", pipeline="testing"}'
         values: "_x80 0+0x40 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", pod="promtail-3xxxx", node="ip-10-0-5-3.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
+      - series: kube_pod_info{cluster_id="gauss", cluster_type="management_cluster", installation="gauss", namespace="kube-system", pod="promtail-3xxxx", node="ip-10-0-5-3.eu-west-1.compute.internal", provider="aws", pipeline="testing"}
         values: "1x180"
     alert_rule_test:
       - alertname: PromtailDown
@@ -38,6 +38,7 @@ tests:
               cluster_id: gauss
               cluster_type: management_cluster
               installation: gauss
+              namespace: kube-system
               node: ip-10-0-5-1.eu-west-1.compute.internal
               pipeline: testing
               pod: promtail-1xxxx
@@ -63,6 +64,7 @@ tests:
               cluster_id: gauss
               cluster_type: management_cluster
               installation: gauss
+              namespace: kube-system
               node: ip-10-0-5-3.eu-west-1.compute.internal
               pipeline: testing
               pod: promtail-3xxxx
@@ -89,6 +91,7 @@ tests:
               cluster_id: gauss
               cluster_type: management_cluster
               installation: gauss
+              namespace: kube-system
               node: ip-10-0-5-2.eu-west-1.compute.internal
               pipeline: testing
               pod: promtail-2xxxx
@@ -110,6 +113,7 @@ tests:
               cluster_id: gauss
               cluster_type: management_cluster
               installation: gauss
+              namespace: kube-system
               node: ip-10-0-5-3.eu-west-1.compute.internal
               pipeline: testing
               pod: promtail-3xxxx


### PR DESCRIPTION
Rules fails to evaluate because there are multiples pods matching the `up{container="promtail"} == 0` query

1. Failing evaluation
![image](https://github.com/user-attachments/assets/ba81b3d1-721b-4b07-bb81-4dd940831e2d)

2. Multiple pods for `up` metrics
![image](https://github.com/user-attachments/assets/0e46eeb3-e5aa-4149-a93b-f798239f7c20)

3. `kube_pod_info` is only available for `kube-system` namespace
![image](https://github.com/user-attachments/assets/5cd12a0e-e8c8-4f50-8bee-89a91587df77)

This PR fixes the PromtailDown alert by limiting its scope to the kube-system namespace.
