### PR TITLE
prevent MonitoringAgentDown to page for clusters in the deleting phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `MonitoringAgentDown` to not page for non deleting clusters.
+
 ## [4.54.0] - 2025-04-07
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
@@ -115,12 +115,15 @@ spec:
           expr: |-
             count(
               label_replace(
-                capi_cluster_status_condition{type="ControlPlaneReady", status="True"},
+                (capi_cluster_status_condition{type="ControlPlaneReady", status="True"} == 1)
+                  * on (name, installation, pipeline, provider)
+                  # We do not want to alert on clusters that are being deleted.
+                  (capi_cluster_status_phase{phase="Deleting"} == 0),
                 "cluster_id",
                 "$1",
                 "name",
                 "(.*)"
-              ) == 1
+              )
             ) by (cluster_id, installation, pipeline, provider) > 0
             unless on (cluster_id) (
               count(up{job=~"alloy-metrics|prometheus-agent"} > 0) by (cluster_id)

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -236,9 +236,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="alloy-metrics", cluster_id="golem", installation="golem", provider="capa", pipeline="testing"}'
-        values: "_x40 1+0x50 0+0x70"
+        values: "_x60 1+0x60 0+0x60"
       - series: 'capi_cluster_status_condition{type="ControlPlaneReady", status="True", name="golem", installation="golem", provider="capa", pipeline="testing"}'
-        values: "1x150"
+        values: "1x180"
+      - series: 'capi_cluster_status_phase{phase="Deleting", name="golem", installation="golem", provider="capa", pipeline="testing"}'
+        values: "0x150 1x30"
     alert_rule_test:
       - alertname: MonitoringAgentDown
         eval_time: 10m
@@ -311,7 +313,7 @@ tests:
       - alertname: InhibitionMonitoringAgentDown
         eval_time: 80m
       - alertname: MonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -333,7 +335,30 @@ tests:
               dashboardQueryParams: "orgId=1"
               summary: "Monitoring agent fails to send samples to remote write endpoint."
       - alertname: InhibitionMonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              inhibit_monitoring_agent_down: "true"
+              cluster_id: golem
+              installation: golem
+              provider: capa
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "Monitoring agent fails to send samples."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/#monitoring-agent-down
+              __dashboardUid__: promRW001
+              dashboardQueryParams: "orgId=1"
+              summary: "Monitoring agent fails to send samples to remote write endpoint."
+      - alertname: MonitoringAgentDown
+        eval_time: 170m
+      - alertname: InhibitionMonitoringAgentDown
+        eval_time: 170m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -236,9 +236,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="alloy-metrics", cluster_id="glean", installation="glean", provider="capz", pipeline="testing"}'
-        values: "_x40 1+0x50 0+0x70"
+        values: "_x60 1+0x60 0+0x60"
       - series: 'capi_cluster_status_condition{type="ControlPlaneReady", status="True", name="glean", installation="glean", provider="capz", pipeline="testing"}'
-        values: "1x150"
+        values: "1x180"
+      - series: 'capi_cluster_status_phase{phase="Deleting", name="glean", installation="glean", provider="capz", pipeline="testing"}'
+        values: "0x150 1x30"
     alert_rule_test:
       - alertname: MonitoringAgentDown
         eval_time: 10m
@@ -311,7 +313,7 @@ tests:
       - alertname: InhibitionMonitoringAgentDown
         eval_time: 80m
       - alertname: MonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -333,7 +335,30 @@ tests:
               dashboardQueryParams: "orgId=1"
               summary: "Monitoring agent fails to send samples to remote write endpoint."
       - alertname: InhibitionMonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              inhibit_monitoring_agent_down: "true"
+              cluster_id: glean
+              installation: glean
+              provider: capz
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "Monitoring agent fails to send samples."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/#monitoring-agent-down
+              __dashboardUid__: promRW001
+              dashboardQueryParams: "orgId=1"
+              summary: "Monitoring agent fails to send samples to remote write endpoint."
+      - alertname: MonitoringAgentDown
+        eval_time: 170m
+      - alertname: InhibitionMonitoringAgentDown
+        eval_time: 170m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -230,9 +230,11 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="alloy-metrics", cluster_id="gauss", installation="gauss", provider="aws", pipeline="testing"}'
-        values: "_x40 1+0x50 0+0x70"
+        values: "_x60 1+0x60 0+0x60"
       - series: 'capi_cluster_status_condition{type="ControlPlaneReady", status="True", name="gauss", installation="gauss", provider="aws", pipeline="testing"}'
-        values: "1x150"
+        values: "1x180"
+      - series: 'capi_cluster_status_phase{phase="Deleting", name="gauss", installation="gauss", provider="aws", pipeline="testing"}'
+        values: "0x150 1x30"
     alert_rule_test:
       - alertname: MonitoringAgentDown
         eval_time: 10m
@@ -302,7 +304,7 @@ tests:
       - alertname: InhibitionMonitoringAgentDown
         eval_time: 80m
       - alertname: MonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -323,7 +325,29 @@ tests:
               __dashboardUid__: promRW001
               summary: "Monitoring agent fails to send samples to remote write endpoint."
       - alertname: InhibitionMonitoringAgentDown
-        eval_time: 140m
+        eval_time: 150m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              inhibit_monitoring_agent_down: "true"
+              cluster_id: gauss
+              installation: gauss
+              provider: aws
+              pipeline: testing
+              severity: none
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "Monitoring agent fails to send samples."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/#monitoring-agent-down
+              __dashboardUid__: promRW001
+              summary: "Monitoring agent fails to send samples to remote write endpoint."
+      - alertname: MonitoringAgentDown
+        eval_time: 170m
+      - alertname: InhibitionMonitoringAgentDown
+        eval_time: 170m
         exp_alerts:
           - exp_labels:
               area: platform


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR makes sure we do not receive false alerts for clusters in deleting phase

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
