### PR TITLE
CI: add lokitool

### DIFF
--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -3,40 +3,47 @@ set -euo pipefail
 
 # let's have reproducable tests - pin to specific versions
 ARCHITECT_VERSION="6.17.0"
-PROMETHEUS_VERSION="2.54.0"
 HELM_VERSION="3.1.0"
-YQ_VERSION="4.44.3"
 JQ_VERSION="1.7.1"
+LOKITOOL_VERSION="3.4.2"
 PINT_VERSION="0.64.0"
+PROMETHEUS_VERSION="2.54.0"
+YQ_VERSION="4.44.3"
 
 GIT_WORKDIR=$(git rev-parse --show-toplevel)
-
 OS_BASE="$(uname -s)"
-TAR_CMD="tar"
+
 case "${OS_BASE}" in
 Linux*)
-    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
-    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    TAR_CMD="$(command -v tar)"
+
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-linux-amd64.tar.gz"
-    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
-    export YQ_BIN_FILE="yq_linux_amd64"
+    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    export JQ_BIN_FILE="jq-linux-amd64"
     export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
-    export JQ_BIN_FILE="jq"
-    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
+    export LOKITOOL_BIN_FILE="lokitool-linux-amd64"
+    export LOKITOOL_SOURCE="https://github.com/grafana/loki/releases/download/v${LOKITOOL_VERSION}/lokitool-linux-amd64.zip"
     export PINT_BIN_FILE="pint-linux-amd64"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
+    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+    export YQ_BIN_FILE="yq_linux_amd64"
+    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
     ;;
 
 Darwin*)
-    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.darwin-amd64.tar.gz"
-    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz"
+    TAR_CMD="$(command -v gtar)"
+
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-darwin-amd64.tar.gz"
-    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
-    export YQ_BIN_FILE="yq_darwin_amd64"
+    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz"
+    export JQ_BIN_FILE="jq-macos-amd64"
     export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-macos-amd64"
-    export JQ_BIN_FILE="jq"
-    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
+    export LOKITOOL_BIN_FILE="lokitool-darwin-amd64"
+    export LOKITOOL_SOURCE="https://github.com/grafana/loki/releases/download/v${LOKITOOL_VERSION}/lokitool-darwin-amd64.zip"
     export PINT_BIN_FILE="pint-darwin-amd64"
-    TAR_CMD="gtar"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
+    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.darwin-amd64.tar.gz"
+    export YQ_BIN_FILE="yq_darwin_amd64"
+    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
     ;;
 
 *)
@@ -47,42 +54,65 @@ Darwin*)
 esac
 
 download() {
-    local sourcefile="$1" && shift
+    local sourceurl="$1" && shift
     local destfile="$1" && shift
 
     # download files only if they don't exist yet
     if [[ ! -f "$destfile" ]]; then
-        echo "Downloading $destfile"
-        curl -s -L -o "$destfile" "$sourcefile"
+        echo "## Downloading $sourceurl"
+        curl --silent --location --output "$destfile" "$sourceurl"
     fi
 
     if [[ ! -f "$destfile" ]]; then
-        echo "Failed downloading $destfile"
+        echo "## Failed downloading $destfile"
         return 1
     fi
 }
 
 extract() {
     local binfile="$1" && shift
-    local tarfile="$1" && shift
     local sourceurl="$1" && shift
-    local wildcards="$1" && shift
+    local archivebinpath="$1" && shift
     local stripcomponents="${1:-1}" && shift || true
+
+    local archivefile
+    remotearchivefile="${sourceurl##*/}"
+    archivefile="${TMP_DIR}/${remotearchivefile}"
 
     # extract files only if not exist yet
     if [[ ! -f "$binfile" ]]; then
+        echo
+        echo "## Installing $binfile"
 
-        download "$sourceurl" "$tarfile"
+        download "$sourceurl" "$archivefile"
+        archivedir="$TMP_DIR/${remotearchivefile}.extracted"
+        mkdir -p "$archivedir"
 
-        echo ""
-        echo "## Contents for $tarfile:"
-        "$TAR_CMD" -tzvf "$tarfile"
+        case "$archivefile" in
+          *.tar*)
+            echo "## Contents for $archivefile:"
+            "$TAR_CMD" --list --gzip --verbose --file "$archivefile"
 
-        echo "## Extracted files:"
-        "$TAR_CMD" -xvf "$tarfile" \
-            -C "$GIT_WORKDIR/test/hack/bin/" \
-            --strip-components="$stripcomponents" \
-            --wildcards "$wildcards"
+            echo "## Extracted files:"
+            "$TAR_CMD" --extract --gzip --verbose --file "$archivefile" \
+                --directory "$archivedir" \
+                --strip-components "$stripcomponents"
+            ;;
+          *.zip)
+            echo "## Contents for $archivefile:"
+            unzip -l "$archivefile"
+
+            echo "## Extracted files:"
+            unzip -q "$archivefile" -d "$archivedir" "$archivebinpath"
+            ;;
+          *)
+            # assuming it's a binary
+            mv "$archivefile" "$archivedir/$archivebinpath"
+            ;;
+        esac
+
+        mv "$archivedir/$archivebinpath" "$binfile"
+        chmod +x "$binfile"
     fi
 
     if [[ ! -f "$binfile" ]]; then
@@ -92,42 +122,44 @@ extract() {
 }
 
 main() {
-    extract \
-        "${GIT_WORKDIR}/test/hack/bin/promtool" \
-        "$GIT_WORKDIR/test/hack/bin/prometheus-$PROMETHEUS_VERSION.tar.gz" \
-        "$PROMETHEUS_SOURCE" \
-        "prometheus-$PROMETHEUS_VERSION*/promtool"
-    extract \
-        "${GIT_WORKDIR}/test/hack/bin/helm" \
-        "${GIT_WORKDIR}/test/hack/bin/helm-${HELM_VERSION}.tar.gz" \
-        "$HELM_SOURCE" \
-        "*/helm"
+    TMP_DIR="$(mktemp -d -t fetch-tools-XXXXXXXXXX)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
     extract \
         "${GIT_WORKDIR}/test/hack/bin/architect" \
-        "${GIT_WORKDIR}/test/hack/bin/architect-${ARCHITECT_VERSION}.tar.gz" \
         "$ARCHITECT_SOURCE" \
-        "architect-v${ARCHITECT_VERSION}-*/architect"
+        "architect"
+
     extract \
-        "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" \
-        "${GIT_WORKDIR}/test/hack/bin/yq-${YQ_VERSION}.tar.gz" \
-        "$YQ_SOURCE" \
-        "*/yq_*"
-    download \
-        "${JQ_SOURCE}" \
-        "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
-    chmod +x "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
-    if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/yq" ]]; then
-        ln -s "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/yq"
-    fi
+        "${GIT_WORKDIR}/test/hack/bin/helm" \
+        "$HELM_SOURCE" \
+        "helm"
+
     extract \
-        "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" \
-        "${GIT_WORKDIR}/test/hack/bin/pint-${PINT_VERSION}.tar.gz" \
+        "${GIT_WORKDIR}/test/hack/bin/jq" \
+        "$JQ_SOURCE" \
+        "$JQ_BIN_FILE"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/lokitool" \
+        "$LOKITOOL_SOURCE" \
+        "$LOKITOOL_BIN_FILE"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/pint" \
         "$PINT_SOURCE" \
-        "pint-*" \
+        "$PINT_BIN_FILE" \
         0
-    if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/pint" ]]; then
-        ln -s "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/pint"
-    fi
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/promtool" \
+        "$PROMETHEUS_SOURCE" \
+        "promtool"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/yq" \
+        "$YQ_SOURCE" \
+        "$YQ_BIN_FILE"
 }
 
 main "$@"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3919

This PR adds `lokitool` to tooling suite in order to later perform Loki rules validation.

This PR also does some refactoring in fetch-tool.sh

- Add support for zip archives
- Use temp directory to fetch and extract archives
- Fetch all tools using extract
- Align extract arguments to consistently use: destination, source, archive path
- Ensure all binaries are executables: chmod +x
- Sort alphabetically versions, source urls, and extraction calls
- Use command -v to find tar/gtar binaries
- Align output format

<details>
<summary>fetch-tools.sh output</summary>

```bash
$ make clean
# clean stage
git clean -xdf -- test/hack/bin test/hack/output test/hack/checkLabels
Removing test/hack/bin/architect
Removing test/hack/bin/helm
Removing test/hack/bin/jq
Removing test/hack/bin/lokitool
Removing test/hack/bin/pint
Removing test/hack/bin/promtool
Removing test/hack/bin/yq
$ ./test/hack/bin/fetch-tools.sh

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/architect
## Downloading https://github.com/giantswarm/architect/releases/download/v6.17.0/architect-v6.17.0-linux-amd64.tar.gz
## Contents for /tmp/fetch-tools-yy9c8g1sp1/architect-v6.17.0-linux-amd64.tar.gz:
drwxr-xr-x runner/docker     0 2024-08-19 18:15 architect-v6.17.0-linux-amd64/
-rwxr-xr-x runner/docker 16621942 2024-08-19 18:15 architect-v6.17.0-linux-amd64/architect
-rw-r--r-- runner/docker    11353 2024-08-19 18:15 architect-v6.17.0-linux-amd64/LICENSE
-rw-r--r-- runner/docker     1155 2024-08-19 18:15 architect-v6.17.0-linux-amd64/README.md
## Extracted files:
architect-v6.17.0-linux-amd64/architect
architect-v6.17.0-linux-amd64/LICENSE
architect-v6.17.0-linux-amd64/README.md

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/helm
## Downloading https://get.helm.sh/helm-v3.1.0-linux-amd64.tar.gz
## Contents for /tmp/fetch-tools-yy9c8g1sp1/helm-v3.1.0-linux-amd64.tar.gz:
drwxr-xr-x circleci/circleci 0 2020-02-13 17:34 linux-amd64/
-rw-r--r-- circleci/circleci 11373 2020-02-13 17:34 linux-amd64/LICENSE
-rwxr-xr-x circleci/circleci 38457344 2020-02-13 17:34 linux-amd64/helm
-rw-r--r-- circleci/circleci     3238 2020-02-13 17:34 linux-amd64/README.md
## Extracted files:
linux-amd64/LICENSE
linux-amd64/helm
linux-amd64/README.md

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/jq
## Downloading https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/lokitool
## Downloading https://github.com/grafana/loki/releases/download/v3.4.2/lokitool-linux-amd64.zip
## Contents for /tmp/fetch-tools-yy9c8g1sp1/lokitool-linux-amd64.zip:
Archive:  /tmp/fetch-tools-yy9c8g1sp1/lokitool-linux-amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 82854040  2025-02-14 09:55   lokitool-linux-amd64
---------                     -------
 82854040                     1 file
## Extracted files:

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/pint
## Downloading https://github.com/cloudflare/pint/releases/download/v0.64.0/pint-0.64.0-linux-amd64.tar.gz
## Contents for /tmp/fetch-tools-yy9c8g1sp1/pint-0.64.0-linux-amd64.tar.gz:
-rw-r--r-- runner/docker 11357 2024-08-08 18:34 LICENSE
-rw-r--r-- runner/docker   946 2024-08-08 18:34 README.md
-rwxr-xr-x runner/docker 21426328 2024-08-08 18:36 pint-linux-amd64
## Extracted files:
LICENSE
README.md
pint-linux-amd64

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/promtool
## Downloading https://github.com/prometheus/prometheus/releases/download/v2.54.0/prometheus-2.54.0.linux-amd64.tar.gz
## Contents for /tmp/fetch-tools-yy9c8g1sp1/prometheus-2.54.0.linux-amd64.tar.gz:
drwxr-xr-x runner/docker     0 2024-08-09 13:57 prometheus-2.54.0.linux-amd64/
-rw-r--r-- runner/docker  3773 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/NOTICE
-rw-r--r-- runner/docker 11357 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/LICENSE
-rw-r--r-- runner/docker   934 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/prometheus.yml
-rwxr-xr-x runner/docker 140098738 2024-08-09 13:38 prometheus-2.54.0.linux-amd64/prometheus
drwxr-xr-x runner/docker         0 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/
-rw-r--r-- runner/docker      4103 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/prometheus-overview.html
-rw-r--r-- runner/docker      5812 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/node-overview.html
-rw-r--r-- runner/docker       616 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/index.html.example
-rw-r--r-- runner/docker      1488 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/node.html
-rw-r--r-- runner/docker      3522 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/node-disk.html
-rw-r--r-- runner/docker      1334 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/prometheus.html
-rw-r--r-- runner/docker      2704 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/consoles/node-cpu.html
-rwxr-xr-x runner/docker 131797600 2024-08-09 13:38 prometheus-2.54.0.linux-amd64/promtool
drwxr-xr-x runner/docker         0 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/console_libraries/
-rw-r--r-- runner/docker      2888 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/console_libraries/menu.lib
-rw-r--r-- runner/docker      6152 2024-08-09 13:54 prometheus-2.54.0.linux-amd64/console_libraries/prom.lib
## Extracted files:
prometheus-2.54.0.linux-amd64/NOTICE
prometheus-2.54.0.linux-amd64/LICENSE
prometheus-2.54.0.linux-amd64/prometheus.yml
prometheus-2.54.0.linux-amd64/prometheus
prometheus-2.54.0.linux-amd64/consoles/
prometheus-2.54.0.linux-amd64/consoles/prometheus-overview.html
prometheus-2.54.0.linux-amd64/consoles/node-overview.html
prometheus-2.54.0.linux-amd64/consoles/index.html.example
prometheus-2.54.0.linux-amd64/consoles/node.html
prometheus-2.54.0.linux-amd64/consoles/node-disk.html
prometheus-2.54.0.linux-amd64/consoles/prometheus.html
prometheus-2.54.0.linux-amd64/consoles/node-cpu.html
prometheus-2.54.0.linux-amd64/promtool
prometheus-2.54.0.linux-amd64/console_libraries/
prometheus-2.54.0.linux-amd64/console_libraries/menu.lib
prometheus-2.54.0.linux-amd64/console_libraries/prom.lib

## Installing /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/bin/yq
## Downloading https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64.tar.gz
## Contents for /tmp/fetch-tools-yy9c8g1sp1/yq_linux_amd64.tar.gz:
-rwxr-xr-x runner/docker 9969816 2024-08-05 07:46 ./yq_linux_amd64
-rw-r--r-- runner/docker  213859 2024-08-05 07:40 yq.1
-rwxr-xr-x runner/docker     405 2024-08-05 07:39 install-man-page.sh
## Extracted files:
./yq_linux_amd64
$ ls -l test/hack/bin
total 296404
-rwxr-xr-x 1 theo theo  16621942 19 août   2024 architect
-rwxr-xr-x 1 theo theo      7147  7 mars  12:56 check-runbooks.sh
-rwxr-xr-x 1 theo theo      5482  7 mars  14:19 fetch-tools.sh
-rwxr-xr-x 1 theo theo       653  7 mars  12:56 get-inhibition.sh
-rwxr-xr-x 1 theo theo  38457344 13 févr.  2020 helm
-rwxr-xr-x 1 theo theo   2319424  7 mars  14:26 jq
-rwxr-xr-x 1 theo theo  82854040 14 févr. 09:55 lokitool
-rwxr-xr-x 1 theo theo  21426328  8 août   2024 pint
-rwxr-xr-x 1 theo theo 131797600  9 août   2024 promtool
-rwxr-xr-x 1 theo theo       836  7 mars  12:56 run-pint.sh
-rwxr-xr-x 1 theo theo      1164  7 mars  12:56 template-chart.sh
-rwxr-xr-x 1 theo theo      6635  7 mars  13:01 verify-rules.sh
-rwxr-xr-x 1 theo theo   9969816  5 août   2024 yq
```

</details>