### PR TITLE
Update ChartOrphanConfigMap alert runbook URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `TeleportKubeAgentInstancesNotReady` and `TeleportKubeAgentZeroReadyReplicas` alerts.
 
+### Changed
+
+- Update `ChartOrphanConfigMap` alert runbook URL to point to new runbook location with templated installation and cluster variables.
+
 ## [4.77.2] - 2025-10-09
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/chart.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/chart.rules.yml
@@ -30,7 +30,7 @@ spec:
     - alert: ChartOrphanConfigMap
       annotations:
         description: '{{`Chart configmaps have not been deleted.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/chart-orphan-resources/
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/chart-operator-orphan-resources/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
       expr: chart_operator_configmap_orphan > 0
       for: 10m
       labels:


### PR DESCRIPTION
## Description

This PR updates the `ChartOrphanConfigMap` alert to reference the new runbook location following the migration from ops-recipe to runbook format.

## Changes

- Updated `runbook_url` from `/docs/support-and-ops/ops-recipes/chart-orphan-resources/` to `/docs/support-and-ops/runbooks/chart-operator-orphan-resources/`
- Added templated `INSTALLATION` and `CLUSTER` variables to the runbook URL for better user experience
- Updated CHANGELOG.md

## Related PRs

- Content migration PR: https://github.com/giantswarm/giantswarm/pull/34568

Related to https://github.com/giantswarm/roadmap/issues/2838