### PR TITLE
Remove PrometheusOperatorSyncFailed and PrometheusOperatorReconcileErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `PrometheusOperatorSyncFailed` alert.
+- Remove `PrometheusOperatorReconcileErrors` alert.
+
 ## [4.47.0] - 2025-03-04
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
@@ -69,30 +69,6 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    - alert: PrometheusOperatorSyncFailed
-      annotations:
-        description: Controller {{`{{`}} $labels.controller {{`}}`}} in {{`{{`}} $labels.namespace {{`}}`}} namespace fails to reconcile {{`{{`}} $value {{`}}`}} objects.
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/prometheus-operator/
-      expr: min_over_time(prometheus_operator_syncs{status="failed", job=~"prometheus-operator-app-operator|kube-prometheus-stack-operator"}[5m]) > 0
-      for: 10m
-      labels:
-        area: platform
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
-    - alert: PrometheusOperatorReconcileErrors
-      annotations:
-        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconciling operations failed for {{`{{`}} $labels.controller {{`}}`}} controller in {{`{{`}} $labels.namespace {{`}}`}} namespace.'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/prometheus-operator/
-      expr: (sum by (cluster_id, installation, provider, pipeline, controller, namespace) (rate(prometheus_operator_reconcile_errors_total{job=~"prometheus-operator-app-operator|kube-prometheus-stack-operator"}[5m]))) / (sum by (cluster_id, installation, provider, pipeline, controller, namespace) (rate(prometheus_operator_reconcile_operations_total{job=~"prometheus-operator-app-operator|kube-prometheus-stack-operator"}[5m]))) > 0.1
-      for: 10m
-      labels:
-        area: platform
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
     - alert: PrometheusOperatorNodeLookupErrors
       annotations:
         description: Errors while reconciling Prometheus in {{`{{`}} $labels.namespace {{`}}`}} Namespace.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32767

Remove noisy alerts about prometheus operator reconciliations.