### PR TITLE
fix mimir object storage low rate false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change team label `turtles` to `tenet`.
 
+### Fixed
+
+- Fix the `MimirObjectStorageLowRate` alert to be based on a better aligned metric to avoid false positives when Mimir restarts (c.f. https://github.com/giantswarm/giantswarm/issues/32419).
+
 ## [4.35.0] - 2025-01-28
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -179,11 +179,11 @@ spec:
         opsrecipe: mimir/
       expr: |
         sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
-          rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace=~"mimir"}[30m])
+          rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir"}[30m])
         )
         /
         sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
-          rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace=~"mimir"}[30m])
+          rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace="mimir"}[30m])
         )
         > 0
       for: 1h

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -172,6 +172,30 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: MimirObjectStorageLowRate
+      annotations:
+        dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
+        description: '{{`Mimir object storage write rate is down.`}}'
+        opsrecipe: mimir/
+      expr: |
+        sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
+          rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace=~"mimir"}[30m])
+        )
+        /
+        sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
+          rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace=~"mimir"}[30m])
+        )
+        > 0
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
   - name: mimir.compactor
     rules:
     - alert: MimirCompactorFailedCompaction
@@ -277,35 +301,6 @@ spec:
             }
           )
         )
-      for: 1h
-      labels:
-        area: platform
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
-    - alert: MimirObjectStorageLowRate
-      annotations:
-        dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
-        description: '{{`Mimir object storage write rate is down.`}}'
-        opsrecipe: mimir/
-      expr: |
-        rate(cortex_bucket_store_sent_chunk_size_bytes_count{cluster_type="management_cluster"}[30m]) == 0
-        # This part will fire the alert when the metric does not exist
-        or (
-            label_replace(
-              capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},
-              "cluster_id",
-              "$1",
-              "name",
-              "(.*)"
-            ) == 1
-          ) unless on (cluster_id) (
-            count(cortex_bucket_store_sent_chunk_size_bytes_count{cluster_type="management_cluster"}) by (cluster_id)
-          )
       for: 1h
       labels:
         area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -570,10 +570,10 @@ tests:
   # Test for MimirObjectStorageLowRate alert
   - interval: 1m
     input_series:
-      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
-        values: "_x90 1+1x90 90+0x200"
-      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa", name="myinstall", type="ControlPlaneReady", status="True"}'
-        values: "1+0x380"
+      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "0+10x80 100+0x80"
+      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "0+100x80 100+0x80"
     alert_rule_test:
       - alertname: MimirObjectStorageLowRate
         eval_time: 40m
@@ -588,38 +588,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
+              component: store-gateway
               installation: myinstall
-              name: myinstall
-              namespace: mimir
-              pipeline: stable
-              provider: capa
-              severity: page
-              status: "True"
-              team: atlas
-              topic: observability
-              type: ControlPlaneReady
-            exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
-              description: "Mimir object storage write rate is down."
-              opsrecipe: "mimir/"
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 100m
-      - alertname: MimirObjectStorageLowRate
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 200m
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 300m
-        exp_alerts:
-          - exp_labels:
-              area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cluster_id: myinstall
-              cluster_type: management_cluster
-              installation: myinstall
-              namespace: mimir
               pipeline: stable
               provider: capa
               severity: page
@@ -629,6 +599,8 @@ tests:
               dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
               description: "Mimir object storage write rate is down."
               opsrecipe: "mimir/"
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert
   - interval: 1m

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -570,10 +570,10 @@ tests:
   # Test for MimirObjectStorageLowRate alert
   - interval: 1m
     input_series:
-      - series: 'cortex_bucket_store_sent_chunk_size_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capz"}'
-        values: "_x90 1+1x90 90+0x200"
-      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="mimir", pipeline="stable", provider="capz", name="myinstall", type="ControlPlaneReady", status="True"}'
-        values: "1+0x380"
+      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "0+10x80 100+0x80"
+      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+        values: "0+100x80 100+0x80"
     alert_rule_test:
       - alertname: MimirObjectStorageLowRate
         eval_time: 40m
@@ -588,40 +588,10 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
+              component: store-gateway
               installation: myinstall
-              name: myinstall
-              namespace: mimir
               pipeline: stable
-              provider: capz
-              severity: page
-              status: "True"
-              team: atlas
-              topic: observability
-              type: ControlPlaneReady
-            exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
-              description: "Mimir object storage write rate is down."
-              opsrecipe: "mimir/"
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 100m
-      - alertname: MimirObjectStorageLowRate
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 200m
-      - alertname: MimirObjectStorageLowRate
-        eval_time: 300m
-        exp_alerts:
-          - exp_labels:
-              area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_cluster_status_creating: "true"
-              cancel_if_cluster_status_deleting: "true"
-              cancel_if_cluster_status_updating: "true"
-              cluster_id: myinstall
-              cluster_type: management_cluster
-              installation: myinstall
-              namespace: mimir
-              pipeline: stable
-              provider: capz
+              provider: capa
               severity: page
               team: atlas
               topic: observability
@@ -629,6 +599,8 @@ tests:
               dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes
               description: "Mimir object storage write rate is down."
               opsrecipe: "mimir/"
+      - alertname: MimirObjectStorageLowRate
+        eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert
   - interval: 1m


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Closes: https://github.com/giantswarm/giantswarm/issues/32419

This PR should address the false positive as it is based on an error rate when accessing the object storage. The metrics used have been taken from the `Mimir / Object Store dashboards`

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
