### PR TITLE
overridable tenants used to load rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extra logs and metrics tenant into helm values.
+- Make logs and metrics tenant configurable via helm values.
 
 ## [4.46.1] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Document how to create alerts based on logs.
+
+### Changed
+
+- Extra logs and metrics tenant into helm values.
+
 ## [4.46.1] - 2025-02-27
 
 - make disk fill up alert for `zot` more sensitive
@@ -16,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `LokiLogTenantIdMissing` alert to detect dropped log lines due to missing tenant.
-- Document how to create alerts based on logs.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
+++ b/helm/prometheus-rules/templates/alloy-rules-configmap.yaml
@@ -53,7 +53,7 @@ data:
           content: |
             mimir.rules.kubernetes "local" {
               address = "http://mimir-ruler.mimir.svc:8080/"
-              tenant_id = "anonymous"
+              tenant_id = {{ .Values.metrics.tenant | quote }}
               rule_selector {
                   match_expression {
                     key = "application.giantswarm.io/prometheus-rule-kind"
@@ -64,7 +64,7 @@ data:
             }
             loki.rules.kubernetes "local" {
               address = "http://loki-backend.loki.svc:3100/"
-              tenant_id = "giantswarm"
+              tenant_id = {{ .Values.logs.tenant | quote }}
               rule_selector {
                   match_expression {
                     key = "application.giantswarm.io/prometheus-rule-kind"

--- a/helm/prometheus-rules/values.schema.json
+++ b/helm/prometheus-rules/values.schema.json
@@ -2,6 +2,42 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "Installation": {
+            "type": "object",
+            "properties": {
+                "V1": {
+                    "type": "object",
+                    "properties": {
+                        "Guest": {
+                            "type": "object",
+                            "properties": {
+                                "Kubernetes": {
+                                    "type": "object",
+                                    "properties": {
+                                        "IngressController": {
+                                            "type": "object",
+                                            "properties": {
+                                                "BaseDomain": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "logs": {
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "type": "string"
+                }
+            }
+        },
         "managementCluster": {
             "type": "object",
             "properties": {
@@ -30,22 +66,19 @@
                 }
             }
         },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "type": "string"
+                }
+            }
+        },
         "name": {
             "type": "string"
         },
         "namespace": {
             "type": "string"
-        },
-        "project": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "type": "string"
-                },
-                "commit": {
-                    "type": "string"
-                }
-            }
         },
         "serviceType": {
             "type": "string"

--- a/helm/prometheus-rules/values.yaml
+++ b/helm/prometheus-rules/values.yaml
@@ -10,6 +10,11 @@ managementCluster:
     flavor: ""
     region: ""
 
+logs:
+  tenant: giantswarm
+metrics:
+  tenant: anonymous
+
 Installation:
   V1:
     Guest:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/3678

This PR allows us to be able to switch the default tenant used to load rules so we can easily switch from the anymonous tenants to the giantswarm tenants from one shared-config PR

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
