### PR TITLE
increase MimirIngesterNeedsToBeScaledUp time from 1h to 6h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Made `MimirIngesterNeedsToBeScaledUp` alert less sensitive to CPU usage
+- Made `MimirIngesterNeedsToBeScaledUp` alert less sensitive to CPU usage.
+- Increase `MimirIngesterNeedsToBeScaledUp` alert's time to trigger from 1h to 6h to avoid noise coming from temporary spikes like from `stable-testing` installations (https://github.com/giantswarm/giantswarm/issues/33513)
 - Rules unit tests: support for `$provider` template so we can move provider-specific tests to global tests.
 - Rules unit tests: simplify files organization by removing the `capi` folder. Also fixes a bug in cloud-director tests.
 - Rules linting: run against all configured providers.
@@ -564,8 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update alloy-app to 0.6.1. This includes:
-  - an upgrade to upstream version 1.4.2
-  - a ciliumnetworkpolicy fix for clustering.
+    - an upgrade to upstream version 1.4.2
+    - a ciliumnetworkpolicy fix for clustering.
 
 ## [4.18.0] - 2024-10-08
 
@@ -2943,7 +2944,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Opsrecipie link for `KiamSTSIssuingErrors`
+- Opsrecipie link for `KiamSTSIssuingErrors`.
 
 ## [2.14.0] - 2022-04-12
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -85,7 +85,7 @@ spec:
           / 
         sum by(cluster_id, installation, namespace, pipeline, provider) (kube_pod_container_resource_requests{container="ingester", namespace="mimir", unit="core"}) 
           >= 0.95
-      for: 1h
+      for: 6h
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -165,7 +165,7 @@ tests:
       - alertname: MimirIngesterNeedsToBeScaledUp
         eval_time: 3h
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 8h
+        eval_time: 9h
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -153,7 +153,7 @@ tests:
         values: "12+0x2400"
       # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "0+60x600 6000+0x420 10400+0x360 14000+0x420 18400+0x360"
+        values: "0+60x600 6000+130x420 10400+60x360 14000+110x420 18400+60x360"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
         values: "0+0x2400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.

--- a/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -151,11 +151,11 @@ tests:
         values: "12+0x2400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
         values: "12+0x2400"
-      # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
+      # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
         values: "0+60x600 6000+130x420 10400+60x360 14000+110x420 18400+60x360"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "0+0x2400"
+        values: "0+60x2400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
         values: "1.5+0x2400"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -143,29 +143,29 @@ tests:
     input_series:
       # mimir-ingester real memory usage gradually increases until it goes beyond 90% of the memory requests.
       - series: 'container_memory_working_set_bytes{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "8+0x20 11+0x70 8+0x140 11+0x70 8+0x60"
+        values: "8+0x120 11+0x420 8+0x840 11+0x420 8+0x360"
       - series: 'container_memory_working_set_bytes{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "8+0x20 11+0x70 8+0x140 11+0x70 8+0x60"
+        values: "8+0x120 11+0x420 8+0x840 11+0x420 8+0x360"
       # mimir-ingester memory requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "12+0x400"
+        values: "12+0x2400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="byte", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "12+0x400"
+        values: "12+0x2400"
       # mimir-ingester real cpu usage gradually increases until it goes beyond 90% of the cpu requests.                              
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-0", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "0+60x100 6000+130x70 10400+60x60 14000+110x70 18400+60x60"
+        values: "0+60x600 6000+0x420 10400+0x360 14000+0x420 18400+0x360"
       - series: 'container_cpu_usage_seconds_total{pod="mimir-ingester-1", container="ingester", namespace="mimir", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "0+60x400"
+        values: "0+0x2400"
       # mimir-ingester cpu requests stay the same for the entire duration of the test.
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-0", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "1.5+0x400"                                 
+        values: "1.5+0x2400"
       - series: 'kube_pod_container_resource_requests{pod="mimir-ingester-1", container="ingester", namespace="mimir", unit="core", cluster_type="management_cluster", cluster_id="golem", installation="golem", pipeline="testing", provider="$provider", region="eu-west-2"}'
-        values: "1.5+0x400"                                 
+        values: "1.5+0x2400"
     alert_rule_test:
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 15m
+        eval_time: 3h
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 85m
+        eval_time: 8h
         exp_alerts:
           - exp_labels:
               area: platform
@@ -182,9 +182,9 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir-ingester/
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 130m
+        eval_time: 13h
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 170m 
+        eval_time: 17h
         exp_alerts:
           - exp_labels:
               area: platform
@@ -201,9 +201,9 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir-ingester/
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 210m
+        eval_time: 21h
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 295m
+        eval_time: 29h30m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -220,7 +220,7 @@ tests:
               description: Mimir ingester is consuming too much resources and needs to be scaled up.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir-ingester/
       - alertname: MimirIngesterNeedsToBeScaledUp
-        eval_time: 350m
+        eval_time: 35h
   # Test for MimirIngesterNeedsToBeScaledDown alert
   - interval: 1m
     input_series:


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Closes https://github.com/giantswarm/giantswarm/issues/33513

This pull request includes updates to the sensitivity and timing of the `MimirIngesterNeedsToBeScaledUp` alert.

### Alert adjustments:

* Increased the `MimirIngesterNeedsToBeScaledUp` alert's time to trigger from 1 hour to 6 hours to reduce noise caused by temporary CPU usage spikes. This change is reflected in both the `CHANGELOG.md` file and the `mimir.rules.yml` alert configuration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL16-R17) [[2]](diffhunk://#diff-9455cb0df22c7b980afbaa4ac5a0d83170160797b9f2d816cb612e911e6483a2L88-R88)

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
