### PR TITLE
Reenable storage low alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reenabled storage alerts LogVolumeSpaceTooLow and RootVolumeSpaceTooLow as paging during working hours until we have node problem detector deployed.
+
 ## [4.56.0] - 2025-04-24
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/storage.workload-cluster.rules.yml
@@ -64,7 +64,8 @@ spec:
       for: 60m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: tenet
         topic: storage
     - alert: RootVolumeSpaceTooLow
@@ -75,6 +76,7 @@ spec:
       for: 10m
       labels:
         area: kaas
-        severity: notify
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: tenet
         topic: storage


### PR DESCRIPTION

---
Towards: https://github.com/giantswarm/giantswarm/issues/33190

Until we have node-problem-detector in place we need to reenable these alerts


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
