### PR TITLE
fix dashboard for alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix dashboard annotation for the `MimirObjectStorageLowRate` alert.
+
 ## [4.42.0] - 2025-02-14
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -174,7 +174,7 @@ spec:
         topic: observability
     - alert: MimirObjectStorageLowRate
       annotations:
-        dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes?orgId=2
+        dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
         description: '{{`Mimir object storage write rate is down.`}}'
         opsrecipe: mimir/
       expr: |

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -172,11 +172,11 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    - alert: MimirObjectStorageLowRate
+    - alert: MimirObjectStoreLowRate
       annotations:
         dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
-        description: '{{`Mimir object storage write rate is down.`}}'
-        opsrecipe: mimir/
+        description: '{{`Low rate of writes to the Mimir object store.`}}'
+        opsrecipe: mimir/#mimirobjectstorelowrate
       expr: |
         sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
           rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir"}[30m])

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -567,7 +567,7 @@ tests:
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
 
-  # Test for MimirObjectStorageLowRate alert
+  # Test for MimirObjectStoreLowRate alert
   - interval: 1m
     input_series:
       - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
@@ -575,9 +575,9 @@ tests:
       - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+100x80 100+0x80"
     alert_rule_test:
-      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStoreLowRate
         eval_time: 40m
-      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStoreLowRate
         eval_time: 70m
         exp_alerts:
           - exp_labels:
@@ -598,8 +598,8 @@ tests:
             exp_annotations:
               dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
               description: "Low rate of writes to the Mimir object store."
-              opsrecipe: "mimir/"
-      - alertname: MimirObjectStorageLowRate
+              opsrecipe: "mimir/#mimirobjectstorelowrate"
+      - alertname: MimirObjectStoreLowRate
         eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -596,8 +596,8 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes?orgId=2
-              description: "Mimir object storage write rate is down."
+              dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
+              description: "Low rate of writes to the Mimir object store."
               opsrecipe: "mimir/"
       - alertname: MimirObjectStorageLowRate
         eval_time: 140m

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -567,7 +567,7 @@ tests:
               description: "Mimir continuous test myinstall is not producing metrics."
               opsrecipe: "mimir/"
 
-  # Test for MimirObjectStorageLowRate alert
+  # Test for MimirObjectStoreLowRate alert
   - interval: 1m
     input_series:
       - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
@@ -575,9 +575,9 @@ tests:
       - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+100x80 100+0x80"
     alert_rule_test:
-      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStoreLowRate
         eval_time: 40m
-      - alertname: MimirObjectStorageLowRate
+      - alertname: MimirObjectStoreLowRate
         eval_time: 70m
         exp_alerts:
           - exp_labels:
@@ -598,8 +598,8 @@ tests:
             exp_annotations:
               dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
               description: "Low rate of writes to the Mimir object store."
-              opsrecipe: "mimir/"
-      - alertname: MimirObjectStorageLowRate
+              opsrecipe: "mimir/#mimirobjectstorelowrate"
+      - alertname: MimirObjectStoreLowRate
         eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -596,8 +596,8 @@ tests:
               team: atlas
               topic: observability
             exp_annotations:
-              dashboard: 8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes?orgId=2
-              description: "Mimir object storage write rate is down."
+              dashboard: e1324ee2a434f4158c00a9ee279d3292/mimir-object-store?orgId=2
+              description: "Low rate of writes to the Mimir object store."
               opsrecipe: "mimir/"
       - alertname: MimirObjectStorageLowRate
         eval_time: 140m


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR fixes the dashboard that is linked with this alert

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
