### PR TITLE
make MetricForwardingErrors alert less sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Increase `MimirIngesterNeedsToBeScaledUp` alert's time to trigger from 6h to 12h to avoid noise coming from temporary spikes.
 - WorkloadClusterWebhookDurationExceedsTimeoutSolutionEngineers alert: make it page only during business hours, and increase delay to 1h before it pages
+- MetricForwardingErrors alert: make it less sensitive
 
 ## [4.65.0] - 2025-06-10
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
@@ -26,7 +26,7 @@ spec:
             rate(prometheus_remote_storage_samples_total[5m])
           )
         ) * 100
-        > 1
+        > 10
       for: 1h
       labels:
         area: platform

--- a/test/tests/providers/global/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/monitoring-pipeline.rules.test.yml
@@ -101,15 +101,15 @@ tests:
   # Test MetricForwardingErrors
   - interval: 1m
     input_series:
-      # Test case where alert should not fire (error rate < 1%)
+      # Test case where alert should not fire (error rate < 10%)
       - series: 'prometheus_remote_storage_samples_failed_total{remote_name="test-remote", url="http://example.com"}'
-        values: '0+0x65 1+1x60' # Minimal failures for 2h+ period
+        values: '0+0x65 0+50x60' # Minimal failures for 2h+ period
       - series: 'prometheus_remote_storage_samples_total{remote_name="test-remote", url="http://example.com"}'
         values: '1000+1000x125' # Normal sample count
 
-      # Test case where alert should fire (error rate > 1%)
+      # Test case where alert should fire (error rate > 10%)
       - series: 'prometheus_remote_storage_samples_failed_total{remote_name="error-remote", url="http://error.com"}'
-        values: '0+0x5 50+50x120' # Significant failures over time
+        values: '0+0x5 0+120x120' # Significant failures over time
       - series: 'prometheus_remote_storage_samples_total{remote_name="error-remote", url="http://error.com"}'
         values: '1000+1000x125' # Normal sample count
 
@@ -139,7 +139,7 @@ tests:
               topic: observability
             exp_annotations:
               summary: Monitoring agent fails to send samples to remote storage.
-              description: Monitoring agent failed to send 4.8% of the samples to error-remote:http://error.com.
+              description: Monitoring agent failed to send 10.7% of the samples to error-remote:http://error.com.
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-pipeline/
               __dashboardUid__: promRW001
               dashboardQueryParams: "orgId=1"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33617

This PR reduces `MetricForwardingErrors` sensitivity, so we accept the `duplicate metrics` errors that happen when some pods are restarted.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
