### PR TITLE
Add new `ClusterUpgradeStuck` alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new alert `ClusterUpgradeStuck` to detect if the cluster app cannot be upgraded.
+
 ## [4.57.0] - 2025-04-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -200,3 +200,27 @@ spec:
         severity: page
         team: honeybadger
         topic: releng
+    - alert: ClusterUpgradeStuck
+      annotations:
+        description: '{{`Cluster upgrade for {{ $labels.app }} is stuck. Version mismatch detected for {{ $labels.name }} in namespace {{ $labels.namespace }}.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-pending-update/
+      expr: |-
+        (
+          app_operator_app_info{catalog="cluster", app=~"cluster-.*", version_mismatch="true", status="already-exists"}
+          * on(cluster_id) group_left(provider)
+          sum(
+              label_replace(
+                capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
+              )
+          ) by (cluster_id, provider)
+        ) == 1
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_cluster_control_plane_unhealthy: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: {{ include "providerTeam" . }}
+        topic: releng

--- a/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
+++ b/test/tests/providers/global/platform/honeybadger/alerting-rules/app.rules.test.yml
@@ -104,3 +104,54 @@ tests:
             exp_annotations:
               description: App userd has no team label.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-without-team-annotation/
+
+  # ClusterUpgradeStuck tests
+  - interval: 1m
+    input_series:
+      - series: 'app_operator_app_info{app="cluster-aws", catalog="cluster", cluster_id="abc01", cluster_missing="false", cluster_type="management_cluster", container="app-exporter", customer="giantswarm", deployed_version="2.6.2", endpoint="web", installation="alba", instance="100.64.140.199:8000", job="app-exporter", latest_version="3.2.1", name="abc01", namespace="org-giantswarm", organization="giantswarm", pipeline="stable", pod="app-exporter-ff795cc9b-bh89s", provider="capa", region="eu-west-1", service="app-exporter", service_priority="highest", status="already-exists", team="phoenix", upgrade_available="false", version="3.2.1", version_mismatch="true"}'
+        values: "0+0x5 1+0x100"
+      - series: 'capi_cluster_info{cluster_id="abc01", infrastructure_reference_kind="AWSCluster", provider="capa"}'
+        values: "1x120"
+    alert_rule_test:
+      - alertname: ClusterUpgradeStuck
+        eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterUpgradeStuck
+              app: cluster-aws
+              area: platform
+              cancel_if_cluster_control_plane_unhealthy: "true"
+              cancel_if_cluster_status_creating: "true"
+              cancel_if_cluster_status_deleting: "true"
+              cancel_if_outside_working_hours: "true"
+              catalog: cluster
+              cluster_id: abc01
+              cluster_missing: "false"
+              cluster_type: management_cluster
+              container: app-exporter
+              customer: giantswarm
+              deployed_version: "2.6.2"
+              endpoint: web
+              installation: alba
+              instance: 100.64.140.199:8000
+              job: app-exporter
+              latest_version: "3.2.1"
+              name: abc01
+              namespace: org-giantswarm
+              organization: giantswarm
+              pipeline: stable
+              pod: app-exporter-ff795cc9b-bh89s
+              provider: capa
+              region: eu-west-1
+              service: app-exporter
+              service_priority: highest
+              severity: page
+              status: already-exists
+              team: phoenix
+              topic: releng
+              upgrade_available: "false"
+              version: "3.2.1"
+              version_mismatch: "true"
+            exp_annotations:
+              description: "Cluster upgrade for cluster-aws is stuck. Version mismatch detected for abc01 in namespace org-giantswarm."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-pending-update/


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/33398

This alert checks in case a cluster app is stuck via `status="already-exists"`.