### PR TITLE
fluentbit alerts: only monitor GS-managed instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `FluentbitDropRatio` and `FluentbitTooManyErrors` only page for `kube-system` and `monitoring` instances (giantswarm-managed ones).
+
 ## [4.66.0] - 2025-06-24
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/fluentbit.rules.yml
@@ -18,7 +18,7 @@ spec:
         __dashboardUid__: fluentbit
         dashboardQueryParams: "orgId=2"
       # If we have some failures sending data, raise an alert
-      expr: rate(fluentbit_output_retries_failed_total[10m]) > 0
+      expr: rate(fluentbit_output_retries_failed_total{namespace=~"kube-system|monitoring"}[10m]) > 0
       for: 20m
       labels:
         area: platform
@@ -33,7 +33,14 @@ spec:
         __dashboardUid__: fluentbit
         dashboardQueryParams: "orgId=2"
       # Check the ratio of dropped records over the total number of records.
-      expr: rate(fluentbit_output_dropped_records_total[10m]) / (rate(fluentbit_output_proc_records_total[10m]) + rate(fluentbit_output_dropped_records_total[10m])) > 0.01
+      expr: |-
+        rate(
+          fluentbit_output_dropped_records_total{namespace=~"kube-system|monitoring"}[10m])
+          / (
+            rate(fluentbit_output_proc_records_total{namespace=~"kube-system|monitoring"}[10m])
+            + rate(fluentbit_output_dropped_records_total{namespace=~"kube-system|monitoring"}[10m])
+          )
+        > 0.01
       for: 20m
       labels:
         area: platform


### PR DESCRIPTION

Towards https://github.com/giantswarm/giantswarm/issues/33716
This PR updates fluentbit alerts (`FluentbitDropRatio` and `FluentbitTooManyErrors`) so that they only page for Giantswarm-managed instances.
It assumes that the instances we manage are deployed either in the `monitoring` namespace (usually on management clusters) or in the `kube-system` namespace (usually on workload clusters).

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
