### PR TITLE
Remove obvious vintage/capi conditions in Cabbage rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Vintage cleanup:
+  - Removed code behind obvious vintage/capi conditions in Cabbage rules.
+
 ## [4.60.0] - 2025-05-13
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -59,7 +59,6 @@ spec:
         severity: page
         team: cabbage
         topic: cilium
-    {{- if eq .Values.managementCluster.provider.flavor "capi" }}
     - alert: FluxHelmReleaseFailed
       annotations:
         description: |-
@@ -77,4 +76,3 @@ spec:
         topic: cilium
         namespace: |-
           {{`{{ $labels.exported_namespace }}`}}
-    {{- end -}}

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
@@ -23,7 +23,6 @@ spec:
         severity: page
         team: cabbage
         topic: dns
-    {{- if eq .Values.managementCluster.provider.flavor "capi" }}
     - alert: FluxHelmReleaseFailed
       annotations:
         description: |-
@@ -41,7 +40,6 @@ spec:
         topic: dns
         namespace: |-
           {{`{{ $labels.exported_namespace }}`}}
-    {{- end }}
     - alert: CoreDNSMaxHPAReplicasReached
       expr: |
         (

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
@@ -4,9 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    {{- if eq .Values.managementCluster.provider.flavor "vintage" }}
-    cluster_type: "workload_cluster"
-    {{- end }}
   name: external-dns.rules
   namespace: {{ .Values.namespace }}
 spec:


### PR DESCRIPTION
Follow-up on https://github.com/giantswarm/prometheus-rules/pull/1602
Similar as https://github.com/giantswarm/prometheus-rules/pull/1603 as https://github.com/giantswarm/prometheus-rules/pull/1604

Now that we don't push to vintage anymore, we can do some cleanup in rules.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
