### PR TITLE
Tweak settings for some alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore webhook rejection for `Kyverno` webhooks.
+- Exclude `CONNECT` for API server request duration due to long-lived connections.
+- Increase timeout for unexpected taints on CAPI nodes.
+
 ## [4.36.0] - 2025-01-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -15,11 +15,12 @@ spec:
     rules:
     # expr produces 95th percentile latency for requests to the api server, by request verb.
     # verb WATCH is excluded because it produces a flat line and is not relevant.
+    # verb CONNECT requests often stay open for streaming or tunneling, avoid counting those long-lived connections.
     - alert: WorkloadClusterAPIServerLatencyTooHigh
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
         opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{cluster_type="workload_cluster", verb=~"CONNECT|DELETE|GET|PATCH|POST|PUT"}[1h])) by (cluster_id, installation, pipeline, provider, verb, le)) > 1
+      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{cluster_type="workload_cluster", verb=~"DELETE|GET|PATCH|POST|PUT"}[1h])) by (cluster_id, installation, pipeline, provider, verb, le)) > 1
       for: 1h
       labels:
         area: kaas
@@ -35,7 +36,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors (webhook: {{ $labels.name }}).`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="workload_cluster", error_type=~"calling_webhook_error|apiserver_internal_error"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="workload_cluster",error_type=~"calling_webhook_error|apiserver_internal_error",name!~"validate\\.kyverno\\.svc-fail|mutate\\.kyverno\\.svc-fail"}[5m]) > 0
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
@@ -170,7 +170,7 @@ spec:
         description: '{{`Node {{ $labels.node }} in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has CAPI taint node.cluster.x-k8s.io/uninitialized for too long`}}'
         opsrecipe: unexpected-taint-capi/
       expr: kube_node_spec_taint{key="node.cluster.x-k8s.io/uninitialized"} > 0
-      for: 15m
+      for: 20m
       labels:
         area: kaas
         severity: page

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/systemd.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/systemd.rules.yml
@@ -10,7 +10,7 @@ spec:
   groups:
   - name: systemd
     rules:
-    ## TODO(@giantswarm/team-turtles) Update those lists when all vintage clusters are gone
+    ## TODO(@giantswarm/team-tenet) Update those lists when all vintage clusters are gone
     - alert: ClusterCriticalSystemdUnitFailed
       annotations:
         description: '{{`Critical systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'


### PR DESCRIPTION
This adjusts:

- Ignore webhook rejection for `Kyverno` webhooks.
- Exclude `CONNECT` for API server request duration due to long-lived connections.
- Increase timeout for unexpected taints on CAPI nodes mainly due to facing alerts for CICDProd which took a bit longer on upgrading the cluster

