### PR TITLE
Add `ClusterCrossplaneResourcesNotSynced` alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ClusterCrossplaneResourcesNotSynced` alert
+
 ## [4.102.0] - 2026-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-crossplane.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/cluster-crossplane.rules.yml
@@ -34,3 +34,25 @@ spec:
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: phoenix
+
+    # Similar to `ClusterCrossplaneResourcesNotReady`
+    - alert: ClusterCrossplaneResourcesNotSynced
+      annotations:
+        description: '{{`Not all managed Crossplane resources of type "{{ $labels.gvk }}" on {{ $labels.cluster_id }} are synced. This could affect creation or health of workload clusters.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cluster-crossplane-resources/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+      expr: |
+        (
+        crossplane_managed_resource_exists{gvk=~"(iam.aws.upbound.io/.*, Kind=(Role|RolePolicy|Policy)|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup|acm.aws.upbound.io/.*, Kind=Certificate|cloudfront.aws.upbound.io/.*, Kind=.+|iam.aws.upbound.io/.*, Kind=OpenIDConnectProvider|route53.aws.upbound.io/.*, Kind=Record|s3.aws.upbound.io/.*, Kind=Bucket.*)"} != crossplane_managed_resource_synced{gvk=~"(iam.aws.upbound.io/.*, Kind=(Role|RolePolicy|Policy)|sqs.aws.upbound.io/.*, Kind=Queue|sqs.aws.upbound.io/.*, Kind=QueuePolicy|cloudwatchevents.aws.upbound.io/.*, Kind=Rule|cloudwatchevents.aws.upbound.io/.*, Kind=Target|ec2.aws.upbound.io/.*, Kind=SecurityGroup|acm.aws.upbound.io/.*, Kind=Certificate|cloudfront.aws.upbound.io/.*, Kind=.+|iam.aws.upbound.io/.*, Kind=OpenIDConnectProvider|route53.aws.upbound.io/.*, Kind=Record|s3.aws.upbound.io/.*, Kind=Bucket.*)"}
+        ) OR
+        iam_aws_upbound_role_synced{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        sqs_aws_upbound_queue_synced{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        sqs_aws_upbound_queuepolicy_synced{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        cloudwatchevents_aws_upbound_rule_synced{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        cloudwatchevents_aws_upbound_target_synced{status="False", label_giantswarm_io_service_type="managed"} == 1 OR
+        ec2_aws_upbound_securitygroup_synced{status="False", label_giantswarm_io_service_type="managed"} == 1
+      for: 60m # less severe than "Ready" status
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: phoenix

--- a/test/tests/providers/capa/kaas/phoenix/alerting-rules/cluster-crossplane.rules.test.yml
+++ b/test/tests/providers/capa/kaas/phoenix/alerting-rules/cluster-crossplane.rules.test.yml
@@ -24,3 +24,26 @@ tests:
             exp_annotations:
               description: 'Not all managed Crossplane resources of type "cloudwatchevents.aws.upbound.io/v1beta1, Kind=Rule" on mymc are ready. This could affect creation or health of workload clusters.'
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cluster-crossplane-resources/?INSTALLATION=test-installation&CLUSTER=mymc
+
+  - interval: 1m
+    input_series:
+      - series: 'crossplane_managed_resource_exists{gvk="sqs.aws.upbound.io/v1beta1, Kind=Queue", cluster_id="mymc", installation="test-installation"}'
+        values: "6x70"
+      - series: 'crossplane_managed_resource_synced{gvk="sqs.aws.upbound.io/v1beta1, Kind=Queue", cluster_id="mymc", installation="test-installation"}'
+        values: "5x70"
+
+    alert_rule_test:
+      - alertname: ClusterCrossplaneResourcesNotSynced
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "false"
+              cluster_id: "mymc"
+              gvk: "sqs.aws.upbound.io/v1beta1, Kind=Queue"
+              installation: "test-installation"
+              severity: page
+              team: phoenix
+            exp_annotations:
+              description: 'Not all managed Crossplane resources of type "sqs.aws.upbound.io/v1beta1, Kind=Queue" on mymc are synced. This could affect creation or health of workload clusters.'
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cluster-crossplane-resources/?INSTALLATION=test-installation&CLUSTER=mymc


### PR DESCRIPTION
Towards: [Chat incident](https://gigantic.slack.com/archives/C02GDJJ68Q1/p1775226405883409)

Don't merge this yet – there are numerous non-Synced objects floating around for different reasons (such as the China config problem from the chat, or [this S3 too-many-tags issue](https://github.com/giantswarm/giantswarm/issues/36318)) and we want to fix those first.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
