### PR TITLE
fix capi-kubeadmconfig rule for hybrid providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix capi-kubeadmconfig rule for hybrid providers
+
 ## [4.38.1] - 2025-02-06
 
 ### Fixed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmconfig.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmconfig.rules.yml
@@ -12,7 +12,7 @@ spec:
         - alert: KubeadmConfigNotReady
           expr: |-
             (
-              app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"}
+              capi_kubeadmconfig_status_condition{type="Ready", status="False"}
               * on(cluster_id) group_left(provider)
               sum(
                   label_replace(

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmconfig.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmconfig.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-kubeadmconfig
       rules:
         - alert: KubeadmConfigNotReady
-          expr: capi_kubeadmconfig_status_condition{type="Ready", status="False"} > 0
+          expr: |-
+            (
+              app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas


### PR DESCRIPTION

Towards https://github.com/giantswarm/giantswarm/issues/32587

This PR fixes multi-provider routing for `KubeadmConfigNotReady` alert.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
