### PR TITLE
Add tempo alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New alert `IRSAClaimNotReady` to monitor Crossplane IRSA objects.
 - Add quicker alerts for Kyverno's `svc-fail` validation/mutation webhooks taking very long or timing out
+- Tempo alerts
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ To update `loki-mixins` recording rules:
 * Run `./loki/update.sh`
 * make sure to update [grafana dashboards](https://github.com/giantswarm/dashboards)
 
+#### tempo-mixins
+
+To update `tempo-mixins` alerting rules:
+
+* Run `./tempo/update.sh`
+
 ## Testing
 
 You can run all tests by running `make test`.

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tempo-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tempo-mixins.rules.yml
@@ -1,0 +1,369 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: tempo-mixins.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+    - name: tempo_alerts
+      rules:
+        - alert: TempoCompactorUnhealthy
+          annotations:
+            message: '{{`There are {{ printf "%f" $value }} unhealthy compactor(s).`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactorUnhealthy
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace) (tempo_ring_members{cluster_type="management_cluster", state="Unhealthy", name="compactor", namespace=~".*"}) > 0
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoDistributorUnhealthy
+          annotations:
+            message: '{{`There are {{ printf "%f" $value }} unhealthy distributor(s).`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoDistributorUnhealthy
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace) (tempo_ring_members{cluster_type="management_cluster", state="Unhealthy", name="distributor", namespace=~".*"}) > 0
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoIngesterUnhealthy
+          annotations:
+            message: '{{`There are {{ printf "%f" $value }} unhealthy ingester(s).`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterUnhealthy
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace) (tempo_ring_members{cluster_type="management_cluster", state="Unhealthy", name="ingester", namespace=~".*"}) > 0
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoMetricsGeneratorUnhealthy
+          annotations:
+            message: '{{`There are {{ printf "%f" $value }} unhealthy metric-generator(s).`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoMetricsGeneratorUnhealthy
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace) (tempo_ring_members{cluster_type="management_cluster", state="Unhealthy", name="metrics-generator", namespace=~".*"}) > 0
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoCompactionsFailing
+          annotations:
+            message: '{{`Greater than 2 compactions have failed in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactionsFailing
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_compaction_errors_total{cluster_type="management_cluster"}[1h])) > 2 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_compaction_errors_total{cluster_type="management_cluster"}[5m])) > 0
+          for: 1h
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoIngesterFlushesUnhealthy
+          annotations:
+            message: '{{`Greater than 2 flush retries have occurred in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterFlushesFailing
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_ingester_failed_flushes_total{cluster_type="management_cluster"}[1h])) > 2 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_ingester_failed_flushes_total{cluster_type="management_cluster"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoIngesterFlushesFailing
+          annotations:
+            message: '{{`Greater than 2 flush retries have failed in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterFlushesFailing
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_ingester_flush_failed_retries_total{cluster_type="management_cluster"}[1h])) > 2 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_ingester_flush_failed_retries_total{cluster_type="management_cluster"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoPollsFailing
+          annotations:
+            message: '{{`Greater than 2 polls have failed in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPollsFailing
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_blocklist_poll_errors_total{cluster_type="management_cluster"}[1h])) > 2 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_blocklist_poll_errors_total{cluster_type="management_cluster"}[5m])) > 0
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoTenantIndexFailures
+          annotations:
+            message: '{{`Greater than 2 tenant index failures in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoTenantIndexFailures
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_blocklist_tenant_index_errors_total{cluster_type="management_cluster"}[1h])) > 2 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempodb_blocklist_tenant_index_errors_total{cluster_type="management_cluster"}[5m])) > 0
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoNoTenantIndexBuilders
+          annotations:
+            message: '{{`No tenant index builders for tenant {{ $labels.tenant }}. Tenant index will quickly become stale.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoNoTenantIndexBuilders
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace, tenant) (tempodb_blocklist_tenant_index_builder{cluster_type="management_cluster"}) == 0 and
+            max by (cluster_id, installation, pipeline, provider, namespace) (tempodb_blocklist_length{cluster_type="management_cluster"}) > 0
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoTenantIndexTooOld
+          annotations:
+            message: '{{`Tenant index age is 600 seconds old for tenant {{ $labels.tenant }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoTenantIndexTooOld
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, tenant) (tempodb_blocklist_tenant_index_age_seconds{cluster_type="management_cluster"}) > 600
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBlockListRisingQuickly
+          annotations:
+            message: '{{`Tempo block list length is up 40 percent over the last 7 days.  Consider scaling compactors.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBlockListRisingQuickly
+          expr: |
+            avg(tempodb_blocklist_length{cluster_type="management_cluster", namespace=~".*", container="compactor"}) / avg(tempodb_blocklist_length{namespace=~".*", container="compactor"} offset 7d) by (cluster_id, installation, pipeline, provider, namespace) > 1.4
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBadOverrides
+          annotations:
+            message: '{{` {{ $labels.job }} failed to reload overrides. `}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBadOverrides
+          expr: |
+            sum(tempo_runtime_config_last_reload_successful{cluster_type="management_cluster", namespace=~".*"} == 0) by (cluster_id, installation, pipeline, provider, namespace, job)
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoUserConfigurableOverridesReloadFailing
+          annotations:
+            message: '{{`Greater than 5 user-configurable overides reloads failed in the past hour.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoTenantIndexFailures
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{cluster_type="management_cluster"}[1h])) > 5 and
+            sum by (cluster_id, installation, pipeline, provider, namespace) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{cluster_type="management_cluster"}[5m])) > 0
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoProvisioningTooManyWrites
+          annotations:
+            message: '{{`Ingesters in {{ $labels.cluster_id }}/{{ $labels.namespace }} are receiving more data/second than desired, add more ingesters.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoProvisioningTooManyWrites
+          expr: |
+            avg by (cluster_id, installation, pipeline, provider, namespace) (rate(tempo_ingester_bytes_received_total{cluster_type="management_cluster", job=~".+/ingester"}[5m])) / 1024 / 1024 > 30
+          for: 15m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoCompactorsTooManyOutstandingBlocks
+          annotations:
+            message: '{{`There are too many outstanding compaction blocks in {{ $labels.cluster_id }}/{{ $labels.namespace }} for tenant {{ $labels.tenant }}, increase compactor s CPU or add more compactors.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactorsTooManyOutstandingBlocks
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace, tenant) (tempodb_compaction_outstanding_blocks{cluster_type="management_cluster", container="compactor", namespace=~".*"}) / ignoring(tenant) group_left count(tempo_build_info{container="compactor", namespace=~".*"}) by (cluster_id, installation, pipeline, provider, namespace) > 100
+          for: 6h
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoCompactorsTooManyOutstandingBlocks
+          annotations:
+            message: '{{`There are too many outstanding compaction blocks in {{ $labels.cluster_id }}/{{ $labels.namespace }} for tenant {{ $labels.tenant }}, increase compactor s CPU or add more compactors.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoCompactorsTooManyOutstandingBlocks
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace, tenant) (tempodb_compaction_outstanding_blocks{cluster_type="management_cluster", container="compactor", namespace=~".*"}) / ignoring(tenant) group_left count(tempo_build_info{container="compactor", namespace=~".*"}) by (cluster_id, installation, pipeline, provider, namespace) > 250
+          for: 24h
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoIngesterReplayErrors
+          annotations:
+            message: '{{`Tempo ingester has encountered errors while replaying a block on startup in {{ $labels.cluster_id }}/{{ $labels.namespace }} for tenant {{ $labels.tenant }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoIngesterReplayErrors
+          expr: |
+            sum by (cluster_id, installation, pipeline, provider, namespace, tenant) (increase(tempo_ingester_replay_errors_total{cluster_type="management_cluster", namespace=~".*"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoMetricsGeneratorPartitionLagCritical
+          annotations:
+            message: '{{`Tempo partition {{ $labels.partition }} in consumer group {{ $labels.group }} is lagging by more than 900 seconds in {{ $labels.cluster_id }}/{{ $labels.namespace }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, partition) (tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", namespace=~".*", container="metrics-generator"}) > 900
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBlockBuilderPartitionLagWarning
+          annotations:
+            message: '{{`Tempo ingest partition {{ $labels.partition }} for blockbuilder {{ $labels.pod }} is lagging by more than 300 seconds in {{ $labels.cluster_id }}/{{ $labels.namespace }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", namespace=~".*", container="block-builder"}[6m])) > 200
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBlockBuilderPartitionLagCritical
+          annotations:
+            message: '{{`Tempo ingest partition {{ $labels.partition }} for blockbuilder {{ $labels.pod }} is lagging by more than 300 seconds in {{ $labels.cluster_id }}/{{ $labels.namespace }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", namespace=~".*", container=~"block-builder"}[6m])) > 300
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBackendSchedulerJobsFailureRateHigh
+          annotations:
+            message: '{{`Tempo backend scheduler job failure rate is {{ printf "%0.2f" $value }} (threshold 0.1) in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBackendSchedulerJobsFailureRateHigh
+          expr: |
+            sum(increase(tempo_backend_scheduler_jobs_failed_total{cluster_type="management_cluster", namespace=~".*"}[5m])) by (cluster_id, installation, pipeline, provider, namespace)
+            /
+            sum(increase(tempo_backend_scheduler_jobs_created_total{cluster_type="management_cluster", namespace=~".*"}[5m])) by (cluster_id, installation, pipeline, provider, namespace)
+            > 0.05
+          for: 10m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBackendSchedulerRetryRateHigh
+          annotations:
+            message: '{{`Tempo backend scheduler retry rate is high ({{ printf "%0.2f" $value }} retries/minute) in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBackendSchedulerRetryRateHigh
+          expr: |
+            sum(increase(tempo_backend_scheduler_jobs_retry_total{cluster_type="management_cluster", namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace) > 20
+          for: 10m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBackendSchedulerCompactionEmptyJobRateHigh
+          annotations:
+            message: '{{`Tempo backend scheduler empty job rate is high ({{ printf "%0.2f" $value }} jobs/minute) in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBackendSchedulerCompactionEmptyJobRateHigh
+          expr: |
+            sum(increase(tempo_backend_scheduler_compaction_tenant_empty_job_total{cluster_type="management_cluster", namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace) > 10
+          for: 10m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBackendWorkerBadJobsRateHigh
+          annotations:
+            message: '{{`Tempo backend worker bad jobs rate is high ({{ printf "%0.2f" $value }} bad jobs/minute) in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBackendWorkerBadJobsRateHigh
+          expr: |
+            sum(increase(tempo_backend_worker_bad_jobs_received_total{cluster_type="management_cluster", namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace) > 0
+          for: 10m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoBackendWorkerCallRetriesHigh
+          annotations:
+            message: '{{`Tempo backend worker call retries rate is high ({{ printf "%0.2f" $value }} retries/minute) in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoBackendWorkerCallRetriesHigh
+          expr: |
+            sum(increase(tempo_backend_worker_call_retries_total{cluster_type="management_cluster", namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace) > 5
+          for: 10m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoVultureHighErrorRate
+          annotations:
+            message: '{{`Tempo vulture error rate is {{ printf "%0.2f" $value }} for error type {{ $labels.error }} in {{ $labels.cluster_id }}/{{ $labels.namespace }}`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoVultureHighErrorRate
+          expr: |
+            sum(rate(tempo_vulture_trace_error_total{cluster_type="management_cluster", namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace, error) / ignoring (error) group_left sum(rate(tempo_vulture_trace_total{namespace=~".*"}[1m])) by (cluster_id, installation, pipeline, provider, namespace) > 0.100000
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"

--- a/tempo/update.sh
+++ b/tempo/update.sh
@@ -1,0 +1,48 @@
+# This script is used to update the Tempo alerts from mixins from the upstream repository.
+#
+# Usage:
+#  ./tempo/update.sh from the root of the repository
+
+set -eau o pipefail
+
+BRANCHREF="heads/main"
+MIXIN_URL="https://raw.githubusercontent.com/grafana/tempo/refs/$BRANCHREF/operations/tempo-mixin-compiled/alerts.yaml"
+OUTPUT_FILE="$(pwd)/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tempo-mixins.rules.yml"
+
+# Retrieve rules and cleanup yaml formatting
+curl -so- "$MIXIN_URL" \
+    | yq -P -M > "$OUTPUT_FILE"
+
+# Add alert labels
+yq -i e '.groups[].rules[].labels += {"area": "platform", "team": "atlas", "topic": "observability", "cancel_if_outside_working_hours": "true", "severity": "page"}' "$OUTPUT_FILE"
+
+# Remove the initial `groups:` line
+sed -i '1d' "$OUTPUT_FILE"
+
+# Add indentation to each line
+sed -i 's/^/  /g' "$OUTPUT_FILE"
+
+# Add the PrometheusRule metadata header
+sed -i '1i\
+apiVersion: monitoring.coreos.com/v1\
+kind: PrometheusRule\
+metadata:\
+  labels:\
+    {{- include "labels.common" . | nindent 4 }}\
+  name: tempo-mixins.rules\
+  namespace: {{ .Values.namespace  }}\
+spec:\
+  groups:' "$OUTPUT_FILE"
+
+# Our cluster labels are named `cluster_id`
+sed -i 's/cluster/cluster_id/g' "$OUTPUT_FILE"
+# Add mandatory labels
+sed -i 's/cluster_id,/cluster_id, installation, pipeline, provider,/g' "$OUTPUT_FILE"
+# Only apply this alert to management clusters - this one is where there's already a selector
+sed -i 's/{\([a-z].*\)}/{cluster_type="management_cluster", \1}/g' "$OUTPUT_FILE"
+# Only apply this alert to management clusters - this one is where there is no selector
+sed -i 's/{}/{cluster_type="management_cluster"}/g' "$OUTPUT_FILE"
+# Fix single quotes in alert messages
+sed -i 's/'\''/ /g' "$OUTPUT_FILE"
+# Wrap alert messages in double curly braces to avoid Helm template parsing issues
+sed -i 's/\(message: \)\(.*\)/\1'\''{{`\2`}}'\''/g' "$OUTPUT_FILE"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34250

This PR adds tempo alerts from mixins, via a script that updates the upstream mixins to comply with our requirements.

Remarks:
- all alerts are currently set as paging only during business hours. We can select / update them later if we see they're generating too much noise.
- CI tests are not provided upstream, and:
  - there's a lot of alerts
  - they're not managed by us
  ...so I'm not sure we need to create them.
- dashboards were not added to the alerts

Maybe in the future the import script will need to loop over all alerts to:
- determine their criticity
- set the proper dashboard

but I don't think we need to do it right now.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
