### PR TITLE
Fix noisy NodeExporterCollectorFailed alert due to customer workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `NodeExporterCollectorFailed` alert being received for customer workload.
+
 ## [4.38.0] - 2025-02-04
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node-exporter.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`NodeExporter Collector {{ $labels.collector }} on {{ $labels.instance }} is failed.`}}'
         opsrecipe: node-exporter-device-error/
-      expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme|watchdog"} == 0
+      expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme|watchdog", namespace="kube-system"} == 0
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node-exporter.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node-exporter.rules.yml
@@ -14,6 +14,7 @@ spec:
       annotations:
         description: '{{`NodeExporter Collector {{ $labels.collector }} on {{ $labels.instance }} is failed.`}}'
         opsrecipe: node-exporter-device-error/
+        # TODO(theo): the namespace filter should be removed when this completed https://github.com/giantswarm/roadmap/issues/3791, see https://github.com/giantswarm/prometheus-rules/pull/1491
       expr: node_scrape_collector_success{collector!~"conntrack|bonding|hwmon|powersupplyclass|mdadm|nfs|nfsd|tapestats|fibrechannel|nvme|watchdog", namespace="kube-system"} == 0
       for: 5m
       labels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32549

The NodeExporterCollectorFailed alert is currently paging due to customer workload related data being ingested.
This PR proposes a temporary fix to exclude data coming from customer workload by filtering data only coming from `namespace=kube-system`. This should go away when multi-tenancy is in place.