### PR TITLE
Adjust aws-load-balancer-controller alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Inhibit `AWSLoadBalancerControllerReconcileErrors` if `AWSLoadBalancerControllerAWSAPIErrors` is already firing.
+
 ## [4.95.0] - 2026-02-12
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws-load-balancer-controller.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/aws-load-balancer-controller.rules.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: aws-load-balancer-controller.rules
-  namespace: {{ .Values.namespace  }}
+  namespace: {{ .Values.namespace }}
 spec:
   groups:
   - name: aws-load-balancer-controller
@@ -22,6 +22,7 @@ spec:
         severity: page
         team: phoenix
         topic: alb
+        inhibit_alb_controller_aws_api_errors: "true"
     - alert: AWSLoadBalancerControllerReconcileErrors
       annotations:
         description: '{{`AWS load balancer controller pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.cluster_id }} is throwing errors while reconciling the {{ $labels.controller }} controller.`}}'
@@ -34,3 +35,4 @@ spec:
         severity: page
         team: phoenix
         topic: alb
+        cancel_if_alb_controller_aws_api_errors: "true"


### PR DESCRIPTION
AWSLoadBalancerControllerReconcileErrors will be inhibited if AWSLoadBalancerControllerAWSAPIErrors is already firing.

This is a root cause suppression pattern. If the AWS API is failing, reconciliation errors are expected symptoms of that root cause. By inhibiting the reconcile error alert when API errors are present, you:

- Avoid alert noise/duplicates
- Focus on the root cause (AWS API issues)
- Get cleaner incident management

Towards https://github.com/giantswarm/giantswarm/issues/35543

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
