### PR TITLE
improve LogForwardingErrors description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MimirToGrafanaCloudExporterDown`
   - `ManagementClusterDexAppMissing`
 
+### Changed
+
+- `LogForwardingErrors` description improvement
+
 ## [4.65.1] - 2025-06-16
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/logging-pipeline.rules.yml
@@ -15,7 +15,7 @@ spec:
           annotations:
             __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
             dashboardQueryParams: "orgId=2"
-            description: '{{`More that 10% of the requests to Loki are failing.`}}'
+            description: '{{`{{ $value | printf "%.2f" }}% of the requests to Loki are failing for pod {{ $labels.pod }} (threshold 10%)`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/logging-pipeline/
           expr: |-
             (
@@ -23,7 +23,7 @@ spec:
               *
                 (
                     (
-                      sum by (cluster_id, installation, provider, pipeline, namespace, job, instance) (
+                      sum by (cluster_id, installation, provider, pipeline, namespace, job, instance, pod) (
                         rate (
                           loki_write_request_duration_seconds_count{status_code!~"2.."}[5m:]
                         )
@@ -31,7 +31,7 @@ spec:
                     )
                   /
                     (
-                      sum by (cluster_id, installation, provider, pipeline, namespace, job, instance) (
+                      sum by (cluster_id, installation, provider, pipeline, namespace, job, instance, pod) (
                         rate (
                           loki_write_request_duration_seconds_count[5m:]
                         )

--- a/test/tests/providers/global/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/logging-pipeline.rules.test.yml
@@ -28,6 +28,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
+              pod: alloy-2j7z7
               provider: capa
               pipeline: testing
               severity: page
@@ -36,7 +37,7 @@ tests:
             exp_annotations:
               __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
               dashboardQueryParams: orgId=2
-              description: "More that 10% of the requests to Loki are failing."
+              description: "14.29% of the requests to Loki are failing for pod alloy-2j7z7 (threshold 10%)"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/logging-pipeline/
       - alertname: LogForwardingErrors
         eval_time: 330m
@@ -46,6 +47,7 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: gauss
               installation: gauss
+              pod: alloy-2j7z7
               provider: capa
               pipeline: testing
               severity: page
@@ -54,7 +56,7 @@ tests:
             exp_annotations:
               __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
               dashboardQueryParams: orgId=2
-              description: "More that 10% of the requests to Loki are failing."
+              description: "100.00% of the requests to Loki are failing for pod alloy-2j7z7 (threshold 10%)"
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/logging-pipeline/
   # Test LogReceivingErrors
   - interval: 1m


### PR DESCRIPTION
This PR improves `LogForwardingErrors` description.

Before:
> More that 10% of the requests to Loki are failing.

After:
> 100% of the requests to Loki are failing for pod alloy-2j7z7 (threshold 10%)

I think having this kind of information directly in the alert's message would help diagnose faster. 

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
