### PR TITLE
Add CiliumAgentPodPending alert for Cabbage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PrometheusMissingGrafanaCloud`
   - `MimirToGrafanaCloudExporterDown`
   - `ManagementClusterDexAppMissing`
+- Add CiliumAgentPodPending alert for Cabbage.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -76,3 +76,17 @@ spec:
         topic: cilium
         namespace: |-
           {{`{{ $labels.exported_namespace }}`}}
+    - alert: CiliumAgentPodPending
+      annotations:
+        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending in cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/pod-stuck-in-pending/
+      expr: kube_pod_status_phase{namespace="kube-system",pod=~"(cilium-.*)",phase="Pending"} == 1
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_cluster_has_no_workers: "true"
+        severity: page
+        team: cabbage
+        topic: cilium


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/31755

This PR adds CiliumAgentPodPending alert for Cabbage

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
