### PR TITLE
Add quicker alerts for Kyverno's `svc-fail` validation/mutation webhooks taking very long or timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add quicker alerts for Kyverno's `svc-fail` validation/mutation webhooks taking very long or timing out
+
 ## [4.73.2] - 2025-08-29
 
 ### Fixed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
@@ -46,5 +46,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: shield
+        team: tenet
         topic: managementcluster

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.management-cluster.rules.yml
@@ -34,3 +34,17 @@ spec:
         severity: page
         team: tenet
         topic: managementcluster
+
+    # Kyverno webhooks that may block critical objects
+    - alert: ManagementClusterWebhookDurationExceedsTimeoutKyvernoCritical
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} takes very long or is timing out.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{cluster_type="management_cluster", name=~".*(kyverno.*fail).*"}[15m])) by (cluster_id, installation, pipeline, provider, name, job, le)) > 10
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: shield
+        topic: managementcluster

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -53,7 +53,7 @@ spec:
         team: se
         topic: kubernetes
 
-      # Webhooks owned by Honeybadger
+    # Webhooks owned by Honeybadger
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutHoneybadger
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
@@ -67,7 +67,7 @@ spec:
         team: honeybadger
         topic: kubernetes
 
-      # Webhooks owned by Cabbage
+    # Webhooks owned by Cabbage
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutCabbage
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
@@ -81,7 +81,7 @@ spec:
         team: cabbage
         topic: kubernetes
 
-      # Webhooks owned by Phoenix
+    # Webhooks owned by Phoenix
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutPhoenix
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
@@ -95,7 +95,7 @@ spec:
         team: phoenix
         topic: kubernetes
 
-      # Webhooks owned by Atlas
+    # Webhooks owned by Atlas
     - alert: WorkloadClusterWebhookDurationExceedsTimeoutAtlas
       annotations:
         description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} is timing out.`}}'
@@ -107,4 +107,18 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: atlas
+        topic: kubernetes
+
+    # Kyverno webhooks that may block critical objects
+    - alert: WorkloadClusterWebhookDurationExceedsTimeoutKyvernoCritical
+      annotations:
+        description: '{{`Kubernetes API Server admission webhook {{ $labels.name }} takes very long or is timing out.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/apiserver-admission-webhook-errors/
+      expr: histogram_quantile(0.95, sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{cluster_type="workload_cluster", name=~".*(kyverno.*fail).*"}[15m])) by (cluster_id, installation, pipeline, provider, name, job, le)) > 10
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: shield
         topic: kubernetes

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/apiserver.workload-cluster.rules.yml
@@ -120,5 +120,5 @@ spec:
         area: kaas
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
-        team: shield
+        team: tenet
         topic: kubernetes


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33863

I came up with this query based on the 2025-07-08 problems of blocking a CAPA cluster's control plane rollout. This alert should fire quickly, during working hours, if webhook durations are very high or even timing out. Long requests can be problematic because the original call, e.g. `CREATE` of a critical object such as `Node`, may time out as well, and if that happens in a program like kubeadm, there's sometimes no retry.

Not sure about the `team` target for this specific alert since there can be various causes for Kyverno problems.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
