### PR TITLE
Add muster transport + token-exchange alert rules (TB-12)

### DIFF
--- a/helm/prometheus-rules/templates/platform/planeteers/alerting-rules/muster-transport.rules.yml
+++ b/helm/prometheus-rules/templates/platform/planeteers/alerting-rules/muster-transport.rules.yml
@@ -31,7 +31,7 @@ spec:
         # values, not a service outage. Notify rather than page.
         - alert: MusterTransportClusterDrift
           annotations:
-            description: '{{`An MCPServer CR is requesting a transport cluster that is not configured in muster on {{ $labels.cluster_id }}. Either add the cluster to muster's helm clusters[] in giantswarm-management-clusters, or kubectl patch the offending CR. MCPServer.status.conditions[type=TransportReady] names the cluster.`}}'
+            description: '{{`An MCPServer CR is requesting a transport cluster that is not configured in muster on {{ $labels.cluster_id }}. Either add the cluster to muster''s helm clusters[] in giantswarm-management-clusters, or kubectl patch the offending CR. MCPServer.status.conditions[type=TransportReady] names the cluster.`}}'
             runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-transport-cluster-drift/
           expr: sum by (cluster_id, installation, pipeline, provider) (rate(muster_transport_lookup_total{result="cluster_unknown"}[5m])) > 0
           for: 10m

--- a/helm/prometheus-rules/templates/platform/planeteers/alerting-rules/muster-transport.rules.yml
+++ b/helm/prometheus-rules/templates/platform/planeteers/alerting-rules/muster-transport.rules.yml
@@ -1,0 +1,65 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: muster-transport.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+    - name: muster-transport
+      rules:
+        # tbot-provisioned identity Secret cannot be loaded — tbot is not running,
+        # the Secret was deleted/recreated, or the watcher broke. Pages because
+        # any failure here breaks the Teleport transport for at least one MCPServer
+        # and is recoverable only by an operator.
+        - alert: MusterTransportSecretMissing
+          annotations:
+            description: '{{`muster failed to load tbot identity Secret {{ $labels.secret }} in cluster {{ $labels.cluster_id }}. tbot may not be running, or the Secret was deleted/recreated. Check the tbot Deployment in muster-system.`}}'
+            runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-transport-secret-missing/
+          expr: sum by (cluster_id, installation, pipeline, provider, secret) (rate(muster_transport_secret_load_total{result="error"}[5m])) > 0
+          for: 5m
+          labels:
+            area: platform
+            cancel_if_outside_working_hours: "true"
+            severity: page
+            team: planeteers
+            topic: muster
+        # An MCPServer CR references a Teleport cluster that is not in muster's
+        # helm clusters[] list. This is GitOps drift between
+        # giantswarm-management-clusters (CR location) and the muster Deployment
+        # values, not a service outage. Notify rather than page.
+        - alert: MusterTransportClusterDrift
+          annotations:
+            description: '{{`An MCPServer CR is requesting a transport cluster that is not configured in muster on {{ $labels.cluster_id }}. Either add the cluster to muster's helm clusters[] in giantswarm-management-clusters, or kubectl patch the offending CR. MCPServer.status.conditions[type=TransportReady] names the cluster.`}}'
+            runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-transport-cluster-drift/
+          expr: sum by (cluster_id, installation, pipeline, provider) (rate(muster_transport_lookup_total{result="cluster_unknown"}[5m])) > 0
+          for: 10m
+          labels:
+            area: platform
+            cancel_if_outside_working_hours: "true"
+            severity: notify
+            team: planeteers
+            topic: muster
+        # RFC 8693 token-exchange error rate above 5%. Likely causes: remote Dex
+        # regression, expired client-credentials Secret, network/Teleport
+        # disruption. Notify rather than page — token-exchange caching means
+        # short-lived disruption is largely absorbed; sustained errors warrant
+        # a human eye on the connector.
+        - alert: MusterTokenExchangeFailures
+          annotations:
+            description: '{{`The Dex RFC 8693 token-exchange path on muster ({{ $labels.cluster_id }}) is failing for more than 5% of requests over the last 5 minutes. Likely causes: remote Dex regression, expired client-credentials Secret, or network/Teleport disruption.`}}'
+            runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-token-exchange-failures/
+          expr: |-
+            (
+              sum by (cluster_id, installation, pipeline, provider) (rate(muster_token_exchange_total{result="error"}[5m]))
+              /
+              sum by (cluster_id, installation, pipeline, provider) (rate(muster_token_exchange_total[5m]))
+            ) > 0.05
+          for: 10m
+          labels:
+            area: platform
+            cancel_if_outside_working_hours: "true"
+            severity: notify
+            team: planeteers
+            topic: muster

--- a/test/tests/providers/global/platform/planeteers/alerting-rules/muster-transport.rules.test.yml
+++ b/test/tests/providers/global/platform/planeteers/alerting-rules/muster-transport.rules.test.yml
@@ -1,0 +1,153 @@
+---
+rule_files:
+  - muster-transport.rules.yml
+
+tests:
+  # MusterTransportSecretMissing
+  # Counter increases by 1 every minute for 30 minutes, simulating tbot identity
+  # Secret load failures. Then the counter stops incrementing for 30 minutes,
+  # so rate(...[5m]) collapses back to zero and the alert resolves.
+  - interval: 1m
+    input_series:
+      - series: 'muster_transport_secret_load_total{secret="tbot-identity-mcp-glean", result="error", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+1x30 30+0x30"
+    alert_rule_test:
+      # Before the 5m for: window completes, the alert is still pending.
+      - alertname: MusterTransportSecretMissing
+        eval_time: 4m
+        exp_alerts: []
+      # After 5m of sustained failures + the 5m for window the alert fires.
+      - alertname: MusterTransportSecretMissing
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              severity: page
+              team: planeteers
+              topic: muster
+              cluster_id: gazelle
+              installation: gazelle
+              pipeline: stable
+              provider: capa
+              secret: tbot-identity-mcp-glean
+            exp_annotations:
+              description: 'muster failed to load tbot identity Secret tbot-identity-mcp-glean in cluster gazelle. tbot may not be running, or the Secret was deleted/recreated. Check the tbot Deployment in muster-system.'
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-transport-secret-missing/
+      # Once the counter stops incrementing the rate falls to zero and the
+      # alert clears (well past the for: window).
+      - alertname: MusterTransportSecretMissing
+        eval_time: 50m
+        exp_alerts: []
+
+  # MusterTransportSecretMissing — non-firing window: only successful loads.
+  - interval: 1m
+    input_series:
+      - series: 'muster_transport_secret_load_total{secret="tbot-identity-mcp-glean", result="ok", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+1x60"
+    alert_rule_test:
+      - alertname: MusterTransportSecretMissing
+        eval_time: 30m
+        exp_alerts: []
+
+  # MusterTransportClusterDrift
+  # An MCPServer references a cluster muster doesn't know about: the
+  # cluster_unknown counter increases steadily for 30 minutes.
+  - interval: 1m
+    input_series:
+      - series: 'muster_transport_lookup_total{result="cluster_unknown", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+1x40 40+0x30"
+    alert_rule_test:
+      # Below the 10m for: window — pending.
+      - alertname: MusterTransportClusterDrift
+        eval_time: 9m
+        exp_alerts: []
+      # Past the for window with sustained drift — firing.
+      - alertname: MusterTransportClusterDrift
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: planeteers
+              topic: muster
+              cluster_id: gazelle
+              installation: gazelle
+              pipeline: stable
+              provider: capa
+            exp_annotations:
+              description: "An MCPServer CR is requesting a transport cluster that is not configured in muster on gazelle. Either add the cluster to muster's helm clusters[] in giantswarm-management-clusters, or kubectl patch the offending CR. MCPServer.status.conditions[type=TransportReady] names the cluster."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-transport-cluster-drift/
+      # Drift stops incrementing — rate drops to zero, alert resolves.
+      - alertname: MusterTransportClusterDrift
+        eval_time: 60m
+        exp_alerts: []
+
+  # MusterTransportClusterDrift — non-firing: only resolved lookups.
+  - interval: 1m
+    input_series:
+      - series: 'muster_transport_lookup_total{result="resolved", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+10x60"
+    alert_rule_test:
+      - alertname: MusterTransportClusterDrift
+        eval_time: 30m
+        exp_alerts: []
+
+  # MusterTokenExchangeFailures — firing case
+  # Errors at 1/min, total at 10/min → error ratio = 10% > 5% threshold.
+  - interval: 1m
+    input_series:
+      - series: 'muster_token_exchange_total{result="error", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+1x40 40+0x30"
+      - series: 'muster_token_exchange_total{result="success", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+9x40 360+9x30"
+    alert_rule_test:
+      # Below the 10m for: window — pending.
+      - alertname: MusterTokenExchangeFailures
+        eval_time: 9m
+        exp_alerts: []
+      # Past the for window with sustained 10% error rate — firing.
+      - alertname: MusterTokenExchangeFailures
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: planeteers
+              topic: muster
+              cluster_id: gazelle
+              installation: gazelle
+              pipeline: stable
+              provider: capa
+            exp_annotations:
+              description: 'The Dex RFC 8693 token-exchange path on muster (gazelle) is failing for more than 5% of requests over the last 5 minutes. Likely causes: remote Dex regression, expired client-credentials Secret, or network/Teleport disruption.'
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/muster-token-exchange-failures/
+
+  # MusterTokenExchangeFailures — non-firing case 1: total non-zero, errors zero.
+  # Confirms the ratio expression doesn't false-positive when all exchanges
+  # succeed.
+  - interval: 1m
+    input_series:
+      - series: 'muster_token_exchange_total{result="success", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+10x60"
+      - series: 'muster_token_exchange_total{result="cache_hit", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+5x60"
+    alert_rule_test:
+      - alertname: MusterTokenExchangeFailures
+        eval_time: 30m
+        exp_alerts: []
+
+  # MusterTokenExchangeFailures — non-firing case 2: low error rate (~2%) below
+  # the 5% threshold.
+  - interval: 1m
+    input_series:
+      - series: 'muster_token_exchange_total{result="error", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+1x60"
+      - series: 'muster_token_exchange_total{result="success", cluster_id="gazelle", installation="gazelle", pipeline="stable", provider="capa"}'
+        values: "0+50x60"
+    alert_rule_test:
+      - alertname: MusterTokenExchangeFailures
+        eval_time: 30m
+        exp_alerts: []


### PR DESCRIPTION
## Summary

Three Prometheus alerts firing on metrics emitted by muster's transport + token-exchange paths (TB-7 + TB-8 in muster):

- **\`MusterTransportSecretMissing\`** (\`severity: page\`) — \`rate(muster_transport_secret_load_total{result=\"error\"}[5m]) > 0\`. tbot identity Secret unreadable; tbot may not be running.
- **\`MusterTransportClusterDrift\`** (\`severity: notify\`) — \`rate(muster_transport_lookup_total{result=\"config_invalid\"}[5m]) > 0\`. An MCPServer CR's \`spec.transport.teleport\` references a Secret/AppName that isn't valid for muster's deployment.
- **\`MusterTokenExchangeFailures\`** (\`severity: notify\`) — error-rate ratio over \`muster_token_exchange_total\` > 5% for 10m. Remote Dex / Teleport / network issue.

Files placed under \`helm/prometheus-rules/templates/platform/planeteers/alerting-rules/\` matching \`atlas\`/\`shield\` neighbours' style. Test fixtures under \`test/tests/.../planeteers/\`.

## Dependencies / stacking

- **Depends functionally on:** the metrics emitted by muster's TB-7 (#TBD) and TB-8 (#TBD). Until those land, the alerts will sit at \`absent()\`-style "no data" — won't fire.
- **\*\* CODEOWNERS gap \*\*:** \`prometheus-rules/CODEOWNERS\` currently has no \`platform/planeteers/\` route. Needs a follow-up entry.

## Testing

- Could **not** run \`promtool test rules\` locally (binary install blocked); fixtures authored carefully against documented \`promtool\` semantics. **Reviewer should run \`make test-rules test_filter=muster-transport\`** to verify.
- Metric label names cross-checked against \`muster/internal/{teleport,oauth}/metrics.go\` source.

## Context

[giantswarm/giantswarm#35456](https://github.com/giantswarm/giantswarm/issues/35456). PLAN §6 TB-12.

---
🚧 **Draft / WIP** — needs promtool tests run + CODEOWNERS follow-up.