### PR TITLE
Improve AlloyUnhealthyComponents alert by adding pod name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved `AlloyUnhealthyComponents` alert by adding pod name
+
 ## [4.59.1] - 2025-05-09
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
@@ -40,10 +40,10 @@ spec:
             {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
             {{ end }}
-            description: '{{`Unhealthy components detected under job {{ $labels.job }}`}}'
+            description: '{{`Unhealthy pods {{ $labels.pod }} detected under job {{ $labels.job }}`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
             summary: Unhealthy components detected.
-          expr: sum by (cluster_id, installation, provider, pipeline, namespace, job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0
+          expr: sum by (cluster_id, installation, provider, pipeline, namespace, job, pod) (alloy_component_controller_running_components{health_type!="healthy"}) > 0
           for: 15m
           labels:
             area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -42,8 +42,8 @@ tests:
   # Test AlloyUnhealthyComponents
   - interval: 1m
     input_series:
-      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="golem", installation="golem", provider="capa", pipeline="testing", namespace="default", job="alloy-controller"}'
-        values: "0+0x10 1+0x50 0x50"
+      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="golem", installation="golem", provider="capa", pipeline="testing", namespace="default", job="alloy-controller", pod="alloy-metrics-0"}'
+        values: "0+0x10 1+0x50 0+0x50"
     alert_rule_test:
       - alertname: AlloyUnhealthyComponents
         eval_time: 10m
@@ -62,13 +62,14 @@ tests:
               pipeline: testing
               namespace: default
               job: alloy-controller
+              pod: alloy-metrics-0
               severity: page
               team: atlas
               topic: observability
             exp_annotations:
               __dashboardUid__: bf9f456aad7108b2c808dbd9973e386f
               dashboardQueryParams: "orgId=2"
-              description: "Unhealthy components detected under job alloy-controller"
+              description: "Unhealthy pods alloy-metrics-0 detected under job alloy-controller"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
               summary: "Unhealthy components detected."
       - alertname: AlloyUnhealthyComponents

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -42,7 +42,7 @@ tests:
   # Test AlloyUnhealthyComponents
   - interval: 1m
     input_series:
-      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="glean", installation="glean", provider="capz", pipeline="testing", namespace="default", job="alloy-controller"}'
+      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="glean", installation="glean", provider="capz", pipeline="testing", namespace="default", job="alloy-controller", pod="alloy-metrics-0"}'
         values: "0+0x10 1+0x50 0x50"
     alert_rule_test:
       - alertname: AlloyUnhealthyComponents
@@ -62,13 +62,14 @@ tests:
               pipeline: testing
               namespace: default
               job: alloy-controller
+              pod: alloy-metrics-0
               severity: page
               team: atlas
               topic: observability
             exp_annotations:
               __dashboardUid__: bf9f456aad7108b2c808dbd9973e386f
               dashboardQueryParams: "orgId=2"
-              description: "Unhealthy components detected under job alloy-controller"
+              description: "Unhealthy pods alloy-metrics-0 detected under job alloy-controller"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
               summary: "Unhealthy components detected."
       - alertname: AlloyUnhealthyComponents

--- a/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/vintage/aws/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -41,7 +41,7 @@ tests:
   # Test AlloyUnhealthyComponents
   - interval: 1m
     input_series:
-      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="gauss", installation="gauss", provider="aws", pipeline="testing", namespace="default", job="alloy-controller"}'
+      - series: 'alloy_component_controller_running_components{health_type="unhealthy", cluster_id="gauss", installation="gauss", provider="aws", pipeline="testing", namespace="default", job="alloy-controller", pod="alloy-metrics-0"}'
         values: "0+0x10 1+0x50 0x50"
     alert_rule_test:
       - alertname: AlloyUnhealthyComponents
@@ -61,12 +61,13 @@ tests:
               pipeline: testing
               namespace: default
               job: alloy-controller
+              pod: alloy-metrics-0
               severity: page
               team: atlas
               topic: observability
             exp_annotations:
               __dashboardUid__: bf9f456aad7108b2c808dbd9973e386f
-              description: "Unhealthy components detected under job alloy-controller"
+              description: "Unhealthy pods alloy-metrics-0 detected under job alloy-controller"
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/"
               summary: "Unhealthy components detected."
       - alertname: AlloyUnhealthyComponents


### PR DESCRIPTION
When we receive `AlloyUnhealthyComponents` we want to know which pod is having issues.
The alert did not give this information, so this PR adds the pod label to the description.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
