### PR TITLE
New alert `IRSAClaimNotReady` to monitor Crossplane IRSA objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New alert `IRSAClaimNotReady` to monitor Crossplane IRSA objects.
+
 ## [4.74.1] - 2025-09-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/irsa.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/irsa.rules.yml
@@ -36,3 +36,18 @@ spec:
         severity: page
         team: phoenix
         topic: aws
+  - name: irsa-crossplane
+    rules:
+    - alert: IRSAClaimNotReady
+      annotations:
+        description: '{{`IRSAClaim {{ $labels.name }} in Cluster {{ $labels.installation }} is not ready.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/irsaclaim-not-ready/
+      expr: irsaclaim_status_conditions{type="Ready", status="False"} > 0
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: phoenix
+        topic: aws


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33870

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
