### PR TITLE
DeploymentNotSatisfiedAtlas: lower sensitivity and page only during business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- DeploymentNotSatisfiedAtlas: lower sensitivity and page only during business hours
+
 ## [4.57.0] - 2025-04-30
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -18,13 +18,13 @@ spec:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/deployment-not-satisfied/
       expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|grafana.*|logging-operator.*|loki.*|mimir.*|oauth2-proxy.*|object-storage.*|observability-gateway.*|observability-operator.*|prometheus.*|promxy.*|tempo.*|pyroscope.*|silence-operator.*|sloth.*"} > 0
-      for: 30m
+      for: 60m
       labels:
         area: platform
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: true
         severity: page
         team: atlas
         topic: managementcluster

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -17,7 +17,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|grafana.*|logging-operator.*|loki.*|mimir.*|oauth2-proxy.*|object-storage.*|observability-gateway.*|observability-operator.*|prometheus.*|promxy.*|tempo.*|pyroscope.*|silence-operator.*|sloth.*"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|grafana.*|logging-operator.*|loki.*|mimir.*|object-storage.*|observability-gateway.*|observability-operator.*|prometheus.*|promxy.*|tempo.*|pyroscope.*|silence-operator.*|sloth.*"} > 0
       for: 60m
       labels:
         area: platform


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33400

Here is a reason why we don't need to page out of business hours, for each monitored component managed by this alert:
- **alertmanager**: if it breaks we eventually have a heartbeat alert
- **grafana**: if it breaks we eventually have a `grafanaDown` alert
- **logging-operator**: not critical for night and week-end operations
- **loki**: If one component is down and the service still works we don't care. If the service breaks we have `LokiMissingLogs`.
- **mimir**: If one component is down and the service still works we don't care. If the service breaks we have heartbeats and `MimirContinuous` alerts
- **oauth2-proxy**: we don't use it anymore, let's remove it from the alert.
- **object-storage**: not critical for night and week-end operations.
- **observability-gateway**: covered by `LogReceivingErrors`
- **observability-operator**: not critical for night and week-end operations.
- **prometheus**: we don't run any `prometheus`-named deployments anymore on CAPI.
- **promxy**: we don't run promxy anymore on CAPI.
- **tempo**: we don't run tempo yet, and when we will we should cover it with higher level alerts like mimir continuous tests and loki canary.
- **pyroscope**: we don't run pyroscope yet, and when we will we should cover it with higher level alerts like mimir continuous tests and loki canary.
- **silence-operator**: not critical for night and week-end operations.
- **sloth**: not critical for night and week-end operations.

Are you all fine with that?

### Checklist

- [ x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
