### PR TITLE
LogForwardingErrors: don't page out of business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `LogForwardingErrors`: don't page out of business hours
+
 ## [4.59.0] - 2025-05-08
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
@@ -51,6 +51,7 @@ spec:
             cancel_if_cluster_status_creating: "true"
             cancel_if_cluster_status_deleting: "true"
             cancel_if_cluster_status_updating: "true"
+            cancel_if_outside_working_hours: "true"
         # This alert pages when the loki source api component of the observability gateway is throwing errors
         - alert: LogReceivingErrors
           annotations:

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
@@ -28,6 +28,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws
@@ -48,6 +49,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
@@ -28,6 +28,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws
@@ -48,6 +49,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws

--- a/test/tests/providers/global/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
@@ -28,6 +28,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws
@@ -47,6 +48,7 @@ tests:
               cancel_if_cluster_status_creating: "true"
               cancel_if_cluster_status_deleting: "true"
               cancel_if_cluster_status_updating: "true"
+              cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
               provider: aws


### PR DESCRIPTION
I consider these alerts not critical enough to page during the night.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
