### PR TITLE
Fix `ClusterControlPlaneMachineStatusNotHealthy`: take workload cluster name from `cluster_name` label because `cluster_id` may be globally overridden in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `ClusterControlPlaneMachineStatusNotHealthy`: take workload cluster name from `cluster_name` label because `cluster_id` may be globally overridden in metrics
+
 ## [4.73.1] - 2025-08-27
 
 ### Fixed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/capi-cluster.rules.yml
@@ -88,33 +88,37 @@ spec:
             # To understand all the comments below, please look at the test `input_series` data to
             # see what the metrics look like during a stuck cluster upgrade.
             sum by (cluster_id, installation, namespace, pipeline, provider) (
-              # The `capi_machine_info` metric may appear with different labels for the same `name`,
-              # e.g. `provider_id` filled or not, so we just combine those. Clamping to 1 is really
-              # only for visual purposes to see in a dashboard how many nodes are really affected.
-              clamp_max(
-                sum by (cluster_id, installation, name, namespace, provider) (
-                  # Filter by `control_plane_name` to only alert on control plane `Machine` objects.
-                  #
-                  # The `capi_machine_info` metric goes away with the `Machine`, so it's important
-                  # to extend the metric for a few minutes here in order to match it against the
-                  # failed-status which we also extend below.
-                  max_over_time(capi_machine_info{control_plane_name!=""}[20m]
-                )
-              ), 1)
+              label_replace(
+                # The `capi_machine_info` metric may appear with different labels for the same `name`,
+                # e.g. `provider_id` filled or not, so we just combine those. Clamping to 1 is really
+                # only for visual purposes to see in a dashboard how many nodes are really affected.
+                clamp_max(
+                  sum by (cluster_name, installation, name, namespace, provider) (
+                    # Filter by `control_plane_name` to only alert on control plane `Machine` objects.
+                    #
+                    # The `capi_machine_info` metric goes away with the `Machine`, so it's important
+                    # to extend the metric for a few minutes here in order to match it against the
+                    # failed-status which we also extend below.
+                    max_over_time(capi_machine_info{control_plane_name!=""}[20m]
+                  )
+                ), 1)
 
-              # Match/filter by machine name
-              * on(name, namespace, cluster_id) group_right
+                # Match/filter by machine name
+                * on(name, namespace, cluster_name) group_right
 
-              # In real cases of `type="HealthCheckSucceeded",status="False",reason="NodeStartupTimeout"`
-              # (mind that the label `reason` doesn't exist at time of writing in `cluster-api-monitoring`,
-              # so it can't be used to filter for that specific condition unless we add it), the
-              # metric for the unhealthy condition only appears for a short time and then the
-              # machine gets destroyed to try creating a new control plane machine. Therefore,
-              # extend the metric to the right on the timeline so we can use a longer `for:` to
-              # alert only if CP machines failed to come up for a long time (= stuck/failed upgrade)
-              # and not just a few minutes (= one-time failure, upgrade may still succeed).
-              max_over_time(
-                capi_machine_status_condition{type="HealthCheckSucceeded",status!="True"}[15m]
+                # In real cases of `type="HealthCheckSucceeded",status="False",reason="NodeStartupTimeout"`
+                # (mind that the label `reason` doesn't exist at time of writing in `cluster-api-monitoring`,
+                # so it can't be used to filter for that specific condition unless we add it), the
+                # metric for the unhealthy condition only appears for a short time and then the
+                # machine gets destroyed to try creating a new control plane machine. Therefore,
+                # extend the metric to the right on the timeline so we can use a longer `for:` to
+                # alert only if CP machines failed to come up for a long time (= stuck/failed upgrade)
+                # and not just a few minutes (= one-time failure, upgrade may still succeed).
+                max_over_time(
+                  capi_machine_status_condition{type="HealthCheckSucceeded",status!="True"}[15m]
+                ),
+                "cluster_id", "$1",
+                "cluster_name", "(.*)"
               )
             )
             > 0

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/capi-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/capi-cluster.rules.test.yml
@@ -79,54 +79,54 @@ tests:
   - interval: 1m
     input_series:
       # Taken from a real upgrade failure, unnecessary labels removed
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-6d9q7", namespace="giantswarm", provider_id="aws:///eu-central-1c/i-0643d384aa5d42d57"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-6d9q7", namespace="giantswarm", provider_id="aws:///eu-central-1c/i-0643d384aa5d42d57"}
         values: "_x26 1x10 _x60"
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-7npqj", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-0325c255e1a65cd07"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-7npqj", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-0325c255e1a65cd07"}
         values: "_x47 1x10 _x60"
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-9rhg7", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-02636d5d4c6eca6e4"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-9rhg7", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-02636d5d4c6eca6e4"}
         values: "_x16 1x8 _x60"
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-hw757", namespace="giantswarm", provider_id="aws:///eu-central-1a/i-081d154aba0f21660"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-hw757", namespace="giantswarm", provider_id="aws:///eu-central-1a/i-081d154aba0f21660"}
         values: "1x60"
 
       # This `name` appeared twice with different labels (e.g. with/without `provider_id`).
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-dhd55", namespace="giantswarm", provider_id="aws:///eu-central-1a/i-028756797a3e68e09"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-dhd55", namespace="giantswarm", provider_id="aws:///eu-central-1a/i-028756797a3e68e09"}
         values: "_x36 1x7 _x60"
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-dhd55", namespace="giantswarm"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-dhd55", namespace="giantswarm"}
         values: "_x34 1x1 _x60"
 
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-q49zf", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-0a026aff280d4cb18"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-q49zf", namespace="giantswarm", provider_id="aws:///eu-central-1b/i-0a026aff280d4cb18"}
         values: "1x60"
-      - series: capi_machine_info{cluster_id="oopsie", control_plane_name="oopsie", name="oopsie-sf9zr", namespace="giantswarm", provider_id="aws:///eu-central-1c/i-025ad92e96fa3a2c9"}
+      - series: capi_machine_info{cluster_name="oopsie", control_plane_name="oopsie", name="oopsie-sf9zr", namespace="giantswarm", provider_id="aws:///eu-central-1c/i-025ad92e96fa3a2c9"}
         values: "1x60"
 
 
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-6d9q7", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-6d9q7", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "_x33 1x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-6d9q7", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-6d9q7", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "_x33 0x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-7npqj", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-7npqj", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "_x55 1x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-7npqj", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-7npqj", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "_x55 1x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-9rhg7", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-9rhg7", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "_x24 1x1 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-9rhg7", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-9rhg7", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "_x24 0x1 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-dhd55", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-dhd55", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "_x44 1x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-dhd55", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-dhd55", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "_x44 0x3 _x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-hw757", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-hw757", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "0x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-hw757", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-hw757", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "0x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-q49zf", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-q49zf", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "0x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-q49zf", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-q49zf", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "0x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-sf9zr", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-sf9zr", namespace="giantswarm", status="False", type="HealthCheckSucceeded"}
         values: "0x60"
-      - series: capi_machine_status_condition{cluster_id="oopsie", name="oopsie-sf9zr", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
+      - series: capi_machine_status_condition{cluster_name="oopsie", name="oopsie-sf9zr", namespace="giantswarm", status="Unknown", type="HealthCheckSucceeded"}
         values: "0x60"
     alert_rule_test:
       - alertname: ClusterControlPlaneMachineStatusNotHealthy


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/34025 (see https://github.com/giantswarm/giantswarm/issues/34112 why `cluster_id` can't be used here)

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
