### PR TITLE
Exclude more containers from Rocket's ManagementClusterContainerIsRestartingTooFrequently alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rules unit tests: support for `$provider` template so we can move provider-specific tests to global tests.
 - Rules unit tests: simplify files organization by removing the `capi` folder. Also fixes a bug in cloud-director tests.
 - Rules linting: run against all configured providers.
-
+- Exclude more containers from Rocket's `ManagementClusterContainerIsRestartingTooFrequently` alert.
 ## [4.62.0] - 2025-05-15
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
@@ -72,7 +72,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="grafana.*|prometheus.*|promxy.*|promtail.*|silence.*|teleport.*|.*-admission-controller.*|*-aws-*|aws-*|route53-manager.*"}[1h]) > 5
+      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="grafana.*|prometheus.*|promxy.*|promtail.*|silence.*|teleport.*|.*-admission-controller.*|*-aws-*|aws-*|route53-manager.*|cilium.*|external-dns.*|teleport.*|falco.*|kyverno.*|postgres.*|exception.*|edgedb.*|athena.*|app.*"}[1h]) > 5
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Ref https://gigantic.slack.com/archives/CLPMFRVU6/p1748599402519089

This PR ...

- stops alerts going to Rocket for other team's workloads

### Checklist

- [x] Update CHANGELOG.md
