### PR TITLE
Update alert for Cilium HelmRelease to match timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `grafana` from `DeploymentNotSatisfiedAtlas` because it's already monitored via `GrafanaDown` alert.
 - Rework Rocket's `ManagementClusterContainerIsRestartingTooFrequently` to use pod names as the selector.
+- Update alert for Cilium HelmRelease to match timeout.
 
 ## [4.63.0] - 2025-06-02
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1
+aGpiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null
@@ -65,7 +65,7 @@ spec:
           {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}-{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-helmrelease/
       expr: gotk_reconcile_condition{type="Ready", status="False", kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~".*(cilium|network-policies)"} > 0
-      for: 20m
+      for: 1h10m
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -1,4 +1,4 @@
-aGpiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/33410



### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
