### PR TITLE
Rework Rocket's ManagementClusterContainerIsRestartingTooFrequently to use pod names as the selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed `grafana` from `DeploymentNotSatisfiedAtlas` because it's already monitored via `GrafanaDown` alert.
+- Rework Rocket's `ManagementClusterContainerIsRestartingTooFrequently` to use pod names as the selector.
 
 ## [4.63.0] - 2025-06-02
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
@@ -72,7 +72,7 @@ spec:
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/container-is-restarting-too-often/
-      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", container!="grafana.*|prometheus.*|promxy.*|promtail.*|silence.*|teleport.*|.*-admission-controller.*|*-aws-*|aws-*|route53-manager.*|cilium.*|external-dns.*|teleport.*|falco.*|kyverno.*|postgres.*|exception.*|edgedb.*|athena.*|app.*"}[1h]) > 5
+      expr: increase(kube_pod_container_status_restarts_total{cluster_type="management_cluster", pod!~"grafana.*|prometheus.*|silence.*|teleport.*|.*-admission-controller.*|.*-aws-.*|aws-.*|route53-manager.*|cilium.*|external-dns.*|falco.*|kyverno.*|postgres.*|exception.*|edgedb.*|athena.*|app.*"}[1h]) > 5
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
This PR reworks the `ManagementClusterContainerIsRestartingTooFrequently` rule for several reasons, the main one being:

The selector was using container names which are somewhat arbitrary. see this example:

```
Container nmi in pod kube-system/azure-ad-pod-identity
```

By switching to pod names we can cover more matches without ending up with a ridiculously long regex whilst still returning the same data.

There were also several other smaller issues which this PR addresses:

- the alert never worked in the first place, to negatively regex labels you need to use the `!~` operator, not `!=`.
- `*-aws-*|aws-*` is not a valid regex, it should be `.*-aws-.*|aws-.*`. Grafana errored out with the original regex: `error parsing regexp: missing argument to repetition operator`.
- a bunch of the labels reference pods which we no longer use (promxy, promtail etc).

### Checklist

- [x] Update CHANGELOG.md
