### PR TITLE
Rewrite flux alerting rules towards the gotk_resource_info metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- - Rewrite Flux alerting rules towards the `gotk_resource_info` emitted by the Kube State Metrics.
+- Rewrite Flux alerting rules towards the `gotk_resource_info` emitted by the Kube State Metrics.
 
 ## [4.71.0] - 2025-07-21
 

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cloud-provider-controller.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cloud-provider-controller.rules.yml
@@ -19,7 +19,7 @@ spec:
       {{- $components := "(aws-ebs-csi-driver|cloud-provider-aws|azure-cloud-controller-manager|azure-cloud-node-manager|azuredisk-csi-driver|azurefile-csi-driver|cloud-provider-vsphere|cloud-provider-cloud-director)" }}
       expr: |
         (
-          label_replace(gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~"(.+)-{{ $components }}"}, "cluster_id", "$1", "name", "(.+)-{{ $components }}")
+          label_replace(gotk_resource_info{ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~"(.+)-{{ $components }}"}, "cluster_id", "$1", "name", "(.+)-{{ $components }}")
           * on(cluster_id) group_left(provider)
           sum(
               label_replace(

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/vertical-pod-autoscaler.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/vertical-pod-autoscaler.rules.yml
@@ -33,7 +33,7 @@ spec:
       {{- $components := "(vertical-pod-autoscaler-crd)" }}
       expr: |
         (
-          label_replace(gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~"(.+)-{{ $components }}"}, "cluster_id", "$1", "name", "(.+)-{{ $components }}")
+          label_replace(gotk_resource_info{ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~"(.+)-{{ $components }}"}, "cluster_id", "$1", "name", "(.+)-{{ $components }}")
           * on(cluster_id) group_left(provider)
           sum(
               label_replace(

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/flux-atlas.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/flux-atlas.rules.yml
@@ -20,7 +20,7 @@ spec:
         description: |-
           {{`Flux Kustomization {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-kustomization/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="Kustomization", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*", name="silences"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind="Kustomization", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*", name="silences"} > 0
       for: 20m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -64,7 +64,7 @@ spec:
         description: |-
           {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}-{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-helmrelease/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~".*(cilium|network-policies)"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~".*(cilium|network-policies)"} > 0
       for: 1h10m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
@@ -28,7 +28,7 @@ spec:
         description: |-
           {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}-{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-helmrelease/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~".*coredns"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace!="flux-giantswarm", exported_namespace!~"org-t-.*", name=~".*coredns"} > 0
       for: 20m
       labels:
         area: platform

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/flux.rules.yml
@@ -32,7 +32,7 @@ spec:
         description: |-
           {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-helmrelease/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*"} > 0
       for: 10m
       labels:
         area: platform
@@ -72,7 +72,7 @@ spec:
         description: |-
           {{`Flux Kustomization {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-kustomization/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind="Kustomization", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*", name!="silences"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind="Kustomization", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*", name!="silences"} > 0
       for: 20m
       labels:
         area: platform
@@ -108,7 +108,7 @@ spec:
         description: |-
           {{`Flux {{ $labels.customresource_kind }} {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-source/
-      expr: gotk_resource_info{ready="False", job="giantswarm/cluster-api-monitoring", customresource_kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*"} > 0
+      expr: gotk_resource_info{ready="False", customresource_kind=~"GitRepository|HelmRepository|Bucket", cluster_type="management_cluster", exported_namespace=~".*giantswarm.*"} > 0
       for: 2h
       labels:
         area: platform
@@ -162,7 +162,7 @@ spec:
         description: |-
           {{`Flux {{ $labels.customresource_kind }} {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }} has been suspended for 24h.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-suspended-for-too-long/
-      expr: gotk_resource_info{job="giantswarm/cluster-api-monitoring", cluster_type="management_cluster", exported_namespace="flux-giantswarm", suspended="true"} > 0
+      expr: gotk_resource_info{cluster_type="management_cluster", exported_namespace="flux-giantswarm", suspended="true"} > 0
       for: 24h
       labels:
         area: platform


### PR DESCRIPTION
Upgrading flux broke the alerts depending on `gotk_reconcile_condition`. We have an alternative using kube-state-metrics.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
