### PR TITLE
Increase the PodsUnschedulable pending time from 5 minutes to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `AppWithoutTeamAnnotation` alert runbook URL to point to migrated runbook
+- Adjust `PodsUnschedulable` alert trigger time: Pods have to be more than 10 minutes Pending for the alert to trigger
 
 ### Added
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/pods.rules.yml
@@ -25,8 +25,8 @@ spec:
             count(
               kube_pod_status_unschedulable{namespace="kube-system"}
             ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region, pod)
-          # only keep those that have been unschedulable for more than 5 minutes over the past 30 minutes
-          [30m:]) > 5
+          # only keep those that have been unschedulable for more than 10 minutes over the past 30 minutes
+          [30m:]) > 10
         # count per cluster
         ) by (cluster_id, cluster_type, customer, installation, pipeline, provider, region)
         # At least 2 pods should be unschedulable for the alert to page.


### PR DESCRIPTION
We've seen a few occasions where this alert would fire and by the time we'd look into it the Pod(s) already got scheduled. I think 10 minutes should be enough time for the cluster to react and scale to acomodate pending Pods, and will still fire if there's an actual problem.

Towards https://github.com/giantswarm/giantswarm/issues/34337

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
