### PR TITLE
Fix invalid runbook url for aws-node-taint-nodewithimpairedvolumes

### DIFF
--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws.node.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws.node.workload-cluster.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: WorkloadClusterNodeUnexpectedTaintNodeWithImpairedVolumes
       annotations:
         description: '{{`Node {{ $labels.node }} has unexpected taint NodeWithImpairedVolumes`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/aws-node-taint-nodewithimpairedvolumes/
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/WHAT-GOES-HERE
       expr: kube_node_spec_taint{key="NodeWithImpairedVolumes"} > 0
       for: 30m
       labels:


### PR DESCRIPTION
The `aws-node-taint-nodewithimpairedvolumes` runbook was removed in https://github.com/giantswarm/giantswarm/pull/35413 which broken the CI tests checking for existing runbook URLs.

@AndiDog can you please take a look here ? What is the new runbook URL for this alert ?