### PR TITLE
tune MimirIngesterNeedsToBeScaledUp alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `IncorrectResourceUsageData` alert.
 
+### Changed
+
+- Made `MimirIngesterNeedsToBeScaledUp` alert less sensitive to CPU usage
+
 ## [4.62.0] - 2025-05-15
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -84,7 +84,7 @@ spec:
         sum(rate(container_cpu_usage_seconds_total{container="ingester", namespace="mimir"}[5m])) by (cluster_id, installation, namespace, pipeline, provider) 
           / 
         sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="ingester", namespace="mimir", unit="core"}) 
-          >= 0.90
+          >= 0.95
       for: 1h
       labels:
         area: platform

--- a/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capa/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -153,7 +153,7 @@ tests:
         values: "12+0x400"
       # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
-        values: "0+60x100 6000+110x70 10400+60x60 14000+110x70 18400+60x60"
+        values: "0+60x100 6000+130x70 10400+60x60 14000+110x70 18400+60x60"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capa", region="eu-west-2"}'
         values: "0+60x400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.

--- a/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/capi/capz/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -151,16 +151,16 @@ tests:
         values: "12+0x400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capz", region="eu-west-2"}'
         values: "12+0x400"
-      # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
+      # mimir-ingester real cpu usage gradually increases until it goes beyond 95% of the cpu requests.
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capz", region="eu-west-2"}'
-        values: "0+60x100 6000+110x70 10400+60x60 14000+110x70 18400+60x60"
+        values: "0+60x100 6000+130x70 10400+60x60 14000+110x70 18400+60x60"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capz", region="eu-west-2"}'
         values: "0+60x400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capz", region="eu-west-2"}'
-        values: "1.5+0x400"                                 
+        values: "1.5+0x400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="capz", region="eu-west-2"}'
-        values: "1.5+0x400"                                 
+        values: "1.5+0x400"
     alert_rule_test:
       - alertname: MimirIngesterNeedsToBeScaledUp
         eval_time: 15m


### PR DESCRIPTION
I've seen some case when the alert pages and:
- it triggers because CPU usage is too high
- VPA still has some margin, but does not trigger

My conclusion is this alert should be less sensitive on CPU usage.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
