### PR TITLE
improve metrics-forwarding-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fine tune the `MetricForwardingErrors` so it does not trigger on sporadic issues like duplicate samples (e.g. when a pod restarts too frequently for a small time window). This alert is now based on the upstream alert and uses a percentage of failed remote storage samples as described in this issue https://github.com/giantswarm/giantswarm/issues/32873
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
 
 ## [4.50.0] - 2025-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.51.0] - 2025-03-25
 
+### Changed
+
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
 - Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
 - Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.51.0] - 2025-03-25
-
 ### Changed
 
 - Fine tune the `MetricForwardingErrors` so it does not trigger on sporadic issues like duplicate samples (e.g. when a pod restarts too frequently for a small time window). This alert is now based on the upstream alert and uses a percentage of failed remote storage samples as described in this issue https://github.com/giantswarm/giantswarm/issues/32873
+
+## [4.51.0] - 2025-03-25
+
 - Increased the threshold time for `ManagementClusterWebhookDurationExceedsTimeout` from 15m to 25m
 - Set `WorkloadClusterNodeUnexpectedTaintNodeCAPIUninitialized` to page
 - Cancel `WorkloadClusterEtcdNumberOfLeaderChangesTooHigh` during cluster upgrades, creation and deletion

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
@@ -11,16 +11,24 @@ spec:
     rules:
     - alert: MetricForwardingErrors
       annotations:
-        description: '{{`Monitoring agent can''t communicate with Remote Storage API at {{ $labels.url }}.`}}'
+        summary: Monitoring agent fails to send samples to remote storage.
+        description: '{{`Monitoring agent failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
         __dashboardUid__: promRW001
         {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
         {{ end }}
       expr: |-
-        rate(prometheus_remote_storage_samples_failed_total[10m]) > 0.1
-          or rate(prometheus_remote_storage_samples_total[10m]) == 0
-          or rate(prometheus_remote_storage_metadata_retried_total[10m]) > 0
+        (
+          rate(prometheus_remote_storage_samples_failed_total[5m])
+          /
+          (
+            rate(prometheus_remote_storage_samples_failed_total[5m])
+            +
+            rate(prometheus_remote_storage_samples_total[5m])
+          )
+        ) * 100
+        > 1
       for: 1h
       labels:
         area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -104,22 +104,45 @@ tests:
   # Test MetricForwardingErrors
   - interval: 1m
     input_series:
-      # remote write has no failure for 1 hour and then fails for 2 hours
-      - series: 'prometheus_remote_storage_samples_failed_total{url="http://remote-storage_samples_failed_total"}'
-        values: "0+0x60 0+100x120"
+      # Test case where alert should not fire (error rate < 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="test-remote", url="http://example.com"}'
+        values: '0+0x65 1+1x60' # Minimal failures for 2h+ period
+      - series: 'prometheus_remote_storage_samples_total{remote_name="test-remote", url="http://example.com"}'
+        values: '1000+1000x125' # Normal sample count
+
+      # Test case where alert should fire (error rate > 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="error-remote", url="http://error.com"}'
+        values: '0+0x5 50+50x120' # Significant failures over time
+      - series: 'prometheus_remote_storage_samples_total{remote_name="error-remote", url="http://error.com"}'
+        values: '1000+1000x125' # Normal sample count
+
     alert_rule_test:
-      - alertname: MetricForwardingErrors
-        eval_time: 180m
+      # Alert shouldn't fire for low error rate
+      - eval_time: 65m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert shouldn't fire yet (not enough time elapsed)
+      - eval_time: 70m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert should fire after 1h of high error rate
+      - eval_time: 125m
+        alertname: MetricForwardingErrors
         exp_alerts:
           - exp_labels:
+              alertname: MetricForwardingErrors
+              remote_name: error-remote
+              url: http://error.com
               area: platform
+              cancel_if_outside_working_hours: "true"
               severity: page
               team: atlas
               topic: observability
-              cancel_if_outside_working_hours: "true"
-              url: "http://remote-storage_samples_failed_total"
             exp_annotations:
-              description: "Monitoring agent can't communicate with Remote Storage API at http://remote-storage_samples_failed_total."
+              summary: Monitoring agent fails to send samples to remote storage.
+              description: Monitoring agent failed to send 4.8% of the samples to error-remote:http://error.com.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
               __dashboardUid__: promRW001
               dashboardQueryParams: "orgId=1"

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -101,7 +101,7 @@ tests:
               description: "Monitoring agents for cluster glean/glean has failed to scrape all targets in kube-controller-manager job."
 
 
-    # Test MetricForwardingErrors
+  # Test MetricForwardingErrors
   - interval: 1m
     input_series:
       # Test case where alert should not fire (error rate < 1%)

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -101,25 +101,48 @@ tests:
               description: "Monitoring agents for cluster glean/glean has failed to scrape all targets in kube-controller-manager job."
 
 
-  # Test MetricForwardingErrors
+    # Test MetricForwardingErrors
   - interval: 1m
     input_series:
-      # remote write has no failure for 1 hour and then fails for 2 hours
-      - series: 'prometheus_remote_storage_samples_failed_total{url="http://remote-storage_samples_failed_total"}'
-        values: "0+0x60 0+100x120"
+      # Test case where alert should not fire (error rate < 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="test-remote", url="http://example.com"}'
+        values: '0+0x65 1+1x60' # Minimal failures for 2h+ period
+      - series: 'prometheus_remote_storage_samples_total{remote_name="test-remote", url="http://example.com"}'
+        values: '1000+1000x125' # Normal sample count
+
+      # Test case where alert should fire (error rate > 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="error-remote", url="http://error.com"}'
+        values: '0+0x5 50+50x120' # Significant failures over time
+      - series: 'prometheus_remote_storage_samples_total{remote_name="error-remote", url="http://error.com"}'
+        values: '1000+1000x125' # Normal sample count
+
     alert_rule_test:
-      - alertname: MetricForwardingErrors
-        eval_time: 180m
+      # Alert shouldn't fire for low error rate
+      - eval_time: 65m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert shouldn't fire yet (not enough time elapsed)
+      - eval_time: 70m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert should fire after 1h of high error rate
+      - eval_time: 125m
+        alertname: MetricForwardingErrors
         exp_alerts:
           - exp_labels:
+              alertname: MetricForwardingErrors
+              remote_name: error-remote
+              url: http://error.com
               area: platform
+              cancel_if_outside_working_hours: "true"
               severity: page
               team: atlas
               topic: observability
-              cancel_if_outside_working_hours: "true"
-              url: "http://remote-storage_samples_failed_total"
             exp_annotations:
-              description: "Monitoring agent can't communicate with Remote Storage API at http://remote-storage_samples_failed_total."
+              summary: Monitoring agent fails to send samples to remote storage.
+              description: Monitoring agent failed to send 4.8% of the samples to error-remote:http://error.com.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
               __dashboardUid__: promRW001
               dashboardQueryParams: "orgId=1"

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -98,24 +98,47 @@ tests:
               description: "Monitoring agents for cluster gauss/gauss has failed to scrape all targets in kube-controller-manager job."
 
 
-  # Test MetricForwardingErrors
+    # Test MetricForwardingErrors
   - interval: 1m
     input_series:
-      # remote write has no failure for 1 hour and then fails for 2 hours
-      - series: 'prometheus_remote_storage_samples_failed_total{url="http://remote-storage_samples_failed_total"}'
-        values: "0+0x60 0+100x120"
+      # Test case where alert should not fire (error rate < 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="test-remote", url="http://example.com"}'
+        values: '0+0x65 1+1x60' # Minimal failures for 2h+ period
+      - series: 'prometheus_remote_storage_samples_total{remote_name="test-remote", url="http://example.com"}'
+        values: '1000+1000x125' # Normal sample count
+
+      # Test case where alert should fire (error rate > 1%)
+      - series: 'prometheus_remote_storage_samples_failed_total{remote_name="error-remote", url="http://error.com"}'
+        values: '0+0x5 50+50x120' # Significant failures over time
+      - series: 'prometheus_remote_storage_samples_total{remote_name="error-remote", url="http://error.com"}'
+        values: '1000+1000x125' # Normal sample count
+
     alert_rule_test:
-      - alertname: MetricForwardingErrors
-        eval_time: 180m
+      # Alert shouldn't fire for low error rate
+      - eval_time: 65m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert shouldn't fire yet (not enough time elapsed)
+      - eval_time: 70m
+        alertname: MetricForwardingErrors
+        exp_alerts: []
+      
+      # Alert should fire after 1h of high error rate
+      - eval_time: 125m
+        alertname: MetricForwardingErrors
         exp_alerts:
           - exp_labels:
+              alertname: MetricForwardingErrors
+              remote_name: error-remote
+              url: http://error.com
               area: platform
+              cancel_if_outside_working_hours: "true"
               severity: page
               team: atlas
               topic: observability
-              cancel_if_outside_working_hours: "true"
-              url: "http://remote-storage_samples_failed_total"
             exp_annotations:
-              description: "Monitoring agent can't communicate with Remote Storage API at http://remote-storage_samples_failed_total."
+              summary: Monitoring agent fails to send samples to remote storage.
+              description: Monitoring agent failed to send 4.8% of the samples to error-remote:http://error.com.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
               __dashboardUid__: promRW001

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -98,7 +98,7 @@ tests:
               description: "Monitoring agents for cluster gauss/gauss has failed to scrape all targets in kube-controller-manager job."
 
 
-    # Test MetricForwardingErrors
+  # Test MetricForwardingErrors
   - interval: 1m
     input_series:
       # Test case where alert should not fire (error rate < 1%)


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Closes https://github.com/giantswarm/giantswarm/issues/32873

This pull request includes significant updates to the `MetricForwardingErrors` alert to improve its accuracy and reliability. The changes involve fine-tuning the alert to avoid triggering on sporadic issues and updating the associated test cases to reflect the new alerting logic.

### Improvements to `MetricForwardingErrors` alert:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12): Fine-tuned the `MetricForwardingErrors` alert to avoid triggering on sporadic issues like duplicate samples. The alert now uses a percentage of failed remote storage samples.
* [`helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml`](diffhunk://#diff-f396246683ce0ddbc397a88f67fa860ec535823f7b6ca79ed5f69c5b427b1ff3L14-R31): Updated the `MetricForwardingErrors` alert to use a percentage-based expression and adjusted the alert summary and description.

### Updates to test cases:

* [`test/tests/providers/capi/capa/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml`](diffhunk://#diff-d61ee3bc5a0dded583029348426122419cc74db28a1351c92fc1a5648174e063L107-R145): Added new test cases to ensure the alert does not fire for low error rates and correctly fires after sustained high error rates.
* [`test/tests/providers/capi/capz/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml`](diffhunk://#diff-ab7c2bc5fc6632e0a53744e8100026748e7c6cfd1f2434bf76d68c506548591cL107-R145): Similar updates to test cases as the above file to verify the new alerting logic.
* [`test/tests/providers/vintage/aws/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml`](diffhunk://#diff-435d3b68e20738ad34b28dd4820255506695645fc0e712c084dea3e94fe311b3L104-R142): Updated test cases to reflect the changes in the alerting logic, ensuring accurate testing across different environments.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
