### PR TITLE
chore: disable envoy5xx alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `EnvoyHighDownstreamHTTP5xxErrorRate` and `EnvoyHighClusterUpstream5xxErrorRate` alerts by commenting alerts definitions.
+
 ## [4.106.0] - 2026-05-14
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -34,52 +34,52 @@ spec:
         severity: page
         team: cabbage
         topic: envoy-gateway
-    - alert: EnvoyHighDownstreamHTTP5xxErrorRate
-      annotations:
-        description: '{{`More than 5% of downstream HTTP responses are 5xx on {{ $labels.pod }} ({{ $value | printf "%.1f" }}%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
-        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
-      expr: |
-        sum(
-          rate(envoy_http_downstream_rq_xx{envoy_response_code_class="5"}[5m])
-        ) by (pod, namespace, cluster_id, installation, pipeline, provider)
-          /
-        sum(
-          rate(envoy_http_downstream_rq_completed[5m])
-        ) by (pod, namespace, cluster_id, installation, pipeline, provider)
-        * 100 > 5
-        and sum(
-          rate(envoy_http_downstream_rq_completed[5m])
-        ) by (pod, namespace, cluster_id, installation, pipeline, provider) > 0
-      for: 10m
-      labels:
-        area: platform
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: cabbage
-        topic: envoy-gateway
-    - alert: EnvoyHighClusterUpstream5xxErrorRate
-      annotations:
-        description: '{{`More than 5% of upstream requests return 5xx in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
-        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
-      expr: | 
-        rate(
-          envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]
-        ) 
-          / 
-        rate(
-          envoy_cluster_upstream_rq_completed[5m]
-        ) 
-        * 100 > 5 
-        and rate(
-          envoy_cluster_upstream_rq_completed[5m]
-        ) > 0
-      for: 10m
-      labels:
-        area: platform
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: cabbage
-        topic: envoy-gateway
+    # - alert: EnvoyHighDownstreamHTTP5xxErrorRate
+    #   annotations:
+    #     description: '{{`More than 5% of downstream HTTP responses are 5xx on {{ $labels.pod }} ({{ $value | printf "%.1f" }}%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+    #     runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+    #   expr: |
+    #     sum(
+    #       rate(envoy_http_downstream_rq_xx{envoy_response_code_class="5"}[5m])
+    #     ) by (pod, namespace, cluster_id, installation, pipeline, provider)
+    #       /
+    #     sum(
+    #       rate(envoy_http_downstream_rq_completed[5m])
+    #     ) by (pod, namespace, cluster_id, installation, pipeline, provider)
+    #     * 100 > 5
+    #     and sum(
+    #       rate(envoy_http_downstream_rq_completed[5m])
+    #     ) by (pod, namespace, cluster_id, installation, pipeline, provider) > 0
+    #   for: 10m
+    #   labels:
+    #     area: platform
+    #     cancel_if_outside_working_hours: "true"
+    #     severity: page
+    #     team: cabbage
+    #     topic: envoy-gateway
+    # - alert: EnvoyHighClusterUpstream5xxErrorRate
+    #   annotations:
+    #     description: '{{`More than 5% of upstream requests return 5xx in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+    #     runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+    #   expr: | 
+    #     rate(
+    #       envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]
+    #     ) 
+    #       / 
+    #     rate(
+    #       envoy_cluster_upstream_rq_completed[5m]
+    #     ) 
+    #     * 100 > 5 
+    #     and rate(
+    #       envoy_cluster_upstream_rq_completed[5m]
+    #     ) > 0
+    #   for: 10m
+    #   labels:
+    #     area: platform
+    #     cancel_if_outside_working_hours: "true"
+    #     severity: page
+    #     team: cabbage
+    #     topic: envoy-gateway
     - alert: EnvoyHighDownstreamRequestTimeoutRate
       annotations:
         description: '{{`More than 10% of downstream requests timeout for gateway {{ $labels.gateway_name }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'


### PR DESCRIPTION
Cabbage decided to disable these 2 alerts for now as they're mostly generating noise and should be tuned to be actually useful.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
