### PR TITLE
make cronjob not scheduled alerts business hours only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `LokiLogTenantIdMissing` alert to detect dropped log lines due to missing tenant
+- Add `LokiLogTenantIdMissing` alert to detect dropped log lines due to missing tenant.
+
+### Changed
+
+- Make `JobHasNotBeenScheduledForTooLong` alerts business hours only.
 
 ## [4.45.0] - 2025-02-25
 

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vintage.aws.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/vintage.aws.management-cluster.rules.yml
@@ -175,4 +175,5 @@ spec:
         severity: page
         team: phoenix
         topic: managementcluster
+        cancel_if_outside_working_hours: "true"
 {{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/silence-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/silence-operator.rules.yml
@@ -36,3 +36,4 @@ spec:
         severity: page
         team: atlas
         topic: managementcluster
+        cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://gigantic.slack.com/archives/C020E38NGTZ/p1740556869980439

This PR marks all `CronJobHasNotBeenScheduledForTooLong` as business hours only alert to prevent nightly alerts

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
