### PR TITLE
Setup signal for olly op

### DIFF
--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/job.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/job.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: ManagementClusterJobFailed
       annotations:
         description: '{{`Job {{ $labels.namespace }}/{{ $labels.job_name }} is failed.`}}'
-      expr: kube_job_failed{cluster_type="management_cluster", condition="true", job_name!~"silence-operator-sync.+|grafana-permission.+"} == 1
+      expr: kube_job_failed{cluster_type="management_cluster", condition="true"} == 1
       for: 15m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -593,3 +593,7 @@ spec:
               container, namespace, organization, team)
           ) >= 1
         record: aggregation:giantswarm:jobscrapingfailures
+
+      # Observability platform product signals
+      - expr: count(giantswarm:observability:grafana:unique_users:30d) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+        record: aggregation:giantswarm:observability:signals:user_logins

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -595,5 +595,5 @@ spec:
         record: aggregation:giantswarm:jobscrapingfailures
 
       # Observability platform product signals
-      - expr: count(giantswarm:observability:grafana:unique_users:30d) by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+      - expr: count_over_time(giantswarm:observability:grafana:unique_users:hourly[30d])
         record: aggregation:giantswarm:observability:signals:user_logins

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/grafana-cloud.rules.yml
@@ -595,5 +595,5 @@ spec:
         record: aggregation:giantswarm:jobscrapingfailures
 
       # Observability platform product signals
-      - expr: count(giantswarm:observability:grafana:unique_users:30d) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+      - expr: count(giantswarm:observability:grafana:unique_users:30d) by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
         record: aggregation:giantswarm:observability:signals:user_logins

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/signals.observability-platform.logs.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/signals.observability-platform.logs.yml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4}}
+  name: signals.observability-platform.logs.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+    - name: signals.observability-platform.logs
+      rules:
+        - record: giantswarm:observability:grafana:unique_users:30d
+          annotations:
+            description: "The number of unique Grafana users over the last 30 days"
+          expr: |
+            count(
+                count(
+                    count_over_time(
+                        {container="grafana"}
+                            | logfmt
+                            | handler="/api/live/ws"
+                            |~ `uname=.*@.*`
+                            !~ `uname=.*@giantswarm\.io`
+                            | line_format "{{.uname}}"[30d]
+                    )
+                ) by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region)
+          ) by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region)

--- a/helm/prometheus-rules/templates/platform/atlas/recording-rules/signals.observability-platform.logs.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/recording-rules/signals.observability-platform.logs.yml
@@ -9,18 +9,18 @@ spec:
   groups:
     - name: signals.observability-platform.logs
       rules:
-        - record: giantswarm:observability:grafana:unique_users:30d
+        - record: giantswarm:observability:grafana:unique_users:hourly
           expr: |
             count by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region) (
                 count by (uname, cluster_id, cluster_type, customer, installation, pipeline, provider, region) (
                     count_over_time(
-                        {container="grafana"}
+                        {container="grafana", cluster_id="{{ .Values.managementCluster.name }}"}
                             | logfmt
                             | handler="/api/live/ws"
                             |~ `uname=.*@.*`
                             !~ `uname=.*@giantswarm\.io`
                             | line_format "{{`{{.uname}}`}}"
-                        [30d]
+                        [1h]
                     )
                 ) 
             )


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/4022

This PR adds the necessary rules to collect setup signals and send them to grafana cloud. The dashboard is accesible here https://giantswarm.grafana.net/d/observability-platform-product-signals/observability-platform-product-signals?orgId=1&from=now-5m&to=now&timezone=browser&var-customer=$__all&var-installation=$__all

It is dependent on https://github.com/giantswarm/prometheus-remotewrite/pull/170 so the metrics in grafana cloud have the customer label and on https://github.com/giantswarm/loki-app/pull/430 so loki can send it's recording rules evaluations to mimir


### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
