### PR TITLE
Use 'exported_namespace' for certificate expiration alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `exported_namespace` for certificate expiration alerts.
+
 ### Changed
 
 - Improve ClusterCrossplaneResourcesNotReady with new metrics where available

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.all.rules.yml
@@ -26,7 +26,7 @@ spec:
     {{- end }}
     - alert: IRSACertificateSecretWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`IRSA Pod Identity Webhook Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        description: '{{`IRSA Pod Identity Webhook Certificate stored in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
       expr: (cert_exporter_secret_not_after{name=~"aws-pod-identity-webhook.*"} - time()) < 13 * 24 * 60 * 60
       for: 5m
@@ -38,7 +38,7 @@ spec:
         topic: cert-manager
     - alert: KyvernoCertificateSecretWillExpireInLessThanTwoDays
       annotations:
-        description: '{{`Kyverno Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two days.`}}'
+        description: '{{`Kyverno Certificate stored in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two days.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/kyverno-certificate-secret-will-expire-in-less-than-two-days/
       expr: (cert_exporter_secret_not_after{name=~".*kyverno.*"} - time()) < 2 * 24 * 60 * 60
       labels:
@@ -49,7 +49,7 @@ spec:
         topic: kyverno
     - alert: CertificateSecretWillExpireInLessThanTwoWeeks
       annotations:
-        description: '{{`Certificate stored in Secret {{ $labels.namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
+        description: '{{`Certificate stored in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two weeks.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/managed-app-cert-manager/certificate-secret-will-expire-in-less-than-two-weeks/
       expr: (cert_exporter_secret_not_after{name!~"kiam.*|.*kyverno.*",cluster_type="management_cluster"} - time()) < 13 * 24 * 60 * 60
       labels:


### PR DESCRIPTION
This PR fixes the namespace used in the alert description to use `exported_namespace` instead of `namespace`.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
