### PR TITLE
Fix grafana postgresql recovery alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `GrafanaPostgresqlRecoveryTestFailed` by relying on the new `kube_cnpg_cluster_info` metric introduced in kube-state-metrics (https://github.com/giantswarm/observability-bundle/pull/340)
+
 ## [4.78.0] - 2025-10-21
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
@@ -52,7 +52,13 @@ spec:
         description: '{{`grafana-postgresql db automated recovery test failed.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/grafana-down/
       # If we have a pod for grafana-postgresql-recovery-test postgresql cluster running for 1 hour, we can consider the recovery failed. This alert works because the test clusters are automatically deleted right after the tests are successful, and the grafana database is small so restore+tests never take that long.
-      expr: sum(kube_pod_info{cluster_type="management_cluster", namespace="monitoring", pod=~"grafana-postgresql-recovery-test-[0-9]+"}) by (cluster_id, installation, pipeline, provider) >= 1
+      expr: |
+        (
+          # On v33+ clusters, we introduced the kube_cnpg_cluster_info metric to complement kube_pod_info for better reliability.
+          count(kube_cnpg_cluster_info{cluster_type="management_cluster", name="grafana-postgresql-recovery-test", namespace="monitoring"}) by (cluster_id, installation, pipeline, provider)
+          or
+          sum(kube_pod_info{cluster_type="management_cluster", namespace="monitoring", pod=~"grafana-postgresql-recovery-test-[0-9]+"}) by (cluster_id, installation, pipeline, provider)
+        ) >= 1
       for: 1h
       labels:
         area: platform


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/observability/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/34463

This pull request addresses a reliability issue with the `GrafanaPostgresqlRecoveryTestFailed` alert by updating its Prometheus rule to use a new metric for improved accuracy. The change ensures that the alert works correctly on newer clusters while maintaining compatibility with older ones.

Reliability improvements for alerting:

* Updated the `expr` in `helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml` to use the new `kube_cnpg_cluster_info` metric for more reliable detection of failed Grafana PostgreSQL recovery tests, with a fallback to the old `kube_pod_info` metric for legacy clusters.

Documentation update:

* Added a changelog entry in `CHANGELOG.md` noting the fix for `GrafanaPostgresqlRecoveryTestFailed` and referencing the new metric.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
