### PR TITLE
alert if the teleport logs have been missing for 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert to detect missing installation logs that relates to teleport access.
+
 ### Changed
 
 - Fine tune the `MetricForwardingErrors` so it does not trigger on sporadic issues like duplicate samples (e.g. when a pod restarts too frequently for a small time window). This alert is now based on the upstream alert and uses a percentage of failed remote storage samples as described in this issue https://github.com/giantswarm/giantswarm/issues/32873

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/teleport.logs.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/teleport.logs.yml
@@ -1,0 +1,26 @@
+{{- if eq .Values.managementCluster.provider.flavor "capi" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4}}
+  name: teleport.audit.logs.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+    - name: teleport.audit.logs
+      rules:
+        - alert: TeleportAuditLogsMissing
+          annotations:
+            description: Teleport audit logs are missing from installation {{`{{ $labels.installation }}`}}.
+            runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/teleport-audit-logs-missing/
+          expr: |-
+            absent_over_time({scrape_job="teleport.giantswarm.io"} [7d]) > 0
+          for: 5m
+          labels:
+            area: kaas
+            cancel_if_outside_working_hours: "true"
+            severity: page
+            team: atlas
+            topic: observability
+{{ end }}


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/roadmap/issues/3343

This PR adds a new alert that ensures we receive teleport logs from an installation. This might trigger false positives if no one connected to an installation in 7 days but it is unlikely

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
