### PR TITLE
add dashboard annotation for PromtailRequestsErrors alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add dashboard annotation for `PromtailRequestsErrors` alert.
+
 ### Fixed
 
 - Fix duplicate series in `PromtailDown` alert.

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -34,6 +34,7 @@ spec:
             cancel_if_node_not_ready: "true"
         - alert: PromtailRequestsErrors
           annotations:
+            dashboard: promtail-overview/promtail-overview
             description: This alert checks if that the amount of failed requests is below 10% for promtail
             opsrecipe: promtail/
           expr: |

--- a/test/tests/providers/global/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -156,6 +156,7 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
+              dashboard: promtail-overview/promtail-overview
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
               opsrecipe: "promtail/"
       - alertname: PromtailRequestsErrors
@@ -174,5 +175,6 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
+              dashboard: promtail-overview/promtail-overview
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
               opsrecipe: "promtail/"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32240

This PR adds a dashboard annotation for the `PromtailRequestsErrors` alert to help oncallers to better understand what could be happening.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
