### PR TITLE
fix and improve the observability-platform overview recording rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix observability-platform overview recording rules.
+
 ## [4.72.0] - 2025-07-23
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/observability.grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/observability.grafana-cloud.rules.yml
@@ -15,59 +15,93 @@ spec:
     - expr: |-
         sum(
           label_replace(
-            container_memory_working_set_bytes{namespace="loki", cluster_type="management_cluster"},
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            container_memory_working_set_bytes{
+              namespace="loki",
+              cluster_type="management_cluster",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:memory_usage
-      
+
     # CPU usage by SSD component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            rate(container_cpu_usage_seconds_total{namespace="loki", cluster_type="management_cluster"}[5m]),
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            rate(container_cpu_usage_seconds_total{
+              namespace="loki",
+              cluster_type="management_cluster",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            }[5m]),
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:cpu_usage
-      
+
     # === RESOURCE REQUESTS & LIMITS ===
     # Memory requests by SSD component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_requests{namespace="loki", cluster_type="management_cluster", resource="memory"},
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            kube_pod_container_resource_requests{
+              namespace="loki",
+              cluster_type="management_cluster",
+              resource="memory",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:memory_requests
       
     # Memory limits by SSD component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_limits{namespace="loki", cluster_type="management_cluster", resource="memory"},
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            kube_pod_container_resource_limits{
+              namespace="loki",
+              cluster_type="management_cluster",
+              resource="memory",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:memory_limits
-      
+
     # CPU requests by SSD component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_requests{namespace="loki", cluster_type="management_cluster", resource="cpu"},
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            kube_pod_container_resource_requests{
+              namespace="loki",
+              cluster_type="management_cluster",
+              resource="cpu",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:cpu_requests
-      
+
     # CPU limits by SSD component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_limits{namespace="loki", cluster_type="management_cluster", resource="cpu"},
-            "component", "$1", "pod", "loki-([^-]+)-.*"
+            kube_pod_container_resource_limits{
+              namespace="loki",
+              cluster_type="management_cluster",
+              resource="cpu",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(loki-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:loki:cpu_limits
@@ -82,62 +116,96 @@ spec:
     rules:
     # === BASIC RESOURCE USAGE ===
     # Memory usage by component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            container_memory_working_set_bytes{namespace="mimir", cluster_type="management_cluster"},
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            container_memory_working_set_bytes{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:memory_usage
-      
-    # CPU usage by component  
-    - expr: |-
+
+    # CPU usage by component
+    - expr: |
         sum(
           label_replace(
-            rate(container_cpu_usage_seconds_total{namespace="mimir", cluster_type="management_cluster"}[5m]),
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            rate(container_cpu_usage_seconds_total{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            }[5m]),
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:cpu_usage
-      
+
     # === RESOURCE REQUESTS & LIMITS ===
     # Memory requests by component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_requests{namespace="mimir", cluster_type="management_cluster", resource="memory"},
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            kube_pod_container_resource_requests{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              resource="memory",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:memory_requests
-      
+
     # Memory limits by component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_limits{namespace="mimir", cluster_type="management_cluster", resource="memory"},
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            kube_pod_container_resource_limits{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              resource="memory",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:memory_limits
-      
+
     # CPU requests by component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_requests{namespace="mimir", cluster_type="management_cluster", resource="cpu"},
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            kube_pod_container_resource_requests{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              resource="cpu",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:cpu_requests
       
     # CPU limits by component
-    - expr: |-
+    - expr: |
         sum(
           label_replace(
-            kube_pod_container_resource_limits{namespace="mimir", cluster_type="management_cluster", resource="cpu"},
-            "component", "$1", "pod", "mimir-([^-]+)-.*"
+            kube_pod_container_resource_limits{
+              namespace="mimir",
+              cluster_type="management_cluster",
+              resource="cpu",
+              container!="",        # Exclude unnamed containers
+              container!="POD"      # Exclude pause containers
+            },
+            "component", "$1", "pod", "(mimir-[^-]+)(?:-[0-9]+|-[a-z0-9]{8,}-[a-z0-9]{5,})"
           )
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, component)
       record: aggregation:mimir:cpu_limits


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR fixes the olly plat recording rules

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
