### PR TITLE
LokiObjectStorageLowRate: don't page when WCs are being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `PodsUnschedulable` alert
 
+### Changed
+
+- LokiObjectStorageLowRate: don't page when WCs are being created
+
 ## [4.69.0] - 2025-07-03
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -185,7 +185,7 @@ spec:
         # This part will fire the alert when the metric does not exist
         or (
             label_replace(
-              capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster"},
+              capi_cluster_status_condition{type="ControlPlaneReady", status="True", cluster_type="management_cluster", app="cluster-api-monitoring"},
               "cluster_id",
               "$1",
               "name",

--- a/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/loki.rules.test.yml
@@ -309,7 +309,7 @@ tests:
     input_series:
       - series: 'loki_rate_store_stream_rate_bytes_count{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="loki", pipeline="stable"}'
         values: "_x90 1+1x90 90+0x200"
-      - series: 'capi_cluster_status_condition{cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="loki", pipeline="stable", name="myinstall", type="ControlPlaneReady", status="True"}'
+      - series: 'capi_cluster_status_condition{app="cluster-api-monitoring", cluster_id="myinstall", cluster_type="management_cluster", installation="myinstall", namespace="loki", pipeline="stable", name="myinstall", type="ControlPlaneReady", status="True"}'
         values: "1+0x380"
     alert_rule_test:
       - alertname: LokiObjectStorageLowRate
@@ -319,6 +319,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
+              app: cluster-api-monitoring
               cancel_if_outside_working_hours: "true"
               cluster_id: myinstall
               cluster_type: management_cluster


### PR DESCRIPTION
This alert could fire for WCs during their creation.

This was because `capi_cluster_status_condition{cluster_type="management_cluster"}` returns multiple metrics:
- for all clusters with app=KSM
- only for MC when app=capi-monitoring, because the app properly sets `cluster_type`.

See:
![image](https://github.com/user-attachments/assets/58a4b3e5-2f3b-4b98-b8c9-db3c11cbc0a3)

So, we have to explicitely use the `cluster-api-monitoring` metrics to avoid false alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
