### PR TITLE
added PromtailConflictsWithAlloy alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PromtailRequestsErrors does not fire anymore when alloy-logs is running
 
+### Added
+
+- Added PromtailConflictsWithAlloy alert
+
 ## [4.56.1] - 2025-04-28
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -58,3 +58,27 @@ spec:
             cancel_if_cluster_status_creating: "true"
             cancel_if_cluster_status_deleting: "true"
             cancel_if_cluster_status_updating: "true"
+        - alert: PromtailConflictsWithAlloy
+          # This alert was created as a workaround of https://github.com/giantswarm/giantswarm/issues/33341
+          # We are replacing promtail with alloy-logs. This is done during cluster upgrades.
+          # Sometimes the old promtail is not uninstalled properly, so we need this alert to inform us.
+          annotations:
+            __dashboardUid__: promtail-overview
+            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
+            dashboardQueryParams: "orgId=2"
+            {{ end }}
+            description: Both promtail and alloy-logs are installed and conflicting on the cluster
+            runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/#check-that-it-does-not-conflict-with-alloy-logs
+          expr: |
+            count(up{service="alloy-logs"}) by (cluster_id, installation, provider, pipeline) > 0
+            and count(up{service="promtail-metrics"}) by (cluster_id, installation, provider, pipeline) > 0
+          for: 60m
+          labels:
+            area: platform
+            severity: page
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+            cancel_if_cluster_status_creating: "true"
+            cancel_if_cluster_status_deleting: "true"
+            cancel_if_cluster_status_updating: "true"

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -195,3 +195,42 @@ tests:
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
       - alertname: PromtailRequestsErrors
         eval_time: 360m
+  - interval: 1m
+    input_series:
+      # Test various configs of promtail + alloy-logs:
+      #  - 120min with none installed
+      #  - 120min with only promtail
+      #  - 120min with promtail + alloy
+      #  - 120min with only alloy
+      - series: 'up{service="promtail-metrics", cluster_id="golem", cluster_type="management_cluster", installation="golem", namespace="kube-system", pod="promtail-1xxxx", provider="capa", pipeline="testing"}'
+        values: "_x120 1+0x120 1+0x120 _x120"
+      - series: 'up{service="alloy-logs", cluster_id="golem", cluster_type="management_cluster", installation="golem", namespace="kube-system", pod="alloy-logs-1xxxx", provider="capa", pipeline="testing"}'
+        values: "_x120 _x120   1+0x120 1+0x120"
+    alert_rule_test:
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 70m
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 190m
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 310m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: golem
+              installation: golem
+              pipeline: testing
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              __dashboardUid__: promtail-overview
+              dashboardQueryParams: "orgId=2"
+              description: "Both promtail and alloy-logs are installed and conflicting on the cluster"
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/#check-that-it-does-not-conflict-with-alloy-logs
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 430m

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/promtail.rules.test.yml
@@ -195,3 +195,42 @@ tests:
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
       - alertname: PromtailRequestsErrors
         eval_time: 360m
+  - interval: 1m
+    input_series:
+      # Test various configs of promtail + alloy-logs:
+      #  - 120min with none installed
+      #  - 120min with only promtail
+      #  - 120min with promtail + alloy
+      #  - 120min with only alloy
+      - series: 'up{service="promtail-metrics", cluster_id="glean", cluster_type="management_cluster", installation="glean", namespace="kube-system", pod="promtail-1xxxx", provider="capz", pipeline="testing"}'
+        values: "_x120 1+0x120 1+0x120 _x120"
+      - series: 'up{service="alloy-logs", cluster_id="glean", cluster_type="management_cluster", installation="glean", namespace="kube-system", pod="alloy-logs-1xxxx", provider="capz", pipeline="testing"}'
+        values: "_x120 _x120   1+0x120 1+0x120"
+    alert_rule_test:
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 70m
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 190m
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 310m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_cluster_status_updating: "true"
+              cluster_id: glean
+              installation: glean
+              pipeline: testing
+              provider: capz
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              __dashboardUid__: promtail-overview
+              dashboardQueryParams: "orgId=2"
+              description: "Both promtail and alloy-logs are installed and conflicting on the cluster"
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/#check-that-it-does-not-conflict-with-alloy-logs
+      - alertname: PromtailConflictsWithAlloy
+        eval_time: 430m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33341
This PR pages atlas during business hours when promtail and alloy-logs are both installed on some WC.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
