### PR TITLE
Remove KubeletDockerOperationsLatencyTooHigh / ManagementClusterAPIServerLatencyTooHigh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `ManagementClusterAPIServerLatencyTooHigh` and `KubeletDockerOperationsLatencyTooHigh` noisy notifying alerts.
+
 ## [4.40.0] - 2025-02-13
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
@@ -13,26 +13,6 @@ spec:
   groups:
   - name: apiserver
     rules:
-    # expr produces 95th percentile latency for requests to the api server, by request verb.
-    # verb WATCH is excluded because it produces a flat line and is not relevant.
-    # verb CONNECT requests often stay open for streaming or tunneling, avoid counting those long-lived connections.
-    # apiserver_request_latencies_bucket are expressed in microseconds, dividing by 1e+06 bring this to seconds.
-    - alert: ManagementClusterAPIServerLatencyTooHigh
-      annotations:
-        description: '{{`Kubernetes API Server {{ $labels.verb }} request latency is too high.`}}'
-        opsrecipe: apiserver-overloaded/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{cluster_type="management_cluster", verb=~"DELETE|GET|PATCH|POST|PUT"}[1h])) by (cluster_id, installation, pipeline, provider, verb, le)) > 1
-      for: 1h
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_cluster_with_notready_nodepools: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        severity: notify
-        team: tenet
-        topic: managementcluster
     - alert: ManagementClusterAPIServerAdmissionWebhookErrors
       annotations:
         description: '{{`Kubernetes API Server {{ $labels.cluster_id }} having admission webhook errors.`}}'

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
@@ -58,22 +58,6 @@ spec:
         severity: notify
         team: tenet
         topic: kubernetes
-    # operation type exec_type Because "exec_sync" operations can be long-running, 
-    # they inflate the 90th-percentile runtime duration above the 120-second threshold, causing the alert to constantly fire. Excluding "exec_sync" or raising the threshold can reduce false positives. 
-    - alert: KubeletDockerOperationsLatencyTooHigh
-      annotations:
-        description: '{{`Kubelet ({{ $labels.instance }}) is taking too long to perform runtime {{ $labels.operation_type }} operations.`}}'
-      expr: histogram_quantile(0.9, rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!~"pull_image|exec_sync"}[5m])) > 120
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
-        cancel_if_kubelet_down: "true"
-        severity: notify
-        team: tenet
-        topic: kubernetes
     - alert: KubeletPLEGLatencyTooHigh
       annotations:
         description: '{{`Kubelet ({{ $labels.instance }}) PLEG latency is too high.`}}'


### PR DESCRIPTION
Those alerts are just too noisy, constant flapping alerts which are flooding our alert channel. Let's drop them