### PR TITLE
Add MimirDistributorReachingInflightPushRequestLimit alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New alert `MimirDistributorReachingInflightPushRequestLimit` to monitor when Mimir distributors are approaching their inflight push request limit (80% threshold).
+
 ## [4.73.2] - 2025-08-29
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/mimir.rules.yml
@@ -177,6 +177,24 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    # This alert monitors when Mimir distributors are approaching their inflight push request limit.
+    # When distributors reach 80% of their maximum inflight push requests, it may indicate
+    # they are becoming overwhelmed and could start rejecting incoming requests.
+    - alert: MimirDistributorReachingInflightPushRequestLimit
+      annotations:
+        description: 'Mimir distributors are approaching their inflight push request limit and may start rejecting requests.'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir
+      expr: |
+        sum(max_over_time(cortex_distributor_inflight_push_requests{pod=~"mimir-distributor.*"}[5m])) by (cluster_id, installation, namespace, pipeline, provider)
+        >= 
+        sum(cortex_distributor_instance_limits{limit="max_inflight_push_requests", pod=~"mimir-distributor.*"}) by (cluster_id, installation, namespace, pipeline, provider) * 0.8
+      for: 1h
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability
   - name: mimir.compactor
     rules:
     - alert: MimirCompactorFailedCompaction

--- a/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/mimir.rules.test.yml
@@ -671,3 +671,41 @@ tests:
               dashboardQueryParams: "orgId=2"
               description: "Mimir Alertmanager mimir-alertmanager-aaaaaaaaaa-bbbbb is failing to replicating partial state to its replicas."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerreplicationfailing
+
+  # Test for MimirDistributorReachingInflightPushRequestLimit alert
+  - interval: 1m
+    input_series:
+      # mimir-distributor current inflight push requests: start low, then increase to 80 (80% of 100 limit) for over 1h, then back to normal
+      - series: 'cortex_distributor_inflight_push_requests{pod="mimir-distributor-0", cluster_id="golem", installation="golem", namespace="mimir", pipeline="testing", provider="$provider"}'
+        values: "10+0x60 80+0x80 50+0x60"
+      - series: 'cortex_distributor_inflight_push_requests{pod="mimir-distributor-1", cluster_id="golem", installation="golem", namespace="mimir", pipeline="testing", provider="$provider"}'
+        values: "15+0x60 80+0x80 55+0x60"
+      # mimir-distributor max inflight push requests limit: 100 for both pods
+      - series: 'cortex_distributor_instance_limits{limit="max_inflight_push_requests", pod="mimir-distributor-0", cluster_id="golem", installation="golem", namespace="mimir", pipeline="testing", provider="$provider"}'
+        values: "100+0x200"
+      - series: 'cortex_distributor_instance_limits{limit="max_inflight_push_requests", pod="mimir-distributor-1", cluster_id="golem", installation="golem", namespace="mimir", pipeline="testing", provider="$provider"}'
+        values: "100+0x200"
+    alert_rule_test:
+      - alertname: MimirDistributorReachingInflightPushRequestLimit
+        eval_time: 30m  # Low usage, should not fire
+      - alertname: MimirDistributorReachingInflightPushRequestLimit
+        eval_time: 90m  # At 80% threshold but not for 1h yet, should not fire
+      - alertname: MimirDistributorReachingInflightPushRequestLimit
+        eval_time: 121m  # At 80% threshold for over 1h, should fire
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: golem
+              installation: golem
+              namespace: mimir
+              pipeline: testing
+              provider: $provider
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "Mimir distributors are approaching their inflight push request limit and may start rejecting requests."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/mimir
+      - alertname: MimirDistributorReachingInflightPushRequestLimit
+        eval_time: 180m  # Back to normal levels, should not fire


### PR DESCRIPTION
---
Towards: https://github.com/giantswarm/giantswarm/issues/33272

This PR:

- Added new alert to monitor when Mimir distributors are approaching their inflight push request limit
- Alert fires when distributors reach 80% of their maximum inflight push requests
- Includes comprehensive tests covering different scenarios
- Alert grouped by cluster_id, installation, namespace, pipeline, provider
- 1-hour duration to avoid false positives

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
