### PR TITLE
fix app platform alerting for hybrid MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support hybrid providers on the app platform alerts.
+
 ## [4.33.0] - 2025-01-20
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -49,7 +49,16 @@ spec:
         description: '{{`Workload Cluster App {{ if $labels.exported_namespace }}{{ $labels.exported_namespace }}{{ else }}{{ $labels.namespace }}{{ end }}/{{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"} == 1
+      expr: |-
+        (
+          app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"}
+          * on(cluster_id) group_left(provider) 
+          sum(
+              label_replace(
+                capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+              )
+          ) by (cluster_id, provider)
+        ) == 1
       {{- else }}
       expr: label_replace(app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog=~"giantswarm|default", team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       {{- end }}
@@ -70,7 +79,16 @@ spec:
         description: '{{`Workload Cluster App {{ if $labels.exported_namespace }}{{ $labels.exported_namespace }}{{ else }}{{ $labels.namespace }}{{ end }}/{{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
         opsrecipe: app-failed/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"} == 1
+      expr: |-
+        (
+          app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"} 
+          * on(cluster_id) group_left(provider) 
+          sum(
+              label_replace(
+                capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+              )
+          ) by (cluster_id, provider)
+        ) == 1
       {{- else }}
       expr: label_replace(app_operator_app_info{status="not-installed", catalog=~"giantswarm|default", team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       {{- end }}
@@ -91,7 +109,16 @@ spec:
         description: 'Current version of {{`App {{ $labels.name }} is {{ $labels.deployed_version }} but it should be {{ $labels.version }}.`}}'
         opsrecipe: app-pending-update/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: app_operator_app_info{catalog=~"giantswarm|cluster|default", deployed_version!="", status="deployed", version_mismatch="true" ,team!~"^$|noteam"} == 1
+      expr: |-
+        (
+          app_operator_app_info{catalog=~"giantswarm|cluster|default", deployed_version!="", status="deployed", version_mismatch="true" ,team!~"^$|noteam"}
+          * on(cluster_id) group_left(provider)
+          sum(
+              label_replace(
+                capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+              )
+          ) by (cluster_id, provider)
+        ) == 1
       {{- else }}
       expr: label_replace(app_operator_app_info{catalog=~"giantswarm|default", deployed_version!="", status="deployed", version_mismatch="true" ,team!~"^$|noteam"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       {{- end }}
@@ -110,7 +137,16 @@ spec:
         description: '{{`App {{ $labels.name }} has no team label.`}}'
         opsrecipe: app-without-team-annotation/
       {{- if eq .Values.managementCluster.provider.flavor "capi" }}
-      expr: app_operator_app_info{app!~"api-spec(-app)?", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"} == 1
+      expr: |-
+        (
+          app_operator_app_info{app!~"api-spec(-app)?", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}
+          * on(cluster_id) group_left(provider) 
+          sum(
+              label_replace(
+                capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+              )
+          ) by (cluster_id, provider)
+        ) == 1
       {{- else }}
       expr: label_replace(app_operator_app_info{app!~"api-spec(-app)?", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}, "cluster_id", "$1", "namespace", {{ include "namespaceNotGiantswarm" . }}) == 1
       {{- end }}

--- a/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
+++ b/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
@@ -6,8 +6,10 @@ tests:
   # WorkloadClusterAppFailed tests
   - interval: 1m
     input_series:
-      - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="aws", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
+      - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="capa", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
         values: "0+0x20 1+0x100"
+      - series: 'capi_cluster_info{cluster_id="gauss", infrastructure_reference_kind="AWSCluster", provider="capa"}'
+        values: "1x120"
     alert_rule_test:
       - alertname: WorkloadClusterAppFailed
         eval_time: 90m
@@ -36,7 +38,7 @@ tests:
               node: ip-10-0-5-93.eu-west-1.compute.internal
               organization: giantswarm
               pod: app-exporter-7f8c5d7dd5-9dh4r
-              provider: aws
+              provider: capa
               service_priority: highest
               severity: page
               sig: none
@@ -53,10 +55,12 @@ tests:
   # AppWithoutTeamAnnotation tests
   - interval: 1m
     input_series:
-      - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="aws", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
+      - series: 'app_operator_app_info{app="cilium", app_version="1.11.2", catalog="giantswarm", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="giantswarm", deployed_version="0.2.6", installation="gauss", instance="100.64.2.221:8000", job="gauss-prometheus/app-exporter-gauss/0", name="cilium", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-7f8c5d7dd5-9dh4r", provider="capa", service_priority="highest", status="pending-upgrade", team="rocket", upgrade_available="false", version="0.2.6", version_mismatch="false"}'
         values: "1+0x100"
-      - series: 'app_operator_app_info{app="userd", catalog="control-plane-catalog", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="vodafone", deployed_version="1.2.1", endpoint="web", installation="gauss", instance="app-exporter", job="app-exporter", name="userd", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-64f9c4fb7b-d77pv", provider="aws", service="app-exporter", service_priority="highest", status="deployed", team="noteam", upgrade_available="false", version="1.2.1", version_mismatch="false"}'
+      - series: 'app_operator_app_info{app="userd", catalog="control-plane-catalog", cluster_id="gauss", cluster_missing="false", cluster_type="management_cluster", customer="vodafone", deployed_version="1.2.1", endpoint="web", installation="gauss", instance="app-exporter", job="app-exporter", name="userd", namespace="giantswarm", node="ip-10-0-5-93.eu-west-1.compute.internal", organization="giantswarm", pod="app-exporter-64f9c4fb7b-d77pv", provider="capa", service="app-exporter", service_priority="highest", status="deployed", team="noteam", upgrade_available="false", version="1.2.1", version_mismatch="false"}'
         values: "1+0x100"
+      - series: 'capi_cluster_info{cluster_id="gauss", infrastructure_reference_kind="AWSCluster", provider="capa"}'
+        values: "1+0x120"
     alert_rule_test:
       - alertname: AppWithoutTeamAnnotation
         eval_time: 30m
@@ -88,7 +92,7 @@ tests:
               node: ip-10-0-5-93.eu-west-1.compute.internal
               organization: giantswarm
               pod: app-exporter-64f9c4fb7b-d77pv
-              provider: aws
+              provider: capa
               service: app-exporter
               service_priority: highest
               severity: notify


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/3801

This PR makes sure onprem WCs App related alerts are sent to the corresponding team based on the WC provider and not the MC provider label.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
