### PR TITLE
More adjustments for tenet alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change alertmanager config url in CI and README
 - Exclude `CONNECT` for API server request duration due to long-lived connections in management clusters.
+- Exclude `exec_sync` from `KubeletDockerOperationsLatencyTooHigh` because they are operations which can be long-running.
+- Exclude Kong validation webhook from `WorkloadClusterAPIServerAdmissionWebhookErrors`.
 
 ## [4.37.0] - 2025-01-31
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -36,7 +36,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors (webhook: {{ $labels.name }}).`}}'
         opsrecipe: apiserver-admission-webhook-errors/
-      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="workload_cluster",error_type=~"calling_webhook_error|apiserver_internal_error",name!~"validate\\.kyverno\\.svc-fail|mutate\\.kyverno\\.svc-fail"}[5m]) > 0
+      expr: rate(apiserver_admission_webhook_rejection_count{cluster_type="workload_cluster",error_type=~"calling_webhook_error|apiserver_internal_error",name!~"validate\\.kyverno\\.svc-fail|mutate\\.kyverno\\.svc-fail|validations\\.kong\\.konghq\\.com"}[5m]) > 0
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
@@ -58,10 +58,12 @@ spec:
         severity: notify
         team: tenet
         topic: kubernetes
+    # operation type exec_type Because "exec_sync" operations can be long-running, 
+    # they inflate the 90th-percentile runtime duration above the 120-second threshold, causing the alert to constantly fire. Excluding "exec_sync" or raising the threshold can reduce false positives. 
     - alert: KubeletDockerOperationsLatencyTooHigh
       annotations:
         description: '{{`Kubelet ({{ $labels.instance }}) is taking too long to perform runtime {{ $labels.operation_type }} operations.`}}'
-      expr: histogram_quantile(0.9, rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[5m])) > 120
+      expr: histogram_quantile(0.9, rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!~"pull_image|exec_sync"}[5m])) > 120
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
- Exclude `exec_sync` from `KubeletDockerOperationsLatencyTooHigh` because they are operations which can be long-running.
- Exclude Kong validation webhook from `WorkloadClusterAPIServerAdmissionWebhookErrors`.