### PR TITLE
Disable fluentbit monitoring on on-prem providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled fluentbit monitoring on on-prem providers (vsphere and cloud-director)
+
 ## [4.31.0] - 2025-01-13
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
@@ -1,3 +1,4 @@
+{{- if not (or (eq .Values.managementCluster.provider.kind "vsphere") (eq .Values.managementCluster.provider.kind "cloud-director")) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -76,3 +77,4 @@ spec:
         severity: page
         team: atlas
         topic: observability
+{{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32390

This PR disables fluentbit monitoring on on-premises installations.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
