### PR TITLE
Moving AAC related alert to HB

### DIFF
--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{cluster_type="management_cluster"}[5m])) by (cluster_id, installation, pipeline, provider, name, job, le)) > 5
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{cluster_type="management_cluster", name!="apps.app-admission-controller.giantswarm.io"}[5m])) by (cluster_id, installation, pipeline, provider, name, job, le)) > 5
       for: 25m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{name="apps.app-admission-controller.giantswarm.io"}[5m])) by (name, le)) > 9
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{name="apps.app-admission-controller.giantswarm.io"}[5m])) by (cluster_id, installation, pipeline, provider, name, le)) > 9
       for: 25m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
-      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{name="apps.app-admission-controller.giantswarm.io"}[5m])) by (le)) > 9
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{name="apps.app-admission-controller.giantswarm.io"}[5m])) by (name, le)) > 9
       for: 25m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -10,6 +10,18 @@ spec:
   groups:
   - name: app
     rules:
+    - alert: AppAdmissionControllerWebhookDurationExceedsTimeout
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{name="apps.app-admission-controller.giantswarm.io"}[5m])) by (le)) > 9
+      for: 25m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: honeybadger
+        topic: releng
     - alert: ManagementClusterAppFailed
       annotations:
         description: '{{`Management Cluster App {{ $labels.name }}, version {{ $labels.version }} is {{if $labels.status }} in {{ $labels.status }} state. {{else}} not installed. {{end}}`}}'
@@ -42,7 +54,7 @@ spec:
       expr: |-
         (
           app_operator_app_info{status!~"(?i:(deployed|cordoned|not-installed))", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"}
-          * on(cluster_id) group_left(provider) 
+          * on(cluster_id) group_left(provider)
           sum(
               label_replace(
                 capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
@@ -64,8 +76,8 @@ spec:
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-failed/
       expr: |-
         (
-          app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"} 
-          * on(cluster_id) group_left(provider) 
+          app_operator_app_info{status="not-installed", catalog=~"giantswarm|cluster|default", team!~"^$|noteam"}
+          * on(cluster_id) group_left(provider)
           sum(
               label_replace(
                 capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"
@@ -109,7 +121,7 @@ spec:
       expr: |-
         (
           app_operator_app_info{app!~"api-spec(-app)?", team=~"^$|noteam", catalog=~"giantswarm.*|control-plane(-test)?-catalog|cluster(-test)?|default(-test)?|releases(-test)?"}
-          * on(cluster_id) group_left(provider) 
+          * on(cluster_id) group_left(provider)
           sum(
               label_replace(
                 capi_cluster_info, "provider", "vsphere", "infrastructure_reference_kind", "VSphereCluster"


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
