### PR TITLE
Fix provider label in cluster recording rules for hybrid installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix provider label in cluster recording rules for hybrid installations.
+
 ## [4.72.4] - 2025-07-31
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -36,7 +36,13 @@ spec:
     - expr: |-
         avg by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, exported_namespace) (
           label_replace(
-            capi_cluster_info,
+            label_replace(
+              capi_cluster_info,
+              "provider",
+              "vsphere",
+              "infrastructure_reference_kind",
+              "VSphereCluster"
+            )
             "cluster_id",
             "$1",
             "name",
@@ -45,9 +51,30 @@ spec:
         )
       record: aggregation:giantswarm:cluster_info
     - expr: |-
-        sum(cluster_service_cluster_info) by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region) / 2
-        or sum(cluster_operator_cluster_status{release_version!=""}) by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
-        or sum(capi_cluster_info) by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+        (
+          sum(
+            cluster_service_cluster_info
+          )
+          by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+        ) / 2
+        or (
+          sum(
+            cluster_operator_cluster_status{release_version!=""}
+          )
+          by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+        )
+        or (
+          sum(
+            label_replace(
+              capi_cluster_info,
+              "provider",
+              "vsphere",
+              "infrastructure_reference_kind",
+              "VSphereCluster"
+            )
+          )
+          by (release_version, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+        )
       record: aggregation:giantswarm:cluster_release_version
     - expr: avg_over_time(cluster_operator_cluster_create_transition[1w])
       record: aggregation:giantswarm:cluster_transition_create

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -42,7 +42,7 @@ spec:
               "vsphere",
               "infrastructure_reference_kind",
               "VSphereCluster"
-            )
+            ),
             "cluster_id",
             "$1",
             "name",


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/monitoring/slo-alerting/

---
This PR fixes the grafana cloud recording rules to support hybrid MCs towards https://gigantic.slack.com/archives/C01176DKNP4/p1753950438604789

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
