### PR TITLE
Remove alert AppOperatorNotReady

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix the `MonitoringAgentDown` alert which is currently erroring on all installations because both kube-state-metrics and cluster-api-monitoring app provide the same metrics.
 
+### Removed
+
+- Remove `AppOperatorNotReady` alert.
+
 ## [4.78.1] - 2025-10-22
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/app.rules.yml
@@ -147,18 +147,6 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
         topic: releng
-    - alert: AppOperatorNotReady
-      annotations:
-        description: '{{`app CR version ({{ $labels.version }}) in namespace {{ $labels.namespace }} has no ready app-operator.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/app-operator-not-ready/
-      expr: app_operator_ready_total != 1
-      for: 15m
-      labels:
-        area: platform
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: honeybadger
-        topic: releng
     - alert: AppExporterDown
       annotations:
         description: '{{`App-exporter ({{ $labels.instance }}) is down.`}}'


### PR DESCRIPTION
This PR removes the alert AppOperatorNotReady, as team honeybadger thinks it's no longer needed.

It fired once since the end of May 2026.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
