### PR TITLE
PromtailRequestsErrors: lower sensitivity and cancel outside of busin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `StatefulsetNotSatisfiedAtlas` to fire after 3 days.
+- Update `PromtailRequestsErrors` to fire after 1h instead of 25min.
+- Update `PromtailRequestsErrors` to cancel outside of working hours.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -42,12 +42,13 @@ spec:
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
           expr: |
             100 * (sum(rate(promtail_request_duration_seconds_count{status_code!~"2.."}[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance) / sum(rate(promtail_request_duration_seconds_count[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)) > 10
-          for: 25m
+          for: 60m
           labels:
             area: platform
             severity: page
             team: atlas
             topic: observability
+            cancel_if_outside_working_hours: "true"
             cancel_if_cluster_status_creating: "true"
             cancel_if_cluster_status_deleting: "true"
             cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -142,9 +142,12 @@ tests:
         eval_time: 210m
       - alertname: PromtailRequestsErrors
         eval_time: 270m
+      - alertname: PromtailRequestsErrors
+        eval_time: 310m
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -165,6 +168,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -142,9 +142,12 @@ tests:
         eval_time: 210m
       - alertname: PromtailRequestsErrors
         eval_time: 270m
+      - alertname: PromtailRequestsErrors
+        eval_time: 310m
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -165,6 +168,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -142,9 +142,12 @@ tests:
         eval_time: 210m
       - alertname: PromtailRequestsErrors
         eval_time: 270m
+      - alertname: PromtailRequestsErrors
+        eval_time: 310m
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
@@ -164,6 +167,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
+              cancel_if_outside_working_hours: "true"
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32824

This PR updates `PromtailRequestsErrors` alert:
- now pages after 1h instead of 25min
- does not page anymore during nights and week-ends

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
