### PR TITLE
no PromtailRequestsErrors alert if alloy-logs is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- PromtailRequestsErrors does not fire anymore when alloy-logs is running
+
 ## [4.56.1] - 2025-04-28
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -46,7 +46,7 @@ spec:
                 /
                 sum(rate(promtail_request_duration_seconds_count[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)
             ) > 10
-            # ignore this alert when alloy-logs is installed
+            # ignore this alert when alloy-logs is installed - this avoids false alerts when an unconfigured and unused promtail remains after migration to alloy-logs
             unless on (cluster_id) count(up{service="alloy-logs"}) by (cluster_id) > 0
           for: 60m
           labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -41,7 +41,13 @@ spec:
             description: This alert checks if that the amount of failed requests is below 10% for promtail
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
           expr: |
-            100 * (sum(rate(promtail_request_duration_seconds_count{status_code!~"2.."}[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance) / sum(rate(promtail_request_duration_seconds_count[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)) > 10
+            100 * (
+                sum(rate(promtail_request_duration_seconds_count{status_code!~"2.."}[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)
+                /
+                sum(rate(promtail_request_duration_seconds_count[5m])) by (cluster_id, installation, provider, pipeline, namespace, job, route, instance)
+            ) > 10
+            # ignore this alert when alloy-logs is installed
+            unless on (cluster_id) count(up{service="alloy-logs"}) by (cluster_id) > 0
           for: 60m
           labels:
             area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -126,11 +126,20 @@ tests:
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
   - interval: 1m
     input_series:
-      # Tests with multiple cases: no metrics, no requests, only status_code 204 ones, 204 ones and 500 that are less than 10% of the the total, 500 request that represent more than 10% of the total, only 500 ones
+      # Tests with multiple cases:
+      #   no metrics (no alert)
+      #   no requests (no alert)
+      #   only status_code 204 ones (no alert)
+      #   status codes 204 and less than 10% of status codes 500 (no alert)
+      #   status codes 500 requests that represent more than 10% of the total (alert fires)
+      #   only status codes 500 (alert fires)
+      #   only status code 500, but alloy-logs is installed (no alert)
       - series: 'promtail_request_duration_seconds_count{status_code="500", cluster_type="management_cluster", cluster_id="golem", installation="golem", provider="aws", pipeline="testing", node="ip-10-0-5-145.eu-west-1.compute.internal", pod="promtail-2j7z7"}'
-        values: "_x60 0+0x60 0+0x60   0+50x60      3000+100x60  9000+600x60"
+        values: "_x60 0+0x60 0+0x60   0+50x60      3000+100x60  9000+600x60 45000+600x60"
       - series: 'promtail_request_duration_seconds_count{status_code="204", cluster_type="management_cluster", cluster_id="golem", installation="golem", provider="aws", pipeline="testing", node="ip-10-0-5-145.eu-west-1.compute.internal", pod="promtail-2j7z7"}'
-        values: "_x60 0+0x60 0+600x60 36000+600x60 72000+600x60 108000+0x60"
+        values: "_x60 0+0x60 0+600x60 36000+600x60 72000+600x60 108000+0x60 108000+0x60"
+      - series: 'up{service="alloy-logs", cluster_id="golem"}'
+        values: "_x60 _x60   _x60     _x60         _x60         _x60        1+0x60"
     alert_rule_test:
       - alertname: PromtailRequestsErrors
         eval_time: 30m
@@ -184,3 +193,5 @@ tests:
               dashboardQueryParams: "orgId=2"
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
+      - alertname: PromtailRequestsErrors
+        eval_time: 360m

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -126,11 +126,20 @@ tests:
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
   - interval: 1m
     input_series:
-      # Tests with multiple cases: no metrics, no requests, only status_code 204 ones, 204 ones and 500 that are less than 10% of the the total, 500 request that represent more than 10% of the total, only 500 ones
+      # Tests with multiple cases:
+      #   no metrics (no alert)
+      #   no requests (no alert)
+      #   only status_code 204 ones (no alert)
+      #   status codes 204 and less than 10% of status codes 500 (no alert)
+      #   status codes 500 requests that represent more than 10% of the total (alert fires)
+      #   only status codes 500 (alert fires)
+      #   only status code 500, but alloy-logs is installed (no alert)
       - series: 'promtail_request_duration_seconds_count{status_code="500", cluster_type="management_cluster", cluster_id="glean", installation="glean", provider="capz", pipeline="testing", node="ip-10-0-5-145.eu-west-1.compute.internal", pod="promtail-2j7z7"}'
-        values: "_x60 0+0x60 0+0x60   0+50x60      3000+100x60  9000+600x60"
+        values: "_x60 0+0x60 0+0x60   0+50x60      3000+100x60  9000+600x60 45000+600x60"
       - series: 'promtail_request_duration_seconds_count{status_code="204", cluster_type="management_cluster", cluster_id="glean", installation="glean", provider="capz", pipeline="testing", node="ip-10-0-5-145.eu-west-1.compute.internal", pod="promtail-2j7z7"}'
-        values: "_x60 0+0x60 0+600x60 36000+600x60 72000+600x60 108000+0x60"
+        values: "_x60 0+0x60 0+600x60 36000+600x60 72000+600x60 108000+0x60 108000+0x60"
+      - series: 'up{service="alloy-logs", cluster_id="glean"}'
+        values: "_x60 _x60   _x60     _x60         _x60         _x60        1+0x60"
     alert_rule_test:
       - alertname: PromtailRequestsErrors
         eval_time: 30m
@@ -184,3 +193,5 @@ tests:
               dashboardQueryParams: "orgId=2"
               description: "This alert checks if that the amount of failed requests is below 10% for promtail"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
+      - alertname: PromtailRequestsErrors
+        eval_time: 360m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33341

This PR ensures `PromtailRequestsErrors` alerts won't fire if alloy-logs is running on the cluster.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
