### PR TITLE
Update kyverno cert rotation alert for new exporter logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `KyvernoCertificateSecretWillExpireInLessThanTwoDays` alert logic for [new cert-exporter logic](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#2100---2026-03-10) for overlapping certificates.
+
 ## [4.102.0] - 2026-04-08
 
 ### Changed

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.all.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.all.rules.yml
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`Kyverno Certificate stored in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.cluster_id }} will expire in less than two days.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kyverno-troubleshooting/
-      expr: (cert_exporter_secret_not_after{name=~".*kyverno.*"} - time()) < 2 * 24 * 60 * 60
+      expr: (max by (cluster_id, installation, pipeline, provider, name, exported_namespace, secretkey) (cert_exporter_secret_not_after{name=~".*kyverno.*"}) - time()) < 2 * 24 * 60 * 60
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/certificate.all.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/certificate.all.rules.test.yml
@@ -92,3 +92,71 @@ tests:
     alert_rule_test:
       - alertname: GiantswarmManagedCertificateCRWillExpireInLessThanTwoWeeks
         eval_time: 10d
+  # KyvernoCertificateSecretWillExpireInLessThanTwoDays - rotation: old cert expiring, new cert valid - should NOT fire
+  - interval: 1d
+    input_series:
+      # Old certificate - expires at day 3 (259200 seconds)
+      - series: 'cert_exporter_secret_not_after{cluster_id="test01", cluster_type="management_cluster", installation="test01", pipeline="stable", provider="capa", name="kyverno-svc.kyverno.svc.kyverno-tls-ca", namespace="kube-system", exported_namespace="kyverno", secretkey="tls.crt", certificatename="old-cert"}'
+        values: "259200x10"
+      # New certificate - expires at day 31 (2678400 seconds)
+      - series: 'cert_exporter_secret_not_after{cluster_id="test01", cluster_type="management_cluster", installation="test01", pipeline="stable", provider="capa", name="kyverno-svc.kyverno.svc.kyverno-tls-ca", namespace="kube-system", exported_namespace="kyverno", secretkey="tls.crt", certificatename="new-cert"}'
+        values: "2678400x10"
+    alert_rule_test:
+      - alertname: KyvernoCertificateSecretWillExpireInLessThanTwoDays
+        eval_time: 2d
+  # KyvernoCertificateSecretWillExpireInLessThanTwoDays - all certs expiring - SHOULD fire
+  - interval: 1d
+    input_series:
+      # Old certificate - expires at day 3
+      - series: 'cert_exporter_secret_not_after{cluster_id="test01", cluster_type="management_cluster", installation="test01", pipeline="stable", provider="capa", name="kyverno-svc.kyverno.svc.kyverno-tls-ca", namespace="kube-system", exported_namespace="kyverno", secretkey="tls.crt", certificatename="old-cert"}'
+        values: "259200x10"
+      # New certificate - also expires at day 4 (345600 seconds)
+      - series: 'cert_exporter_secret_not_after{cluster_id="test01", cluster_type="management_cluster", installation="test01", pipeline="stable", provider="capa", name="kyverno-svc.kyverno.svc.kyverno-tls-ca", namespace="kube-system", exported_namespace="kyverno", secretkey="tls.crt", certificatename="new-cert"}'
+        values: "345600x10"
+    alert_rule_test:
+      - alertname: KyvernoCertificateSecretWillExpireInLessThanTwoDays
+        eval_time: 3d
+        exp_alerts:
+          - exp_labels:
+              alertname: KyvernoCertificateSecretWillExpireInLessThanTwoDays
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: test01
+              exported_namespace: kyverno
+              installation: test01
+              name: kyverno-svc.kyverno.svc.kyverno-tls-ca
+              pipeline: stable
+              provider: capa
+              secretkey: tls.crt
+              severity: notify
+              team: shield
+              topic: kyverno
+            exp_annotations:
+              description: "Kyverno Certificate stored in Secret kyverno/kyverno-svc.kyverno.svc.kyverno-tls-ca on test01 will expire in less than two days."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kyverno-troubleshooting/
+  # KyvernoCertificateSecretWillExpireInLessThanTwoDays - single cert expiring - SHOULD fire
+  - interval: 1d
+    input_series:
+      - series: 'cert_exporter_secret_not_after{cluster_id="test01", cluster_type="management_cluster", installation="test01", pipeline="stable", provider="capa", name="kyverno-svc.kyverno.svc.kyverno-tls-ca", namespace="kube-system", exported_namespace="kyverno", secretkey="tls.crt", certificatename="the-cert"}'
+        values: "259200x10"
+    alert_rule_test:
+      - alertname: KyvernoCertificateSecretWillExpireInLessThanTwoDays
+        eval_time: 2d
+        exp_alerts:
+          - exp_labels:
+              alertname: KyvernoCertificateSecretWillExpireInLessThanTwoDays
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: test01
+              exported_namespace: kyverno
+              installation: test01
+              name: kyverno-svc.kyverno.svc.kyverno-tls-ca
+              pipeline: stable
+              provider: capa
+              secretkey: tls.crt
+              severity: notify
+              team: shield
+              topic: kyverno
+            exp_annotations:
+              description: "Kyverno Certificate stored in Secret kyverno/kyverno-svc.kyverno.svc.kyverno-tls-ca on test01 will expire in less than two days."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kyverno-troubleshooting/


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/36233

This PR updates the alert for kyverno's self-signed webhook cert rotation to take advantage of newer cert-exporter logic which correctly captures how kyverno rotates certificates. It should silence noisy alerts for certificates which are expired, but have already been replaced with newer certificates that simply didn't show up in monitoring.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
