### PR TITLE
update MimirObjectStoreLowRate alert : rename it and update expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename `MimirDataPushFailures` to `MimirDataPushFailures` and update its expression to only target `upload` operations from the `ingester` component.
+- Rename `MimirObjectStoreLowRate` to `MimirDataPushFailures` and update its expression to only target `upload` operations from the `ingester` component.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `MimirDataPushFailures` to `MimirDataPushFailures` and update its expression to only target `upload` operations from the `ingester` component.
+
 ### Added
 
 - Add Loki rules validation in CI

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -187,7 +187,7 @@ spec:
           rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir", component="ingester", operation="upload"}[30m])
         )
         /
-        sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
+        sum by (installation, cluster_id, cluster_type, pipeline, provider) (
           rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace="mimir", component="ingester", operation="upload"}[30m])
         )
         > 0

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -176,19 +176,19 @@ spec:
         severity: page
         team: atlas
         topic: observability
-    - alert: MimirObjectStoreLowRate
+    - alert: MimirDataPushFailures
       annotations:
         __dashboardUid__: e1324ee2a434f4158c00a9ee279d3292
         dashboardQueryParams: "orgId=2"
         description: '{{`Low rate of writes to the Mimir object store.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
       expr: |
-        sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
-          rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir"}[30m])
+        sum by (installation, cluster_id, cluster_type, pipeline, provider) (
+          rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir", component="ingester", operation="upload"}[30m])
         )
         /
         sum by (component, installation, cluster_id, cluster_type, pipeline, provider) (
-          rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace="mimir"}[30m])
+          rate(thanos_objstore_bucket_operations_total{cluster_type="management_cluster", namespace="mimir", component="ingester", operation="upload"}[30m])
         )
         > 0
       for: 1h

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -598,8 +598,6 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
-              component: ingester
-              operation: upload
               installation: myinstall
               pipeline: stable
               provider: capa

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -577,17 +577,17 @@ tests:
               description: "Mimir continuous test myinstall is not producing metrics."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
 
-  # Test for MimirObjectStoreLowRate alert
+  # Test for MimirDataPushFailures alert
   - interval: 1m
     input_series:
-      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="ingester", operation="upload", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+10x80 100+0x80"
-      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="ingester", operation="upload", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+100x80 100+0x80"
     alert_rule_test:
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 40m
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 70m
         exp_alerts:
           - exp_labels:
@@ -598,7 +598,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
-              component: store-gateway
+              component: ingester
+              operation: upload
               installation: myinstall
               pipeline: stable
               provider: capa
@@ -610,7 +611,7 @@ tests:
               dashboardQueryParams: "orgId=2"
               description: "Low rate of writes to the Mimir object store."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -598,8 +598,6 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
-              component: ingester
-              operation: upload
               installation: myinstall
               pipeline: stable
               provider: capa

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -577,17 +577,17 @@ tests:
               description: "Mimir continuous test myinstall is not producing metrics."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
 
-  # Test for MimirObjectStoreLowRate alert
+  # Test for MimirDataPushFailures alert
   - interval: 1m
     input_series:
-      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+      - series: 'thanos_objstore_bucket_operation_failures_total{cluster_id="myinstall", cluster_type="management_cluster", component="ingester", operation="upload", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+10x80 100+0x80"
-      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="store-gateway", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
+      - series: 'thanos_objstore_bucket_operations_total{cluster_id="myinstall", cluster_type="management_cluster", component="ingester", operation="upload", installation="myinstall", namespace="mimir", pipeline="stable", provider="capa"}'
         values: "0+100x80 100+0x80"
     alert_rule_test:
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 40m
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 70m
         exp_alerts:
           - exp_labels:
@@ -598,7 +598,8 @@ tests:
               cancel_if_cluster_status_updating: "true"
               cluster_id: myinstall
               cluster_type: management_cluster
-              component: store-gateway
+              component: ingester
+              operation: upload
               installation: myinstall
               pipeline: stable
               provider: capa
@@ -610,7 +611,7 @@ tests:
               dashboardQueryParams: "orgId=2"
               description: "Low rate of writes to the Mimir object store."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
-      - alertname: MimirObjectStoreLowRate
+      - alertname: MimirDataPushFailures
         eval_time: 140m
 
   # Test for MimirRulerTooManyFailedQueries alert


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32679

This PR updates the `MimirObjectStoreLowRate`  alert : 

* Rename it to `MimirDataPushFailures`.
* Update expression to only target the `upload` operations from the `ingester`  component.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
