### PR TITLE
Improved `ClusterAutoscalerFailedScaling` alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved `ClusterAutoscalerFailedScaling` alert to detect stuck states where cluster-autoscaler fails to scale.
+
 ## [4.55.0] - 2025-04-22
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/cluster-autoscaler.rules.yml
@@ -34,7 +34,7 @@ spec:
       annotations:
         description: '{{`Cluster-Autoscaler on {{ $labels.cluster_id }} has failed scaling up.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/cluster-autoscaler-scaling/
-      expr: increase(cluster_autoscaler_failed_scale_ups_total{cluster_type="workload_cluster", provider=~"aws|capa|capz|eks"}[5m]) > 1
+      expr: cluster_autoscaler_failed_scale_ups_total{provider=~"aws|capa|capz|eks"} > 0
       for: 15m
       labels:
         area: kaas
@@ -42,6 +42,6 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: tenet
         topic: cluster-autoscaler


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/33288

This change modifies the alert to trigger on any non-zero value of
`cluster_autoscaler_failed_scale_ups_total`, ensuring we detect both active
and stuck failure states.

Fixes issue observed in `anemone/scn02` where cluster-autoscaler was stuck
trying to delete nodes that existed in the cloud provider but failed to join
the Kubernetes cluster.

Also changing it to paging during business hours because that one is critical.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).