### PR TITLE
CI: add loki rule test

### DIFF
--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -4,14 +4,16 @@ run-name: run unit and conformance tests
 on: [pull_request]
 
 jobs:
-  promtool-unit-tests:
+  rules-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - name: run promtool unit tests
-        run: make test-rules
+      - name: run prometheus rules tests
+        run: make test-rules rule_type=prometheus
+      - name: run loki rules tests
+        run: make test-rules rule_type=loki
   inhibition-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/alert_tests.yaml
+++ b/.github/workflows/alert_tests.yaml
@@ -10,10 +10,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-      - name: run prometheus rules tests
-        run: make test-rules rule_type=prometheus
-      - name: run loki rules tests
-        run: make test-rules rule_type=loki
+      - name: run rules tests
+        run: make test-rules
   inhibition-tests:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Loki rules validation in CI
+
 ### Fixed
 
 - Use the api group for the crossplane alerts to filter out resources that we don't care about.

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -19,7 +19,7 @@ template-chart: install-tools ## prepare the helm chart
 	bash ./test/hack/bin/template-chart.sh
 
 test-rules: install-tools template-chart ## run unit tests for alerting rules
-	bash test/hack/bin/verify-rules.sh "$(test_filter)"
+	bash test/hack/bin/verify-rules.sh "$(test_filter)" "${rule_type}"
 
 test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
 	bash test/hack/bin/get-inhibition.sh

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -19,7 +19,7 @@ template-chart: install-tools ## prepare the helm chart
 	bash ./test/hack/bin/template-chart.sh
 
 test-rules: install-tools template-chart ## run unit tests for alerting rules
-	bash test/hack/bin/verify-rules.sh "$(test_filter)" "${rule_type}"
+	bash test/hack/bin/verify-rules.sh "$(test_filter)" "${rules_type}"
 
 test-inhibitions: install-tools template-chart ## test whether inhibition labels are well defined
 	bash test/hack/bin/get-inhibition.sh

--- a/README.md
+++ b/README.md
@@ -349,6 +349,15 @@ make test-rules test_filter=grafana
 make test-rules test_filter=gr.*na
 ```
 
+##### Filter rules type
+
+You can select which type of rules you want to test, by default all rules are tested:
+
+```
+make test-rules rules_type=prometheus
+make test-rules rules_type=loki
+```
+
 #### Test "no data" case
 
 * It can be nice to test what happens when serie does not exist.

--- a/test/hack/bin/fetch-tools.sh
+++ b/test/hack/bin/fetch-tools.sh
@@ -3,40 +3,47 @@ set -euo pipefail
 
 # let's have reproducable tests - pin to specific versions
 ARCHITECT_VERSION="6.17.0"
-PROMETHEUS_VERSION="2.54.0"
 HELM_VERSION="3.1.0"
-YQ_VERSION="4.44.3"
 JQ_VERSION="1.7.1"
+LOKITOOL_VERSION="3.4.2"
 PINT_VERSION="0.64.0"
+PROMETHEUS_VERSION="2.54.0"
+YQ_VERSION="4.44.3"
 
 GIT_WORKDIR=$(git rev-parse --show-toplevel)
-
 OS_BASE="$(uname -s)"
-TAR_CMD="tar"
+
 case "${OS_BASE}" in
 Linux*)
-    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
-    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    TAR_CMD="$(command -v tar)"
+
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-linux-amd64.tar.gz"
-    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
-    export YQ_BIN_FILE="yq_linux_amd64"
+    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    export JQ_BIN_FILE="jq-linux-amd64"
     export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64"
-    export JQ_BIN_FILE="jq"
-    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
+    export LOKITOOL_BIN_FILE="lokitool-linux-amd64"
+    export LOKITOOL_SOURCE="https://github.com/grafana/loki/releases/download/v${LOKITOOL_VERSION}/lokitool-linux-amd64.zip"
     export PINT_BIN_FILE="pint-linux-amd64"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-linux-amd64.tar.gz"
+    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+    export YQ_BIN_FILE="yq_linux_amd64"
+    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz"
     ;;
 
 Darwin*)
-    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.darwin-amd64.tar.gz"
-    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz"
+    TAR_CMD="$(command -v gtar)"
+
     export ARCHITECT_SOURCE="https://github.com/giantswarm/architect/releases/download/v${ARCHITECT_VERSION}/architect-v${ARCHITECT_VERSION}-darwin-amd64.tar.gz"
-    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
-    export YQ_BIN_FILE="yq_darwin_amd64"
+    export HELM_SOURCE="https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz"
+    export JQ_BIN_FILE="jq-macos-amd64"
     export JQ_SOURCE="https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-macos-amd64"
-    export JQ_BIN_FILE="jq"
-    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
+    export LOKITOOL_BIN_FILE="lokitool-darwin-amd64"
+    export LOKITOOL_SOURCE="https://github.com/grafana/loki/releases/download/v${LOKITOOL_VERSION}/lokitool-darwin-amd64.zip"
     export PINT_BIN_FILE="pint-darwin-amd64"
-    TAR_CMD="gtar"
+    export PINT_SOURCE="https://github.com/cloudflare/pint/releases/download/v${PINT_VERSION}/pint-${PINT_VERSION}-darwin-amd64.tar.gz"
+    export PROMETHEUS_SOURCE="https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.darwin-amd64.tar.gz"
+    export YQ_BIN_FILE="yq_darwin_amd64"
+    export YQ_SOURCE="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_darwin_amd64.tar.gz"
     ;;
 
 *)
@@ -47,42 +54,65 @@ Darwin*)
 esac
 
 download() {
-    local sourcefile="$1" && shift
+    local sourceurl="$1" && shift
     local destfile="$1" && shift
 
     # download files only if they don't exist yet
     if [[ ! -f "$destfile" ]]; then
-        echo "Downloading $destfile"
-        curl -s -L -o "$destfile" "$sourcefile"
+        echo "## Downloading $sourceurl"
+        curl --silent --location --output "$destfile" "$sourceurl"
     fi
 
     if [[ ! -f "$destfile" ]]; then
-        echo "Failed downloading $destfile"
+        echo "## Failed downloading $destfile"
         return 1
     fi
 }
 
 extract() {
     local binfile="$1" && shift
-    local tarfile="$1" && shift
     local sourceurl="$1" && shift
-    local wildcards="$1" && shift
+    local archivebinpath="$1" && shift
     local stripcomponents="${1:-1}" && shift || true
+
+    local archivefile
+    remotearchivefile="${sourceurl##*/}"
+    archivefile="${TMP_DIR}/${remotearchivefile}"
 
     # extract files only if not exist yet
     if [[ ! -f "$binfile" ]]; then
+        echo
+        echo "## Installing $binfile"
 
-        download "$sourceurl" "$tarfile"
+        download "$sourceurl" "$archivefile"
+        archivedir="$TMP_DIR/${remotearchivefile}.extracted"
+        mkdir -p "$archivedir"
 
-        echo ""
-        echo "## Contents for $tarfile:"
-        "$TAR_CMD" -tzvf "$tarfile"
+        case "$archivefile" in
+          *.tar*)
+            echo "## Contents for $archivefile:"
+            "$TAR_CMD" --list --gzip --verbose --file "$archivefile"
 
-        echo "## Extracted files:"
-        "$TAR_CMD" -xvf "$tarfile" \
-            -C "$GIT_WORKDIR/test/hack/bin/" \
-            --strip-components="$stripcomponents" \
-            --wildcards "$wildcards"
+            echo "## Extracted files:"
+            "$TAR_CMD" --extract --gzip --verbose --file "$archivefile" \
+                --directory "$archivedir" \
+                --strip-components "$stripcomponents"
+            ;;
+          *.zip)
+            echo "## Contents for $archivefile:"
+            unzip -l "$archivefile"
+
+            echo "## Extracted files:"
+            unzip -q "$archivefile" -d "$archivedir" "$archivebinpath"
+            ;;
+          *)
+            # assuming it's a binary
+            mv "$archivefile" "$archivedir/$archivebinpath"
+            ;;
+        esac
+
+        mv "$archivedir/$archivebinpath" "$binfile"
+        chmod +x "$binfile"
     fi
 
     if [[ ! -f "$binfile" ]]; then
@@ -92,42 +122,44 @@ extract() {
 }
 
 main() {
-    extract \
-        "${GIT_WORKDIR}/test/hack/bin/promtool" \
-        "$GIT_WORKDIR/test/hack/bin/prometheus-$PROMETHEUS_VERSION.tar.gz" \
-        "$PROMETHEUS_SOURCE" \
-        "prometheus-$PROMETHEUS_VERSION*/promtool"
-    extract \
-        "${GIT_WORKDIR}/test/hack/bin/helm" \
-        "${GIT_WORKDIR}/test/hack/bin/helm-${HELM_VERSION}.tar.gz" \
-        "$HELM_SOURCE" \
-        "*/helm"
+    TMP_DIR="$(mktemp -d -t fetch-tools-XXXXXXXXXX)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
     extract \
         "${GIT_WORKDIR}/test/hack/bin/architect" \
-        "${GIT_WORKDIR}/test/hack/bin/architect-${ARCHITECT_VERSION}.tar.gz" \
         "$ARCHITECT_SOURCE" \
-        "architect-v${ARCHITECT_VERSION}-*/architect"
+        "architect"
+
     extract \
-        "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" \
-        "${GIT_WORKDIR}/test/hack/bin/yq-${YQ_VERSION}.tar.gz" \
-        "$YQ_SOURCE" \
-        "*/yq_*"
-    download \
-        "${JQ_SOURCE}" \
-        "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
-    chmod +x "${GIT_WORKDIR}/test/hack/bin/${JQ_BIN_FILE}"
-    if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/yq" ]]; then
-        ln -s "${GIT_WORKDIR}/test/hack/bin/${YQ_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/yq"
-    fi
+        "${GIT_WORKDIR}/test/hack/bin/helm" \
+        "$HELM_SOURCE" \
+        "helm"
+
     extract \
-        "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" \
-        "${GIT_WORKDIR}/test/hack/bin/pint-${PINT_VERSION}.tar.gz" \
+        "${GIT_WORKDIR}/test/hack/bin/jq" \
+        "$JQ_SOURCE" \
+        "$JQ_BIN_FILE"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/lokitool" \
+        "$LOKITOOL_SOURCE" \
+        "$LOKITOOL_BIN_FILE"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/pint" \
         "$PINT_SOURCE" \
-        "pint-*" \
+        "$PINT_BIN_FILE" \
         0
-    if [[ ! -f "${GIT_WORKDIR}/test/hack/bin/pint" ]]; then
-        ln -s "${GIT_WORKDIR}/test/hack/bin/${PINT_BIN_FILE}" "${GIT_WORKDIR}/test/hack/bin/pint"
-    fi
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/promtool" \
+        "$PROMETHEUS_SOURCE" \
+        "promtool"
+
+    extract \
+        "${GIT_WORKDIR}/test/hack/bin/yq" \
+        "$YQ_SOURCE" \
+        "$YQ_BIN_FILE"
 }
 
 main "$@"

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -euo pipefail
 #
 # This test ensures that all prometheus rules are valid
 #
 
-set -eu
+set -euo pipefail
 
 # Global options
 

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -36,6 +36,7 @@ main() {
 
     # Rule type to test
     rules_type="${2:-$RULES_TYPE_DEFAULT}"
+    # Using variable expansion to access map values, otherwise * would cause a unbound variable error
     rules_suffix_var="RULES_TYPES[$rules_type]"
     rules_suffix_pattern=$(IFS="|"; echo ".*(${!rules_suffix_var})") || {
         echo "Unsupported rule type: $rules_type"

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -121,9 +121,9 @@ main() {
 
             # Detect rule type
             local file_rule_type=
-            for r in "${!RULES_TYPES[@]}"; do
-                if [[ "$file" =~ .*${RULES_TYPES[$r]} ]]; then
-                    file_rule_type="$r"
+            for rules_type_candidate in "${!RULES_TYPES[@]}"; do
+                if [[ "$file" =~ .*${RULES_TYPES[$rules_type_candidate]} ]]; then
+                    file_rule_type="$rules_type_candidate"
                     break
                 fi
             done

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -38,7 +38,7 @@ main() {
     rules_type="${2:-$RULES_TYPE_DEFAULT}"
     # Using variable expansion to access map values, otherwise * would cause a unbound variable error
     rules_suffix_var="RULES_TYPES[$rules_type]"
-    rules_suffix_pattern=$(IFS="|"; echo ".*(${!rules_suffix_var})") || {
+    rules_suffix_pattern=$(IFS="|"; echo ".*(${!rules_suffix_var})$") || {
         echo "Unsupported rule type: $rules_type"
         exit 1
     }

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -13,6 +13,10 @@ GENERATE_ONLY="${GENERATE_ONLY:-false}"
 
 ## RULE_TYPE_DEFAULT: default type of rules to test
 RULE_TYPE_DEFAULT="prometheus"
+## RULE_TYPES: list of supported rule types to test and their suffixes
+declare -A RULE_TYPES
+RULE_TYPES["prometheus"]="rules.yml"
+RULE_TYPES["loki"]="logs.yml"
 
 array_contains() {
     local search="$1" && shift
@@ -38,6 +42,7 @@ main() {
     GIT_WORKDIR=$(git rev-parse --show-toplevel)
 
     local PROMTOOL=test/hack/bin/promtool
+    local LOKITOOL=test/hack/bin/lokitool
     local YQ=test/hack/bin/yq
 
     expected_failure_relative_file_global="test/conf/promtool_ignore"
@@ -78,8 +83,7 @@ main() {
         # Look at each rules file for current provider
         cd "$outputPath/helm-chart/$provider/prometheus-rules/templates" || return 1
 
-        rule_suffix_var_name="RULE_SUFFIX_${RULE_TYPE^^}"
-        rule_suffix="${!rule_suffix_var_name}"
+        rule_suffix="${RULE_TYPES[$rule_type]}"
         find . -type f -name "*${rule_suffix}" -print0 | while read -r -d '' file; do
             # Remove "./" at the vbeggining of the file path
             file="${file#./}"
@@ -109,46 +113,75 @@ main() {
             if [[ "$GENERATE_ONLY" == "true" ]]; then continue; fi
 
             # Syntax check of rules file
-            echo "###    promtool check rules $outputPath/generated/$provider/$file"
-            local promtool_check_output
-            if ! promtool_check_output="$("$GIT_WORKDIR/$PROMTOOL" check rules "$outputPath/generated/$provider/$file" 2>&1)";
-            then
-                echo "###  Warning: Syntax check failing for $file:"
-                echo "$promtool_check_output"
-                promtool_check_errors+=("$promtool_check_output")
-                continue
-            fi
+            case "$rule_type" in
+              prometheus)
+                echo "###    promtool check rules $outputPath/generated/$provider/$file"
+                local promtool_check_output
+                if ! promtool_check_output="$("$GIT_WORKDIR/$PROMTOOL" check rules "$outputPath/generated/$provider/$file" 2>&1)";
+                then
+                    echo "###  Warning: Syntax check failing for $file:"
+                    echo "$promtool_check_output"
+                    promtool_check_errors+=("$promtool_check_output")
+                    continue
+                fi
 
-            local provider_testfile="$outputPath/generated/$provider/$dirname/$filenameWithoutExtension.test.yml"
+                local provider_testfile="$outputPath/generated/$provider/$dirname/$filenameWithoutExtension.test.yml"
 
 
-            # if the file is whitelisted via the global ignore file
-            if array_contains "$file" "${expected_failure_prefixes_global[@]}"; then
-                # don't run tests for it
-                echo "###    Skipping $file: listed in $expected_failure_relative_file_global"
-                continue
-            fi
-            # if the file is whitelisted via the provider ignore file
-            if array_contains "$file" "${expected_failure_prefixes_provider[@]}"; then
-                # don't run tests for it
-                echo "###    Skipping $file: listed in $expected_failure_relative_file_provider"
-                continue
-            fi
+                # if the file is whitelisted via the global ignore file
+                if array_contains "$file" "${expected_failure_prefixes_global[@]}"; then
+                    # don't run tests for it
+                    echo "###    Skipping $file: listed in $expected_failure_relative_file_global"
+                    continue
+                fi
+                # if the file is whitelisted via the provider ignore file
+                if array_contains "$file" "${expected_failure_prefixes_provider[@]}"; then
+                    # don't run tests for it
+                    echo "###    Skipping $file: listed in $expected_failure_relative_file_provider"
+                    continue
+                fi
 
-            # Fail if no testfile found
-            if [[ ! -f "$provider_testfile" ]]
-            then
-                echo "###  Warning: no testfile found for $filename"
-                continue
-            fi
+                # Fail if no testfile found
+                if [[ ! -f "$provider_testfile" ]]
+                then
+                    echo "###  Warning: no testfile found for $filename"
+                    continue
+                fi
 
-            local promtool_test_output
+                local promtool_test_output
 
-            if [[ -f "$provider_testfile" ]]; then
-                echo "###    promtool test rules $filenameWithoutExtension.test.yml - $provider"
-                promtool_test_output="$("$GIT_WORKDIR/$PROMTOOL" test rules "$provider_testfile" 2>&1)" ||
-                    promtool_test_errors+=("$promtool_test_output")
-            fi
+                if [[ -f "$provider_testfile" ]]; then
+                    echo "###    promtool test rules $filenameWithoutExtension.test.yml - $provider"
+                    promtool_test_output="$("$GIT_WORKDIR/$PROMTOOL" test rules "$provider_testfile" 2>&1)" ||
+                        promtool_test_errors+=("$promtool_test_output")
+                fi
+                ;;
+              loki)
+                echo "###    lokitool rules lint $outputPath/generated/$provider/$file"
+                local lokitool_lint_output
+                if ! lokitool_lint_output="$("$GIT_WORKDIR/$LOKITOOL" rules lint "$outputPath/generated/$provider/$file" 2>&1)";
+                then
+                    echo "###  Warning: Linter failed for $file:"
+                    echo "$lokitool_lint_output"
+                    promtool_check_errors+=("$lokitool_lint_output")
+                    continue
+                fi
+
+                echo "###    lokitool rules check $outputPath/generated/$provider/$file"
+                local lokitool_check_output
+                if ! lokitool_check_output="$("$GIT_WORKDIR/$LOKITOOL" rules check "$outputPath/generated/$provider/$file" 2>&1)";
+                then
+                    echo "###  Warning: Syntax check failed for $file:"
+                    echo "$lokitool_check_output"
+                    promtool_check_errors+=("$lokitool_check_output")
+                    continue
+                fi
+                ;;
+              *)
+                echo "###  Warning: Unsupported rule type: $rule_type"
+                exit 1
+                ;;
+            esac
 
         done
     done

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -91,7 +91,7 @@ main() {
         # Look at each rules file for current provider
         cd "$outputPath/helm-chart/$provider/prometheus-rules/templates" || return 1
 
-        find . -type f -regextype posix-egrep -regex "${rules_suffix_pattern}" -print0 | while read -r -d '' file; do
+        while IFS= read -r -d '' file; do
             # Remove "./" at the vbeggining of the file path
             file="${file#./}"
 
@@ -198,8 +198,7 @@ main() {
                 exit 1
                 ;;
             esac
-
-        done
+        done < <(find . -type f -regextype posix-egrep -regex "${rules_suffix_pattern}" -print0)
     done
 
     # Job is done, print end time

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -44,7 +44,7 @@ main() {
     }
 
     START_TIME="$(date +%s)"
-    echo "$(date '+%H:%M:%S') promtool: start"
+    echo "$(date '+%H:%M:%S') - start"
 
     local GIT_WORKDIR
     GIT_WORKDIR=$(git rev-parse --show-toplevel)
@@ -203,7 +203,7 @@ main() {
     done
 
     # Job is done, print end time
-    echo "$(date '+%H:%M:%S') promtool: end (Elapsed time: $(($(date +%s) - START_TIME))s)"
+    echo "$(date '+%H:%M:%S') - end (Elapsed time: $(($(date +%s) - START_TIME))s)"
 
     # Final output
     # Bypassed checks
@@ -219,7 +219,7 @@ main() {
     # Test results
     if [[ ${#promtool_test_errors[@]} -eq 0 && ${#promtool_check_errors[@]} -eq 0 ]]; then
         echo
-        echo "Congratulations!  Prometheus rules have been promtool checked and tested"
+        echo "Congratulations! Rules have been checked and tested"
     else
         echo
         echo "Please review the below errors."


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3919

This PR adds test for Loki rules using `lokitool`. The following checks are performed on each Loki rule file:

- `lokitool rules lint`: parse and format rules files to check if they are valid ([upstream](https://github.com/grafana/loki/blob/31d8648ab7bb3397ab564c1968b902d0dd8f2cdb/pkg/tool/commands/rules.go#L657))
- `lokitool rules check`: check for best practices and duplicated rules ([upstream](https://github.com/grafana/loki/blob/33626906f5d5a44bb1c77e72d6479226a062ec8b/pkg/tool/commands/rules.go#L691))

Unfortunately there is no support for uni tests.

<details>
<summary>test run :heavy_check_mark:</summary>

```bash
$ make test-rules rules_type=loki
./test/hack/bin/fetch-tools.sh
bash ./test/hack/bin/template-chart.sh
Templating chart for provider: vintage/aws
wrote /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/helm-chart/vintage/aws/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws-load-balancer-controller.rules.yml
wrote /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/helm-chart/vintage/aws/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws.node.workload-cluster.rules.yml
... skipped lines ...
bash test/hack/bin/verify-rules.sh "" "loki"
11:11:46 - start
### Running tests for provider: vintage/aws
###  Testing kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules lint /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/vintage/aws/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules check /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/vintage/aws/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
### Running tests for provider: capi/capz
###  Testing kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules lint /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/capi/capz/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules check /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/capi/capz/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
### Running tests for provider: capi/capa
###  Testing kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules lint /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/capi/capa/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
###    lokitool rules check /home/theo/src/github.com/giantswarm/prometheus-rules/test/hack/output/generated/capi/capa/kaas/phoenix/alerting-rules/nodes.cidrnotavailable.events.logs.yml
11:11:46 - end (Elapsed time: 0s)

Congratulations! Rules have been checked and tested
```

</details>
