### PR TITLE
Remove code behind obvious capi conditions on atlas rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Vintage cleanup:
   - Stopped running tests for vintage. Meaning some vintage-specific labels had to be removed.
-  - Removed code behind obvious vintage conditions in Atlas rules.
+  - Removed code behind obvious vintage/capi conditions in Atlas rules.
 
 ## [4.59.2] - 2025-05-09
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alertmanager.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alertmanager.rules.yml
@@ -13,9 +13,7 @@ spec:
     - alert: AlertmanagerNotifyNotificationsFailing
       annotations:
         __dashboardUid__: alertmanager-overview
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
-        {{ end }}
         description: '{{`AlertManager {{ $labels.integration }} notifications are failing.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alert-manager-notifications-failing/
       # Interval = 20m because currently AlertManager config set `group_interval=15m` that means that if a notification fails, it will be retried after 15m
@@ -32,9 +30,7 @@ spec:
     - alert: AlertmanagerPageNotificationsFailing
       annotations:
         __dashboardUid__: alertmanager-overview
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
-        {{ end }}
         description: '{{`AlertManager {{ $labels.integration }} notifications are failing.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alert-manager-notifications-failing/
       # Here, we decide to notify after 2 successive failures (opsgenie notification), so we need to wait 2*15m = 30m before notifying.

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
@@ -17,9 +17,7 @@ spec:
         - alert: AlloySlowComponentEvaluations
           annotations:
             __dashboardUid__: bf9f456aad7108b2c808dbd9973e386f
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: '{{`Component evaluations are taking too long under job {{ $labels.job }}, component_id {{ $labels.component_id }}.`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
             summary: Component evaluations are taking too long.
@@ -34,9 +32,7 @@ spec:
         - alert: AlloyUnhealthyComponents
           annotations:
             __dashboardUid__: bf9f456aad7108b2c808dbd9973e386f
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: '{{`Unhealthy pods {{ $labels.pod }} detected under job {{ $labels.job }}`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
             summary: Unhealthy components detected.
@@ -55,9 +51,7 @@ spec:
         - alert: LoggingAgentDown
           annotations:
             __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: '{{`Scraping of all logging-agent pods to check if one failed every 30 minutes.`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/
           expr: |-
@@ -83,9 +77,7 @@ spec:
             summary: Monitoring agent fails to send samples to remote write endpoint.
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/#monitoring-agent-down
             __dashboardUid__: promRW001
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=1"
-            {{ end }}
           expr: |-
             count(
               label_replace(
@@ -117,9 +109,7 @@ spec:
             summary: Monitoring agent fails to send samples to remote write endpoint.
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/alloy/#monitoring-agent-down
             __dashboardUid__: promRW001
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=1"
-            {{ end }}
           expr: |-
             count(
               label_replace(

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -105,11 +105,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/deployment-not-satisfied/
-      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
       expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|teleport-.*|dex*|athena*|rbac-operator|credentiald"} > 0
-      {{- else }}
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"cert-manager-*|dex*|athena*|rbac-operator|credentiald"} > 0
-      {{- end }}
       for: 30m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
@@ -16,9 +16,7 @@ spec:
         description: '{{`Fluentbit ({{ $labels.instance }}) is erroring.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluentbit-too-many-erros/
         __dashboardUid__: fluentbit
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
       # If we have some failures sending data, raise an alert
       expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
       for: 20m
@@ -33,9 +31,7 @@ spec:
         description: '{{`Fluentbit ({{ $labels.instance }}) is dropping more than 1% records.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluentbit-too-many-erros/
         __dashboardUid__: fluentbit
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
       # Check the ratio of dropped records over the total number of records.
       expr: rate(fluentbit_output_dropped_records_total[10m]) / (rate(fluentbit_output_proc_records_total[10m]) + rate(fluentbit_output_dropped_records_total[10m])) > 0.01
       for: 20m
@@ -50,9 +46,7 @@ spec:
         description: '{{`Fluentbit is down on node ({{ $labels.node }}).`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluentbit-down/
         __dashboardUid__: fluentbit
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
       expr: sum(up{job="fluent-logshipping-app"}) by (job, cluster_id, installation, provider, pipeline, namespace, node) == 0
       for: 15m
       labels:
@@ -66,9 +60,7 @@ spec:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/daemonset-not-satisfied/
         __dashboardUid__: fluentbit
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
       expr: kube_daemonset_status_number_unavailable{daemonset="fluent-logshipping-app"} > 0
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana-cloud.rules.yml
@@ -14,11 +14,7 @@ spec:
       annotations:
         description: 'Prometheus is not sending data to Grafana Cloud.'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/prometheus-grafanacloud/
-      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
       expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud", cluster_type="management_cluster", cluster_id="{{ .Values.managementCluster.name }}", installation="{{ .Values.managementCluster.name }}", provider="{{ .Values.managementCluster.provider.kind }}", pipeline="{{ .Values.managementCluster.pipeline }}"})
-      {{- else }}
-      expr: absent(prometheus_remote_storage_samples_total{remote_name="grafana-cloud"})
-      {{- end }}
       for: 1h
       labels:
         area: platform
@@ -26,7 +22,6 @@ spec:
         severity: page
         team: atlas
         topic: observability
-  {{- if eq .Values.managementCluster.provider.flavor "capi" }}
   - name: mimir-to-grafana-cloud-exporter
     rules:
     - alert: MimirToGrafanaCloudExporterDown
@@ -86,4 +81,3 @@ spec:
         severity: page
         team: atlas
         topic: observability
-  {{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
@@ -14,9 +14,7 @@ spec:
         description: '{{`Grafana ({{ $labels.instance }}) is down.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/grafana-down/
         __dashboardUid__: qRQXmRnik
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
       expr: up{service="grafana", cluster_type="management_cluster"} == 0
       for: 1h
       labels:

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
@@ -14,9 +14,7 @@ spec:
         - alert: LogForwardingErrors
           annotations:
             __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: '{{`More that 10% of the requests to Loki are failing.`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/logging-pipeline/
           expr: |-
@@ -53,9 +51,7 @@ spec:
         - alert: LogReceivingErrors
           annotations:
             __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: '{{`More that 10% of the loki requests to the observability gateway are failing.`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/logging-pipeline/
           expr: |-

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -125,9 +125,7 @@ spec:
     - alert: LokiCompactorFailedCompaction
       annotations:
         __dashboardUid__: loki-retention
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
         description: 'Loki compactor has been failing compactions for more than 2 hours since last compaction.'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/loki#lokicompactorfailedcompaction
       # This alert checks if Loki's the last successful compaction run is older than 2 hours
@@ -142,9 +140,7 @@ spec:
     - alert: LokiCompactorFailedCompaction
       annotations:
         __dashboardUid__: loki-retention
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
         description: 'Loki compactor has been failing compactions for more than 2 hours since start-up.'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/loki#lokicompactorfailedcompaction
       # This alert covers the special case at compactor startup, where the "normal" alert would always consider time `0` is more than 2 hours ago, yet we want to let it 2 hours + `for` duration.
@@ -159,9 +155,7 @@ spec:
     - alert: LokiMissingLogs
       annotations:
         __dashboardUid__: loki-canary
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
         description: This alert checks that loki is not missing canary logs
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/loki/
       expr: |
@@ -183,9 +177,7 @@ spec:
     - alert: LokiObjectStorageLowRate
       annotations:
         __dashboardUid__: loki-operational
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=2"
-        {{ end }}
         description: '{{`Loki object storage write rate is down.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/loki/
       expr: |

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -1,4 +1,3 @@
-{{- if eq .Values.managementCluster.provider.flavor "capi" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -332,4 +331,3 @@ spec:
         severity: page
         team: atlas
         topic: observability
-{{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
@@ -15,9 +15,7 @@ spec:
         description: '{{`Monitoring agent failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
         __dashboardUid__: promRW001
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
-        {{ end }}
       expr: |-
         (
           rate(prometheus_remote_storage_samples_failed_total[5m])
@@ -39,9 +37,7 @@ spec:
     - alert: JobScrapingFailure
       annotations:
         __dashboardUid__: servicemonitors-details
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
-        {{ end }}
         description: '{{`Monitoring agents for cluster {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}'
         summary: Monitoring agent failed to scrape all targets in a job.
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-job-scraping-failure/
@@ -61,9 +57,7 @@ spec:
     - alert: CriticalJobScrapingFailure
       annotations:
         __dashboardUid__: servicemonitors-details
-        {{ if eq .Values.managementCluster.provider.flavor "capi" }}
         dashboardQueryParams: "orgId=1"
-        {{ end }}
         description: '{{`Monitoring agents for cluster {{$labels.installation}}/{{$labels.cluster_id}} has failed to scrape all targets in {{$labels.job}} job.`}}'
         summary: Monitoring agent failed to scrape all targets in a job.
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-job-scraping-failure/

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/promtail.rules.yml
@@ -32,9 +32,7 @@ spec:
         - alert: PromtailRequestsErrors
           annotations:
             __dashboardUid__: promtail-overview
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: This alert checks if that the amount of failed requests is below 10% for promtail
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/
           expr: |
@@ -58,9 +56,7 @@ spec:
           # Sometimes the old promtail is not uninstalled properly, so we need this alert to inform us.
           annotations:
             __dashboardUid__: promtail-overview
-            {{ if eq .Values.managementCluster.provider.flavor "capi" }}
             dashboardQueryParams: "orgId=2"
-            {{ end }}
             description: Both promtail and alloy-logs are installed and conflicting on the cluster
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/promtail/#check-that-it-does-not-conflict-with-alloy-logs
           expr: |

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/teleport.logs.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/teleport.logs.yml
@@ -1,4 +1,3 @@
-{{- if eq .Values.managementCluster.provider.flavor "capi" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -23,4 +22,3 @@ spec:
             severity: page
             team: atlas
             topic: observability
-{{ end }}

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/mimir-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/mimir-mixins.rules.yml
@@ -1,4 +1,3 @@
-{{- if eq .Values.managementCluster.provider.flavor "capi" }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -468,4 +467,3 @@ spec:
         - expr: |
             sum by(cluster_id, installation, pipeline, provider, namespace, pod) (rate(cortex_ingester_ingested_samples_total[1m]))
           record: cluster_id_namespace_pod:cortex_ingester_ingested_samples_total:rate1m
-{{- end }}

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/monitoring.resource-usage-estimation.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/monitoring.resource-usage-estimation.rules.yml
@@ -9,14 +9,7 @@ spec:
   groups:
   - name: monitoring.resource-usage-estimation.recording
     rules:
-    {{- if eq .Values.managementCluster.provider.flavor "capi" }}
     - expr: (sum(scrape_samples_post_metric_relabeling) by (cluster_id, installation, job, pipeline, provider) / on(cluster_id) group_left sum(cortex_ingester_active_series{container="ingester"}) by (cluster_id)) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="ingester", namespace="mimir"}) by (cluster_id)
       record: giantswarm:observability:monitoring:resource_usage_estimation:memory_usage_bytes
     - expr: (sum(scrape_samples_post_metric_relabeling) by (cluster_id, installation, job, pipeline, provider) / on(cluster_id) group_left sum(cortex_ingester_active_series{container="ingester"}) by (cluster_id)) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="ingester", namespace="mimir"}) by (cluster_id)
       record: giantswarm:observability:monitoring:resource_usage_estimation:memory_working_set_bytes
-    {{- else }}
-    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series{instance="localhost:9090"}) * on(cluster_id) group_left sum(container_memory_usage_bytes{container="prometheus", namespace="kube-system"}) by (cluster_id)
-      record: giantswarm:observability:monitoring:resource_usage_estimation:memory_usage_bytes
-    - expr: (count({__name__=~".+"}) by (cluster_id, job) / on(cluster_id) group_left prometheus_tsdb_head_series{instance="localhost:9090"}) * on(cluster_id) group_left sum(container_memory_working_set_bytes{container="prometheus", namespace="kube-system"}) by (cluster_id)
-      record: giantswarm:observability:monitoring:resource_usage_estimation:memory_working_set_bytes
-    {{- end }}


### PR DESCRIPTION
Follow-up on https://github.com/giantswarm/prometheus-rules/pull/1603

Now looking at obvious capi conditions in atlas rules.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
