### PR TITLE
grafana-cloud rules: add job scraping failures stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `GrafanaPostgresqlRecoveryTestFailed` which relies on a metric that does not exist.
 
+### Added
+
+- Recording rule sending job scraping failures to Grafana Cloud
+
 ## [4.73.0] - 2025-08-25
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/monitoring-pipeline.rules.yml
@@ -42,6 +42,7 @@ spec:
         summary: Monitoring agent failed to scrape all targets in a job.
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/monitoring-job-scraping-failure/
       expr: |-
+        # This alert uses the same logic as the `aggregation:giantswarm:jobscrapingfailures` recording rule
         (
           count(up == 0) by (job, installation, cluster_id, provider, pipeline)
           /

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -574,3 +574,16 @@ spec:
             "(.*)"
           )
         record: aggregation:slo:time_period:days
+      - expr: |-
+          (
+            count(up{}== 0 )
+            by (job, installation, cluster_id, provider,
+              pipeline, cluster_type, metrics_path,
+              container, namespace, organization, team)
+            /
+            count(up{})
+            by (job, installation, cluster_id, provider,
+              pipeline, cluster_type, metrics_path,
+              container, namespace, organization, team)
+          ) >= 1
+        record: aggregation:giantswarm:jobscrapingfailures

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -575,6 +575,12 @@ spec:
           )
         record: aggregation:slo:time_period:days
       - expr: |-
+          # The purpose of this metrics is to spot when a servicemonitor is broken, and not when a pod behind the servicemonitor is broken.
+          #
+          # If it's just a pod that is broken, some of the targets will work.
+          # If the whole servicemonitor is broken (misconfigured), then it can't scrape any pods.
+          #
+          # This behaviour reduces the amount of generated metrics, and makes them easier to interpret
           (
             count(up{}== 0 )
             by (job, installation, cluster_id, provider,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26963

If we want a global dashboard showing failing scraping jobs, we should send data to grafana cloud.
So let's create a recording rule with this info.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
