### PR TITLE
remove DuplicatePrometheusOperatorKubeletService alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- DuplicatePrometheusOperatorKubeletService was for clusters before v20, which we don't have anymore.
+
 ## [4.68.0] - 2025-07-02
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/prometheus-operator.rules.yml
@@ -10,21 +10,6 @@ spec:
   groups:
   - name: prometheus-operator
     rules:
-    ## TODO(@giantswarm/team-atlas): Remove once all clusters are passed v20
-    - alert: DuplicatePrometheusOperatorKubeletService
-      annotations:
-        description: '{{`Prometheus-operator in cluster {{ $labels.cluster_id }} has duplicate kubelet service.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/prometheus-rule-failures/
-      expr: count(kube_service_info{namespace=~"monitoring|kube-system", service=~"kube-prometheus-stack-kubelet|prometheus-operator-app-kubelet"}) by (cluster_id, installation, provider, pipeline) > 1
-      for: 20m
-      labels:
-        area: platform
-        cancel_if_cluster_control_plane_unhealthy: "true"
-        cancel_if_cluster_has_no_workers: "true"
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: atlas
-        topic: observability
     - alert: PrometheusOperatorDown
       annotations:
         description: '{{`Prometheus-operator ({{ $labels.instance }}) is down.`}}'


### PR DESCRIPTION
I stumbled on this TODO, so I checked we don't have any such old versions running. They were vintage, so good to go.

### Checklist

- [X] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
