### PR TITLE
fix recording rules slos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reenabled storage alerts LogVolumeSpaceTooLow and RootVolumeSpaceTooLow as paging during working hours until we have node problem detector deployed.
 
+### Fixed
+
+- Fix SLOs recording rules sent to Grafana Cloud that sometimes trigger PrometheusRulesFailure due to the origin metric pod changing.
+
 ## [4.56.0] - 2025-04-24
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -553,104 +553,93 @@ spec:
   - name: slos.grafana-cloud.recording
     rules:
       # Let's not send any of the slo:sli_error:ratio_ratexxx metrics but the slo:sli_error:ratio_rate5m rule to Grafana Cloud as it's not useful for the SLOs dashboard.
-      - expr: sum(
+      - expr: |-
+          label_replace(
             label_replace(
-              label_replace(
-                slo:current_burn_rate:ratio,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:current_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:current_burn_rate:ratio
       - expr: |-
-          sum(
+          label_replace(
             label_replace(
-              label_replace(
-                slo:error_budget:ratio,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:error_budget:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:error_budget:ratio
       - expr: |-
-          sum(
+          label_replace(
             label_replace(
-              label_replace(
-                slo:objective:ratio,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:objective:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:objective:ratio
       - expr: |-
-          sum(
+          label_replace(
             label_replace(
-              label_replace(
-                slo:period_burn_rate:ratio,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:period_burn_rate:ratio) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:period_burn_rate:ratio
       - expr: |-
-          sum(
+          label_replace(
             label_replace(
-              label_replace(
-                slo:sli_error:ratio_rate5m,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:sli_error:ratio_rate5m) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:sli_error:ratio_rate5m
       - expr: |-
-          sum(
+          label_replace(
             label_replace(
-              label_replace(
-                slo:time_period:days,
-                "slo",
-                "$1",
-                "sloth_id",
-                "(.*)"
-              ),
-              "service",
+              sum(slo:time_period:days) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, sloth_id, sloth_service),
+              "slo",
               "$1",
-              "sloth_service",
+              "sloth_id",
               "(.*)"
-            )
-          ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, slo, service)
+            ),
+            "service",
+            "$1",
+            "sloth_service",
+            "(.*)"
+          )
         record: aggregation:slo:time_period:days


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
We often use count or sum_over_time in our SLOs which causes some PrometheusRulesFailure alerts when pods restarts like so:

![image](https://github.com/user-attachments/assets/b22a518a-5619-4609-9823-d75658470bc1)


Moving the sum in the label replace makes sure we do not have labelset issues with pod, node or instance labels:
![image](https://github.com/user-attachments/assets/17622297-0b26-497b-95a0-beba5eca9656)


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
