### PR TITLE
Reduce management cluster resource usage alert window from 2d to 30m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce management cluster resource usage alert window from 2d to 30m.
+
 ## [4.51.0] - 2025-03-25
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} cpu usage is too high.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/management-cluster-resource-limit-reached/
-      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_cpu_cores{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_cpu_cores_total{cluster_type="management_cluster"}[2d]) > 0.93
+      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_cpu_cores{cluster_type="management_cluster"}[30m]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_cpu_cores_total{cluster_type="management_cluster"}[30m]) > 0.93
       for: 1h
       labels:
         area: kaas
@@ -51,7 +51,7 @@ spec:
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} memory usage is too high.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/management-cluster-resource-limit-reached/
-      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_memory_bytes{cluster_type="management_cluster"}[2d]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_memory_bytes{cluster_type="management_cluster"}[2d]) > 0.93
+      expr: avg_over_time(aggregation:kubernetes:pod_resource_requests_memory_bytes{cluster_type="management_cluster"}[30m]) / on (cluster_id) group_left avg_over_time(aggregation:kubernetes:node_allocatable_memory_bytes{cluster_type="management_cluster"}[30m]) > 0.93
       for: 1h
       labels:
         area: kaas


### PR DESCRIPTION
The previous 2-day window caused alerts to fire based on historical data that may 
no longer represent the current cluster state. 

The 30 minutes window provides a more 
accurate view of current resource usage.


Example:

- [Opsgenie](https://giantswarm.app.opsgenie.com/alert/detail/1f574717-1dfe-4702-ac94-909401729206-1742890042153/details)
- [Grafana Dashboard](https://grafana.anemone.capi.aws.k8s.adidas.com.cn/explore?schemaVersion=1&panes=%7B%22sy8%22:%7B%22datasource%22:%22gs-mimir%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22avg_over_time%28aggregation:kubernetes:pod_resource_requests_cpu_cores%7Bcluster_type%3D%5C%22management_cluster%5C%22%7D%5B2d%5D%29%20%2F%20on%20%28cluster_id%29%20group_left%20avg_over_time%28aggregation:kubernetes:node_allocatable_cpu_cores_total%7Bcluster_type%3D%5C%22management_cluster%5C%22%7D%5B2d%5D%29%20%3E%200.93%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22gs-mimir%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

Issue: https://github.com/giantswarm/giantswarm/issues/32919

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).