### PR TITLE
Improve ClusterCrossplaneResourcesNotReady with new metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve ClusterCrossplaneResourcesNotReady with new metrics where available
+
 ## [4.54.1] - 2025-04-08
 
 ### Fixed

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-crossplane.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-crossplane.rules.yml
@@ -18,7 +18,16 @@ spec:
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/cluster-crossplane-resources
       # Match critical resources deployed by cluster-aws via aws-nth-crossplane-resources,
       # cilium-crossplane-resources, ...
-      expr: crossplane_managed_resource_exists{gvk=~"(iam.aws.upbound.io/.*, Kind=Role|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup*)"} != crossplane_managed_resource_ready{gvk=~"(iam.aws.upbound.io/.*, Kind=Role|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup*)"}
+      expr: |
+        (
+        crossplane_managed_resource_exists{gvk=~"(iam.aws.upbound.io/.*, Kind=Role|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup*)"} != crossplane_managed_resource_ready{gvk=~"(iam.aws.upbound.io/.*, Kind=Role|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup*)"}
+        ) OR
+        iam_aws_upbound_role_ready{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        sqs_aws_upbound_queue_ready{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        sqs_aws_upbound_queuepolicy_ready{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        cloudwatchevents_aws_upbound_rule_ready{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        cloudwatchevents_aws_upbound_target_ready{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        ec2_aws_upbound_securitygroup_ready{status="False", label_giantswarm_io_service_type="managed"} == 1
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
This PR updates the alert to use new metrics introduced in https://github.com/giantswarm/observability-bundle/pull/286 if they are available but as it will take some time before these are included in a release and all MCs are updated then we also still use the old query too.

Once the new metrics are available and we can remove the old query we will then be able to get alerted only for Giant Swarm managed Crossplane resources and not those created by customers.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
