### PR TITLE
fix EnvoyControllerNotReconcilingGateway alert

### DIFF
--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -118,26 +118,26 @@ spec:
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       expr: | 
           # Option A: accepted but config never reached the proxy
-          (gatewayapi_gateway_status{type="Accepted"} == 1)
+          (gatewayapi_gateway_status{type="Accepted", namespace="envoy-gateway-system"} == 1)
             and on(name, namespace, cluster_id, installation, pipeline, provider)
-          (gatewayapi_gateway_status{type="Programmed"} == 0)
+          (gatewayapi_gateway_status{type="Programmed", namespace="envoy-gateway-system"} == 0)
           or
           # Option B: controller rejected the resource entirely
-          (gatewayapi_gateway_status{type="Accepted"} == 0)
+          (gatewayapi_gateway_status{type="Accepted", namespace="envoy-gateway-system"} == 0)
             and on(name, namespace, cluster_id, installation, pipeline, provider) (
-              (time() - gatewayapi_gateway_created) > 120
+              (time() - gatewayapi_gateway_created{namespace="envoy-gateway-system"}) > 120
             )
           or
           # Option C: stuck — not programmed 5+ minutes after creation
-          (gatewayapi_gateway_status{type="Programmed"} == 0)
+          (gatewayapi_gateway_status{type="Programmed", namespace="envoy-gateway-system"} == 0)
             and on(name, namespace, cluster_id, installation, pipeline, provider) (
-              (time() - gatewayapi_gateway_created) > 300
+              (time() - gatewayapi_gateway_created{namespace="envoy-gateway-system"}) > 300
             )
           or
           # Option D: regression — was programmed recently, now isn't
-          (gatewayapi_gateway_status{type="Programmed"} == 0)
+          (gatewayapi_gateway_status{type="Programmed", namespace="envoy-gateway-system"} == 0)
             and on(name, namespace, cluster_id, installation, pipeline, provider) (
-              max_over_time(gatewayapi_gateway_status{type="Programmed"}[10m]) == 1
+              max_over_time(gatewayapi_gateway_status{type="Programmed", namespace="envoy-gateway-system"}[10m]) == 1
             )
       for: 10m
       labels:


### PR DESCRIPTION
Towards: https://gigantic.slack.com/archives/C02GLN41UP2/p1776937473357049?thread_ts=1776936807.446369&cid=C02GLN41UP2

This PR restricts the scope of the EnvoyControllerNotReconcilingGateway alert to the `envoy-gateway-system` ns. This alert is currently firing on multiple alba WCs and as it's using a KSM metric, not an Envoy specific one, it is triggered for every Gateway API controllers on the WC (for example: Kong). 

I will create an issue on Cabbage board to follow-up on this.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
