### PR TITLE
Tweaked Team Tenet alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion
 - Tweaked the time and size of the `KubeletVolumeSpaceTooLow` alerts.
 - Change the `KubeletVolumeSpaceTooLow` for <500Mb available to page instead of notify
+- Tweaked the time and size of the `DockerVolumeSpaceTooLow` alerts.
+- Change the `DockerVolumeSpaceTooLow` for <1Gb available to page instead of notify
 
 ## [4.50.0] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
 - Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
 - Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion
+- Tweaked the time and size of the `KubeletVolumeSpaceTooLow` alerts.
+- Change the `KubeletVolumeSpaceTooLow` for <500Mb available to page instead of notify
 
 ## [4.50.0] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
 - Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
+- Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion
 
 ## [4.50.0] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
+- Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
 
 ## [4.50.0] - 2025-03-18
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
@@ -59,6 +59,9 @@ spec:
       expr: increase(etcd_server_leader_changes_seen_total{cluster_type="workload_cluster", provider!="eks"}[1h]) > 8
       labels:
         area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
         severity: notify
         team: tenet
         topic: etcd

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/node.workload-cluster.rules.yml
@@ -173,6 +173,7 @@ spec:
       for: 20m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: tenet
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
@@ -59,9 +59,9 @@ spec:
       # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0.
       # The right hand side of the or is necessary because we need to be alerted in clusters without the node-problem-detector.
       # Note that we add 1 to the disk free space so we still get alerted when the free bytes are 0.
-      # We are also alerted if the free space is less than 2GB for 10 minutes.
-      expr: (( node_filesystem_free_bytes{cluster_type="management_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (2 * 1024 * 1024 * 1024)) * on (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer) (1 - problem_gauge{reason="KubeletDiskIsFull"}) or sum (node_filesystem_free_bytes{cluster_type="management_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (2 * 1024 * 1024 * 1024)) by (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer)) > 0
-      for: 10m
+      # We are also alerted if the free space is less than 1.5GB for 20 minutes.
+      expr: (( node_filesystem_free_bytes{cluster_type="management_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (1.5 * 1024 * 1024 * 1024)) * on (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer) (1 - problem_gauge{reason="KubeletDiskIsFull"}) or sum (node_filesystem_free_bytes{cluster_type="management_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (1.5 * 1024 * 1024 * 1024)) by (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer)) > 0
+      for: 20m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.management-cluster.rules.yml
@@ -17,8 +17,8 @@ spec:
       annotations:
         description: '{{`Docker volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/low-disk-space/#docker-volume
-      expr: node_filesystem_free_bytes{cluster_type="management_cluster", mountpoint=~"(/rootfs)?/var/lib/docker"} < (2 * 1024 * 1024 * 1024)
-      for: 10m
+      expr: node_filesystem_free_bytes{cluster_type="management_cluster", mountpoint=~"(/rootfs)?/var/lib/docker"} < (1.5 * 1024 * 1024 * 1024)
+      for: 20m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
@@ -44,12 +44,13 @@ spec:
       # When this happens, the problem_gauge metric has value 1, so we do a multiply join on that metric - 1 to get 0 when the metric is present and active, and keep the series values that are > 0.
       # The right hand side of the or is necessary because we need to be alerted in clusters without the node-problem-detector.
       # Note that we add 1 to the disk free space so we still get alerted when the free bytes are 0.
-      # We are also alerted if the free space is less than 500MB for 30 minutes.
+      # We are also alerted if the free space is less than 500MB for 60 minutes.
       expr: (( node_filesystem_free_bytes{cluster_type="workload_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (500 * 1024 * 1024)) * on (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer) (1 - problem_gauge{reason="KubeletDiskIsFull"}) or sum (node_filesystem_free_bytes{cluster_type="workload_cluster",mountpoint=~"(/rootfs)?/var/lib/kubelet"} +1 < (500 * 1024 * 1024)) by (node, cluster_type, cluster_id, installation, organization, pipeline, region, customer)) > 0
       for: 60m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: tenet
         topic: storage
     - alert: LogVolumeSpaceTooLow

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
@@ -17,11 +17,12 @@ spec:
       annotations:
         description: '{{`Docker volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/low-disk-space/#docker-volume
-      expr: node_filesystem_free_bytes{cluster_type="workload_cluster", mountpoint=~"(/rootfs)?/var/lib/docker"} < (2 * 1024 * 1024 * 1024)
-      for: 30m
+      expr: node_filesystem_free_bytes{cluster_type="workload_cluster", mountpoint=~"(/rootfs)?/var/lib/docker"} < (1 * 1024 * 1024 * 1024)
+      for: 60m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: tenet
         topic: storage
     - alert: EtcdVolumeSpaceTooLow


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32822

- Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
- Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion
- Tweaked the time and size of the `KubeletVolumeSpaceTooLow` alerts.
- Change the `KubeletVolumeSpaceTooLow` for <500Mb available to page instead of notify
- Tweaked the time and size of the `DockerVolumeSpaceTooLow` alerts.
- Change the `DockerVolumeSpaceTooLow` for <1Gb available to page instead of notify