### PR TITLE
clean up mimir heartbeat type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed code behind obvious vintage/capi conditions in Tenet rules.
   - Removed code behind obvious vintage/capi conditions in Shield rules.
   - Remove the "aws" provider.
+- Clean up mimir-heartbeat type that was needed when we have both old and new heartbeats.
 
 ## [4.60.0] - 2025-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed code behind obvious vintage/capi conditions in Tenet rules.
   - Removed code behind obvious vintage/capi conditions in Shield rules.
   - Remove the "aws" provider.
-- Clean up mimir-heartbeat type that was needed when we have both old and new heartbeats.
+  - Clean up mimir-heartbeat type that was needed when we have both old and new heartbeats.
 
 ## [4.60.0] - 2025-05-13
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -18,8 +18,6 @@ spec:
       labels:
         area: platform
         installation: {{ .Values.managementCluster.name }}
-        # TODO(@giantswarm/team-atlas): We need this label as long as we have the old and new heartbeats. Let's remove once the legacy monitoring is gone
-        type: mimir-heartbeat
         team: atlas
         topic: observability
     # Coming from https://github.com/giantswarm/giantswarm/issues/30124

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -19,7 +19,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
@@ -35,7 +34,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
@@ -51,7 +49,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -19,7 +19,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
@@ -35,7 +34,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/
@@ -51,7 +49,6 @@ tests:
               installation: myinstall
               team: atlas
               topic: observability
-              type: mimir-heartbeat
             exp_annotations:
               description: "This alert is used to ensure the entire alerting pipeline is functional."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir/


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Follow up of https://github.com/giantswarm/observability-operator/pull/391

This PR cleans up the unused mimir heartbeat type

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
