### PR TITLE
fix capi alerts for hybrid mcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix all capi alerts for hybrid providers
+
 ## [4.39.0] - 2025-02-11
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-cluster.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-cluster
       rules:
         - alert: ClusterUnhealthyPhase
-          expr: capi_cluster_status_phase{phase!="Provisioned"} > 0
+          expr: |-
+            (
+              capi_cluster_status_phase{phase!="Provisioned"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas
@@ -25,7 +34,16 @@ spec:
             opsrecipe: capi-cluster/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
         - alert: ClusterStatusNotReady
-          expr: capi_cluster_status_condition{status="False", type="Ready"} > 0
+          expr: |-
+            (
+              capi_cluster_status_condition{status="False", type="Ready"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas
@@ -39,9 +57,17 @@ spec:
               {{`Cluster {{ $labels.exported_namespace }}/{{ $labels.name }} is not ready.`}}
             opsrecipe: capi-cluster/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
-
         - alert: ClusterPaused
-          expr: capi_cluster_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_cluster_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmcontrolplane.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-kubeadmcontrolplane.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-kubeadmcontrolplane
       rules:
         - alert: KubeadmControlPlaneReplicasMismatch
-          expr: capi_kubeadmcontrolplane_spec_replicas != capi_kubeadmcontrolplane_status_replicas_ready
+          expr: |-
+            (
+              capi_kubeadmcontrolplane_spec_replicas != capi_kubeadmcontrolplane_status_replicas_ready
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            )
           # 90min at max 3 replicas results in maximum of 30 minutes per control-plane machine.
           for: 90m
           labels:
@@ -26,7 +35,16 @@ spec:
             opsrecipe: capi-kubeadmcontrolplane/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
         - alert: KubeadmControlPlanePaused
-          expr: capi_kubeadmcontrolplane_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_kubeadmcontrolplane_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machine.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machine.rules.yml
@@ -15,7 +15,16 @@ spec:
               {{`Machine {{ $labels.exported_namespace}}/{{ $labels.name }} stuck in phase {{ $labels.phase }} for more than 30 minutes.`}}
             opsrecipe: capi-machine/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
-          expr: capi_machine_status_phase{phase!="Running", name!~".*bastion.*"} > 0
+          expr: |-
+            (
+              capi_machine_status_phase{phase!="Running", name!~".*bastion.*"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 30m
           labels:
             area: kaas
@@ -25,7 +34,16 @@ spec:
             team: {{ include "providerTeam" . }}
             topic: managementcluster
         - alert: MachinePaused
-          expr: capi_machine_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_machine_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machinedeployment.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machinedeployment.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-machinedeployment
       rules:
         - alert: MachineDeploymentIsNotHealthy
-          expr: capi_machinedeployment_status_phase{phase="Failed"} > 0
+          expr: |-
+            (
+              capi_machinedeployment_status_phase{phase="Failed"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 15m
           labels:
             area: kaas
@@ -25,7 +34,16 @@ spec:
             opsrecipe: capi-machinedeployment/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
         - alert: MachineDeploymentPaused
-          expr: capi_machinedeployment_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_machinedeployment_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machinepool.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machinepool.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-machinepool
       rules:
         - alert: MachinePoolIsNotHealthy
-          expr: capi_machinepool_status_phase{phase="Failed"} > 0
+          expr: |-
+            (
+              capi_machinepool_status_phase{phase="Failed"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 15m
           labels:
             area: kaas
@@ -25,7 +34,16 @@ spec:
             opsrecipe: capi-machinepool/
             dashboard: bdi7iswg81czkcasd/capi-agregated-error-logs-for-capi-controllers
         - alert: MachinePoolPaused
-          expr: capi_machinepool_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_machinepool_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machineset.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-machineset.rules.yml
@@ -10,7 +10,16 @@ spec:
     - name: capi-machineset
       rules:
         - alert: MachineSetPaused
-          expr: capi_machineset_annotation_paused{paused_value="true"} > 0
+          expr: |-
+            (
+              capi_machineset_annotation_paused{paused_value="true"}
+              * on(cluster_id) group_left(provider)
+              sum(
+                  label_replace(
+                    capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+                  )
+              ) by (cluster_id, provider)
+            ) > 0
           for: 1h
           labels:
             area: kaas


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/32587

This PR broadens this fix https://github.com/giantswarm/prometheus-rules/pull/1494/files to all the other CAPI alerts

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/getting-started/observability/grafana/custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
