### PR TITLE
Switch Team Tenet alerts to severity=notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the severity of several Team Tenet alerts to be "notify"
+
 ## [4.49.3] - 2025-03-17
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/cluster-autoscaler.rules.yml
@@ -27,7 +27,7 @@ spec:
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
         cancel_if_cluster_has_no_workers: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: cluster-autoscaler
     - alert: ClusterAutoscalerFailedScaling
@@ -42,6 +42,6 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: cluster-autoscaler

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
@@ -37,7 +37,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         cancel_if_outside_working_hours: "true"
         team: tenet
         topic: etcd
@@ -49,7 +49,7 @@ spec:
       for: 15m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         cancel_if_outside_working_hours: "true"
         team: tenet
         topic: etcd

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/fairness.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/fairness.rules.yml
@@ -18,7 +18,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: kubernetes
     - alert: FlowcontrolTooManyRequests
@@ -30,6 +30,6 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/kubelet.rules.yml
@@ -24,7 +24,7 @@ spec:
           cancel_if_cluster_has_no_workers: "true"
           cancel_if_outside_working_hours: "true"
           cancel_if_monitoring_agent_down: "true"
-          severity: page
+          severity: notify
           team: tenet
           topic: kubernetes
   - name: kubelet

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
@@ -173,6 +173,6 @@ spec:
       for: 20m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         team: tenet
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
@@ -22,7 +22,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: ContainerdVolumeSpaceTooLow
@@ -36,7 +36,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
@@ -55,8 +55,8 @@ spec:
       annotations:
         description: '{{`Kubelet volume /var/lib/kubelet on {{ $labels.node }} does not have enough free space.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/low-disk-space/#kubelet-volume
-      # In clusters where the node-problem-detector-app (https://github.com/giantswarm/node-problem-detector-app/) is installed, we don't want to get alerted if the node-problem-detector is already remediating the issue. 
-      # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0. 
+      # In clusters where the node-problem-detector-app (https://github.com/giantswarm/node-problem-detector-app/) is installed, we don't want to get alerted if the node-problem-detector is already remediating the issue.
+      # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0.
       # The right hand side of the or is necessary because we need to be alerted in clusters without the node-problem-detector.
       # Note that we add 1 to the disk free space so we still get alerted when the free bytes are 0.
       # We are also alerted if the free space is less than 2GB for 10 minutes.
@@ -65,7 +65,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: LogVolumeSpaceTooLow
@@ -79,7 +79,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: RootVolumeSpaceTooLow
@@ -91,7 +91,7 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: PersistentVolumeSpaceTooLow
@@ -130,6 +130,6 @@ spec:
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: storage

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
@@ -21,7 +21,7 @@ spec:
       for: 30m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: EtcdVolumeSpaceTooLow
@@ -40,8 +40,8 @@ spec:
       annotations:
         description: '{{`Kubelet volume /var/lib/kubelet on {{ $labels.node }} does not have enough free space.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/low-disk-space/#kubelet-volume
-      # In clusters where the node-problem-detector-app (https://github.com/giantswarm/node-problem-detector-app/) is installed, we don't want to get alerted if the node-problem-detector is already remediating the issue. 
-      # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0. 
+      # In clusters where the node-problem-detector-app (https://github.com/giantswarm/node-problem-detector-app/) is installed, we don't want to get alerted if the node-problem-detector is already remediating the issue.
+      # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0.
       # The right hand side of the or is necessary because we need to be alerted in clusters without the node-problem-detector.
       # Note that we add 1 to the disk free space so we still get alerted when the free bytes are 0.
       # We are also alerted if the free space is less than 500MB for 30 minutes.
@@ -49,7 +49,7 @@ spec:
       for: 60m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: LogVolumeSpaceTooLow
@@ -62,7 +62,7 @@ spec:
       for: 60m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         team: tenet
         topic: storage
     - alert: RootVolumeSpaceTooLow
@@ -73,6 +73,6 @@ spec:
       for: 10m
       labels:
         area: kaas
-        severity: page
+        severity: notify
         team: tenet
         topic: storage

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/vertical-pod-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/vertical-pod-autoscaler.rules.yml
@@ -25,7 +25,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: tenet
         topic: autoscaling
     - alert: FluxHelmReleaseFailed


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/32822

This PR changes several of the Team Tenet owned alerts to have a severity of "notify" rather than "page".

Note that currently both "notify" and "page" are being treated the same for Tenet and all are going into a Slack channel. We're planning to change that and have "page" also go to opsgenie but first want to make sure that those that are less-critical or still need work remain in Slack to avoid noise.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
