### PR TITLE
update MimirDataPushFailures runbook url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `MimirDataPushFailures` runbook url.
+
 ## [4.49.0] - 2025-03-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -181,7 +181,7 @@ spec:
         __dashboardUid__: e1324ee2a434f4158c00a9ee279d3292
         dashboardQueryParams: "orgId=2"
         description: '{{`Low rate of writes to the Mimir object store.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirdatapushfailures
       expr: |
         sum by (installation, cluster_id, cluster_type, pipeline, provider) (
           rate(thanos_objstore_bucket_operation_failures_total{cluster_type="management_cluster", namespace="mimir", component="ingester", operation="upload"}[30m])

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -608,7 +608,7 @@ tests:
               __dashboardUid__: e1324ee2a434f4158c00a9ee279d3292
               dashboardQueryParams: "orgId=2"
               description: "Low rate of writes to the Mimir object store."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirdatapushfailures
       - alertname: MimirDataPushFailures
         eval_time: 140m
 

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -608,7 +608,7 @@ tests:
               __dashboardUid__: e1324ee2a434f4158c00a9ee279d3292
               dashboardQueryParams: "orgId=2"
               description: "Low rate of writes to the Mimir object store."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirobjectstorelowrate
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/#mimirdatapushfailures
       - alertname: MimirDataPushFailures
         eval_time: 140m
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32679

:warning: Need [ops recipe pr](https://github.com/giantswarm/giantswarm/pull/32852) to be merged before.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
