### PR TITLE
Exclude /userinfo from DexErrorRateHigh alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude `/userinfo` handler from `DexErrorRateHigh` alert to avoid pages caused by external clients polling with expired tokens.
+
 ## [4.103.0] - 2026-04-13
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/shield/alerting-rules/dex.rules.yml
+++ b/helm/prometheus-rules/templates/platform/shield/alerting-rules/dex.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Dex running on {{ $labels.cluster_id }} is reporting an increased error rate.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/dex-error-rate-high/
-      expr: sum(increase(http_requests_total{job="dex", handler!="/token", code=~"^[4]..$|[5]..$", cluster_type="management_cluster"}[5m])) by (cluster_id, installation, pipeline, provider) > 10
+      expr: sum(increase(http_requests_total{job="dex", handler!~"/token|/userinfo", code=~"^[4]..$|[5]..$", cluster_type="management_cluster"}[5m])) by (cluster_id, installation, pipeline, provider) > 10
       for: 30m
       labels:
         area: platform


### PR DESCRIPTION
External OIDC clients polling `/userinfo` with expired tokens generate 403s that dex correctly returns. These are not actionable for the shield team and have caused noisy pages (e.g. [via mcp-kubernetes proxying expired client tokens](https://gigantic.slack.com/archives/C09R22FS57B/p1776084140191959)).

Real Dex health signals remain covered (auth flow handlers + 5xx).

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
