### PR TITLE
Add KongOOMKill alert for OOMKilled Kong containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `KyvernoCertificateSecretWillExpireInLessThanTwoDays` alert logic for [new cert-exporter logic](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#2100---2026-03-10) for overlapping certificates.
 
+### Added
+
+- Add `KongOOMKill` alert for Kong containers being OOMKilled.
+
 ## [4.102.0] - 2026-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -30,7 +30,7 @@ spec:
       for: 10m
       labels:
         area: platform
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: cabbage
         topic: kong

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -25,7 +25,7 @@ spec:
     - alert: KongOOMKill
       annotations:
         description: '{{`Kong container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} is being OOMKilled.`}}'
-        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kong-debugging/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&POD={{ $labels.pod }}`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kong-debugging/#kongoomkill?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&POD={{ $labels.pod }}`}}'
       expr: kube_pod_container_status_restarts_total{namespace=~"kong.*"} - kube_pod_container_status_restarts_total{namespace=~"kong.*"} offset 1h >= 5 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{namespace=~"kong.*", reason="OOMKilled"} > 0
       for: 10m
       labels:

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -22,6 +22,18 @@ spec:
         severity: page
         team: cabbage
         topic: kong
+    - alert: KongOOMKill
+      annotations:
+        description: '{{`Kong container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} is being OOMKilled.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kong-debugging/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&POD={{ $labels.pod }}`}}'
+      expr: kube_pod_container_status_restarts_total{namespace=~"kong.*"} - kube_pod_container_status_restarts_total{namespace=~"kong.*"} offset 1h >= 5 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{namespace=~"kong.*", reason="OOMKilled"} > 0
+      for: 10m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: cabbage
+        topic: kong
     - alert: KongProductionDeploymentNotSatisfied
       annotations:
         description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/observability/slo-alerting/

---
Towards: https://github.com/giantswarm/giantswarm/issues/36280

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
