### PR TITLE
Add Cursor rules for editing alerting rules

### DIFF
--- a/.cursor/rules/alert-editing.mdc
+++ b/.cursor/rules/alert-editing.mdc
@@ -1,0 +1,9 @@
+---
+globs: **/*.rules.yml
+alwaysApply: false
+---
+# Rules for editing alerting rules
+
+- **Update tests:**
+  - When modifying an alerting rule, check if there are any tests for the rule. This is best done by grepping for the alert name.
+  - If a runbook URL is changed, the according test must be updated.


### PR DESCRIPTION
As we are instructing people to use Cursor for help with updating runbook URLs in alerting rules, I thought we should leave this here.