### PR TITLE
aggregation:docker:containers_from_deprecated_registries:*: change labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change labels provided for `aggregation:docker:containers_from_deprecated_registries:*` recording rules, adding `namespace`, `pod` and `image` labels, removing `region` and `pipeline` labels.
+- Change labels provided for `aggregation:docker:containers_from_deprecated_registries:*` recording rules, adding `namespace`, `pod` and `image` labels, removing `region` label.
 
 ## [4.73.1] - 2025-08-27
 

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -91,13 +91,13 @@ spec:
       record: aggregation:docker:containers_using_dockerhub_image
     - expr: sum(kube_pod_container_info{image_spec=~"docker\\.io/.*"} or kube_pod_init_container_info{image_spec=~"docker\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) / sum(kube_pod_container_info{} or kube_pod_init_container_info{}) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
       record: aggregation:docker:containers_using_dockerhub_image_relative
-    - expr: sum(kube_pod_container_info{image=~"quay\\.io/giantswarm/.*"} OR kube_pod_init_container_info{image=~"quay\\.io/giantswarm/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image)
+    - expr: sum(kube_pod_container_info{image=~"quay\\.io/giantswarm/.*"} OR kube_pod_init_container_info{image=~"quay\\.io/giantswarm/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image, pipeline)
       record: aggregation:docker:containers_from_deprecated_registries:quay
-    - expr: sum(kube_pod_container_info{image=~"docker\\.io/giantswarm/.*"} OR kube_pod_init_container_info{image=~"docker\\.io/giantswarm/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image)
+    - expr: sum(kube_pod_container_info{image=~"docker\\.io/giantswarm/.*"} OR kube_pod_init_container_info{image=~"docker\\.io/giantswarm/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image, pipeline)
       record: aggregation:docker:containers_from_deprecated_registries:dockerhub
-    - expr: sum(kube_pod_container_info{image=~"giantswarm\\.azurecr\\.io/.*"} OR kube_pod_init_container_info{image=~"giantswarm\\.azurecr\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image)
+    - expr: sum(kube_pod_container_info{image=~"giantswarm\\.azurecr\\.io/.*"} OR kube_pod_init_container_info{image=~"giantswarm\\.azurecr\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image, pipeline)
       record: aggregation:docker:containers_from_deprecated_registries:giantswarmacr
-    - expr: sum(kube_pod_container_info{image=~"giantswarmpublic\\.azurecr\\.io/.*"} OR kube_pod_init_container_info{image=~"giantswarmpublic\\.azurecr\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image)
+    - expr: sum(kube_pod_container_info{image=~"giantswarmpublic\\.azurecr\\.io/.*"} OR kube_pod_init_container_info{image=~"giantswarmpublic\\.azurecr\\.io/.*"}) by (cluster_id, cluster_type, customer, installation, provider, namespace, pod, image, pipeline)
       record: aggregation:docker:containers_from_deprecated_registries:giantswarmpublicacr
   - name: certificates.grafana-cloud.recording
     rules:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3935

This PR adds more needed detail to aggregation rules `aggregation:docker:containers_from_deprecated_registries:*`, and at the same time removes one that isn't needed.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
