### PR TITLE
Add muster workflow annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add muster workflow annotation to some alerts to test things.
+
 ## [4.72.0] - 2025-07-23
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
@@ -16,6 +16,7 @@ spec:
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/pod-stuck-in-pending/
+        muster_workflow: analyze-managementclusterpodpendingcapa
       expr: kube_pod_status_phase{namespace="giantswarm", provider="capa", pod=~"(aws.*|capa.*|irsa-operator.*)", phase="Pending", cluster_type="management_cluster"} == 1
       for: 15m
       labels:

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cloud-provider-controller.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cloud-provider-controller.rules.yml
@@ -16,6 +16,7 @@ spec:
         description: |-
           {{`Flux HelmRelease {{ $labels.name }} in ns {{ $labels.exported_namespace }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is stuck in Failed state.`}}
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/fluxcd-failing-helmrelease/
+        muster_workflow: analyze-fluxhelmreleasefailed
       {{- $components := "(aws-ebs-csi-driver|cloud-provider-aws|azure-cloud-controller-manager|azure-cloud-node-manager|azuredisk-csi-driver|azurefile-csi-driver|cloud-provider-vsphere|cloud-provider-cloud-director)" }}
       expr: |
         (

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
@@ -16,6 +16,7 @@ spec:
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has unschedulable kube-system pods.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/validate-cluster-health
+        muster_workflow: analyze-podsunschedulable
       expr: |-
         count(
           count_over_time(

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/pods.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/pods.rules.test.yml
@@ -41,3 +41,4 @@ tests:
             exp_annotations:
               description: 'Cluster wc01 has unschedulable kube-system pods.'
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/validate-cluster-health
+              muster_workflow: analyze-podsunschedulable


### PR DESCRIPTION
Add muster workflow annotations to some alerts so we can test things out for the haive sprint.

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
