### PR TITLE
Send loki rules to the giantswarm tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Load loki rules into the giantswarm tenant.
+
 ## [4.42.1] - 2025-02-17
 
 ### Fixed

--- a/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
+++ b/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
@@ -64,7 +64,7 @@ data:
             }
             loki.rules.kubernetes "local" {
               address = "http://loki-backend.loki.svc:3100/"
-              tenant_id = "{{ .Values.managementCluster.name }}"
+              tenant_id = "giantswarm"
               rule_selector {
                   match_expression {
                     key = "application.giantswarm.io/prometheus-rule-kind"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: hhttps://github.com/giantswarm/roadmap/issues/3680

We moved the log tenant to giantswarm, let's fix the rule loading

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
