### PR TITLE
Add OnPremCloudProviderAPIIsDown alert to all clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Added
+
+- Add `OnPremCloudProviderAPIIsDown` alert to all clusters
+
 - Vintage cleanup:
   - Stopped running tests for vintage. Meaning some vintage-specific labels had to be removed.
   - Removed code behind obvious vintage/capi conditions in Atlas rules.

--- a/helm/prometheus-rules/templates/kaas/rocket/alerting-rules/blackbox-exporter.cloud-provider-api.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/rocket/alerting-rules/blackbox-exporter.cloud-provider-api.rules.yml
@@ -1,0 +1,26 @@
+# This rule is applied to all management clusters but it is only active if blackbox
+# exporter is deployed and configured with a scrape job named 'http-cloud-provider-api'
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: rocket-onprem-cloud-provider-api
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  - name: rocket-onprem-cloud-provider-api
+    rules:
+    - alert: OnPremCloudProviderAPIIsDown
+      annotations:
+        description: '{{` blackbox-exporter on {{ $labels.cluster_id}} is unable to connect to the on-prem cloud provider API.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/onprem-cloud-provider-api-is-down/
+      expr: probe_success{cluster_type="management_cluster",job="prometheus-blackbox-exporter",target="http-cloud-provider-api"} == 0
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: rocket
+        topic: network
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32943

This PR adds an alert which fires if blackbox-exporter is unable to connect to an on-prem cloud provider API. This must be deployed all MCs regardless of provider because of hybrid clusters - the MC may be in the cloud but configured to create WCs on-prem.The alert is inactive unless a blackbox exporter target named `http-cloud-provider-api` exists in the MC.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
