### PR TITLE
add dashboard link to alert PodsUnschedulable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Alert `MimirToGrafanaCloudExporterTooManyRestarts` is less sensitive
+- Alert `PodsUnschedulable` gets a dashsboard link
 
 ## [4.77.0] - 2025-10-02
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
@@ -16,6 +16,8 @@ spec:
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has unschedulable kube-system pods.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/validate-cluster-health/
+        __dashboardUid__: unschedulable-pods
+        dashboardQueryParams: '{{`orgId=1&var-namespace=kube-system&var-cluster={{ $labels.cluster_id }}`}}'
       expr: |-
         count(
           count_over_time(

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/pods.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/pods.rules.test.yml
@@ -39,5 +39,7 @@ tests:
               team: "phoenix"
               topic: "workloadcluster"
             exp_annotations:
+              __dashboardUid__: "unschedulable-pods"
+              dashboardQueryParams: "orgId=1&var-namespace=kube-system&var-cluster=wc01"
               description: 'Cluster wc01 has unschedulable kube-system pods.'
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/validate-cluster-health/


### PR DESCRIPTION

Towards: https://github.com/giantswarm/giantswarm/issues/34318
This PR adds a dashboard link to the `PodsUnschedulable` alert

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
