### PR TITLE
Remove runbook_url from HelmHistorySecretCountTooHigh alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Zot runbook URL
+- Remove non-existing runbook_url from HelmHistorySecretCountTooHigh alert
 
 ## [4.77.1] - 2025-10-07
 

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/secret.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/secret.rules.yml
@@ -13,7 +13,6 @@ spec:
     - alert: HelmHistorySecretCountTooHigh
       annotations:
         description: '{{`Helm release Secret count too high.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/clean-up-secrets/
       expr: sum(kube_secret_info{namespace=~"giantswarm|kube-system|monitoring", secret=~"sh.helm.+"}) by (cluster_id, installation, pipeline, provider) > 1000
       for: 15m
       labels:


### PR DESCRIPTION
This PR removes a runbook URL that actually doesn't exist.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
