### PR TITLE
Update grafana permission cronjob related alerts to only run on vintage installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update grafana permission cronjob related alerts to only run on vintage installations
+
 ## [4.41.0] - 2025-02-14
 
 ### Removed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
@@ -28,6 +28,7 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
     - alert: GrafanaFolderPermissionsDown
       # Monitors that folder permissions have been updated at least once in the last 6 hours.
       # We have a cronjob (grafana-permissions) that runs every 20 minutes.
@@ -103,3 +104,4 @@ spec:
         team: atlas
         topic: managementcluster
         cancel_if_outside_working_hours: "true"
+    {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3696

Now that we don't use folders anymore on CAPI installations, we don't need these tests on CAPI installations.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
