### PR TITLE
Remove obvious vintage/capi conditions in Shield rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed code behind obvious vintage/capi conditions in Cabbage rules.
   - Removed code behind obvious vintage/capi conditions in Honeybadger rules.
   - Removed code behind obvious vintage/capi conditions in Tenet rules.
+  - Removed code behind obvious vintage/capi conditions in Shield rules.
 
 ## [4.60.0] - 2025-05-13
-
-### Changed
 
 ### Added
 
 - Add `OnPremCloudProviderAPIIsDown` alert to all clusters
+
+### Changed
 
 - Vintage cleanup:
   - Stopped running tests for vintage. Meaning some vintage-specific labels had to be removed.

--- a/helm/prometheus-rules/templates/platform/shield/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/platform/shield/alerting-rules/dex.rules.yml
@@ -4,9 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-    cluster_type: "management_cluster"
-    {{- end }}
   name: dex.rules
   namespace: {{ .Values.namespace  }}
 spec:
@@ -41,11 +38,7 @@ spec:
       annotations:
         description: '{{`dex-operator did not register a dex-app in giantswarm namespace.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/dex-operator/
-      {{- if eq .Values.managementCluster.provider.flavor "capi" }}
       expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm", cluster_type="management_cluster", cluster_id="{{ .Values.managementCluster.name }}", installation="{{ .Values.managementCluster.name }}", provider="{{ .Values.managementCluster.provider.kind }}", pipeline="{{ .Values.managementCluster.pipeline }}"})
-      {{- else }}
-      expr: absent(dex_operator_idp_secret_expiry_time{app_namespace="giantswarm", cluster_type="management_cluster"}) == 1
-      {{- end }}
       for: 30m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/shield/alerting-rules/falco.rules.yml
+++ b/helm/prometheus-rules/templates/platform/shield/alerting-rules/falco.rules.yml
@@ -4,9 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-    cluster_type: "management_cluster"
-    {{- end }}
   name: falco.rules
   namespace: {{ .Values.namespace  }}
 spec:


### PR DESCRIPTION
Follow-up on https://github.com/giantswarm/prometheus-rules/pull/1602
Similar as https://github.com/giantswarm/prometheus-rules/pull/1603 as https://github.com/giantswarm/prometheus-rules/pull/1604

Now that we don't push to vintage anymore, we can do some cleanup in rules.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
