### PR TITLE
update tempo alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Zot runbook URL
 - Remove non-existing runbook_url from HelmHistorySecretCountTooHigh alert
+- Update tempo alerts
 
 ## [4.77.1] - 2025-10-07
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tempo-mixins.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tempo-mixins.rules.yml
@@ -165,7 +165,7 @@ spec:
             avg(tempodb_blocklist_length{cluster_type="management_cluster", container="compactor"}) by (cluster_id, installation, pipeline, provider, namespace) / avg(tempodb_blocklist_length{cluster_type="management_cluster", container="compactor"} offset 7d) by (cluster_id, installation, pipeline, provider, namespace) > 1.4
           for: 15m
           labels:
-            severity: page
+            severity: none
             area: platform
             team: atlas
             topic: observability
@@ -269,7 +269,7 @@ spec:
             max by (pod, cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", container="block-builder"}[6m])) > 200
           for: 5m
           labels:
-            severity: page
+            severity: notify
             area: platform
             team: atlas
             topic: observability
@@ -280,6 +280,32 @@ spec:
             runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
           expr: |
             max by (pod, cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", container="block-builder"}[6m])) > 300
+          for: 5m
+          labels:
+            severity: page
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoLiveStorePartitionLagWarning
+          annotations:
+            description: '{{`Tempo ingest partition {{ $labels.partition }} for live store {{ $labels.pod }} is lagging by more than 300 seconds in {{ $labels.cluster_id }}/{{ $labels.namespace }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", container="live-store"}[6m])) > 200
+          for: 5m
+          labels:
+            severity: notify
+            area: platform
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        - alert: TempoLiveStorePartitionLagCritical
+          annotations:
+            description: '{{`Tempo ingest partition {{ $labels.partition }} for live store {{ $labels.pod }} is lagging by more than 300 seconds in {{ $labels.cluster_id }}/{{ $labels.namespace }}.`}}'
+            runbook_url: https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoPartitionLag
+          expr: |
+            max by (cluster_id, installation, pipeline, provider, namespace, partition) (avg_over_time(tempo_ingest_group_partition_lag_seconds{cluster_type="management_cluster", container=~"live-store"}[6m])) > 300
           for: 5m
           labels:
             severity: page

--- a/tempo/update.sh
+++ b/tempo/update.sh
@@ -34,7 +34,6 @@ apply_global_sed_fixes() {
       sed 's/'\''/ /g' | # Fix single quotes in alert messages
       sed 's/\(message": "\)\(.*\)"/description": "{{`\2`}}"/g' | # Wrap alert messages in double curly braces to avoid Helm template parsing issues. Also, rename the field to `description`.
       sed 's/, namespace=~\\"\.\*\\"//g' #| # Remove useless namespace selector
-      #jq -c
 }
 
 update_rules() {
@@ -62,6 +61,11 @@ update_rules() {
                 rule="$(echo "$rule" \
                     | sed 's/avg(\(.*\)}) \//avg(\1}) by (cluster_id, installation, pipeline, provider, namespace) \//' \
                     )"
+                # This one fires for 2 days when a new cluster is created,
+                # so we don't want it to page until we run tempo all around.
+                rule="$(echo "$rule" \
+                    | sed 's/"severity": "page"/"severity": "none"/' \
+                    )"
                 ;;
             "TempoMetricsGeneratorPartitionLagCritical")
                 # Template is using `group` label but the query removes it.
@@ -74,6 +78,10 @@ update_rules() {
                 rule="$(echo "$rule" \
                     | sed 's/max by (/max by (pod, /'
                 )"
+                # warning alerts should be severity notify
+                rule="$(echo "$rule" \
+                    | sed 's/"severity": "page"/"severity": "notify"/' \
+                )"
                 ;;
             "TempoBlockBuilderPartitionLagCritical")
                 # Template is using `pod` label but the query removes it.
@@ -83,6 +91,12 @@ update_rules() {
                 # Unnecessary regexp match on static string
                 rule="$(echo "$rule" \
                     | sed 's/container=~/container=/' \
+                )"
+                ;;
+            *Warning)
+                # All warning alerts should be severity notify
+                rule="$(echo "$rule" \
+                    | sed 's/"severity": "page"/"severity": "notify"/' \
                 )"
                 ;;
             *)


### PR DESCRIPTION
Started working on this because `TempoBlockListRisingQuickly` was paging.
I discovered each time we start a Tempo cluster, this alert pages for 2 days.
So let's have this alert quiet (only visible in alertmanager, does not page nor notify on slack).

I also took advantage of this PR to have all "Warning" alerts notify only.
And running the update script included 2 new alerts.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
