### PR TITLE
fix: Fix GrafanaPostgresqlRecoveryTestFailed alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+# Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## Fixed
+
+- Fix GrafanaPostgresqlRecoveryTestFailed alert
 
 ## [4.107.0] - 2026-05-26
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
@@ -68,7 +68,7 @@ spec:
               (kube_job_complete{job_name=~"grafana-postgresql-recovery-test-[0-9]+", namespace="monitoring", condition="true"} == 1)
             )
         )
-      for: 1d
+      for: 13h
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/grafana.rules.yml
@@ -51,11 +51,23 @@ spec:
       annotations:
         description: '{{`grafana-postgresql db automated recovery test failed.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/grafana/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
-      # Fires when all existing grafana-postgresql recovery test Jobs have failed. Clears as soon as a new Job succeeds.
+      # Fires when the most recent grafana-postgresql recovery test Job that failed started after the most recent one that succeeded. Clears as soon as a newer Job succeeds.
       expr: |
-        min by (cluster_id, installation, pipeline, provider) (
-          kube_job_failed{job_name=~"grafana-postgresql-recovery-test.+", namespace="monitoring", condition="true"}
-        ) == 1
+        (
+            max by(cluster_id, installation, pipeline, provider) (
+              kube_job_status_start_time{job_name=~"grafana-postgresql-recovery-test-[0-9]+", namespace="monitoring"}
+              and on(job_name)
+              (kube_job_failed{job_name=~"grafana-postgresql-recovery-test-[0-9]+", namespace="monitoring", condition="true"} == 1)
+            )
+        )
+          >
+        (
+            max by(cluster_id, installation, pipeline, provider) (
+              kube_job_status_start_time{job_name=~"grafana-postgresql-recovery-test-[0-9]+", namespace="monitoring"}
+              and on(job_name)
+              (kube_job_complete{job_name=~"grafana-postgresql-recovery-test-[0-9]+", namespace="monitoring", condition="true"} == 1)
+            )
+        )
       for: 1d
       labels:
         area: platform

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -104,7 +104,7 @@ tests:
     # Jobs are run every 6 hour (360 minutes), with a history limit set to 1 for both successful and failed jobs, no ttl is set so finished jobs stays until a next job with the same status replaces it, leading to failed job staying indefinitely regardless of newer successful jobs.
     # kube_job_status_start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.
     input_series:
-      # A job succeeds at minute 1 and stays until the next successful job in 1440 minutes (24 hours).
+      # A job succeeds at minute 1 and stays until the next successful job at hour 24 (1440 minutes)
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
         values: "_x1 60+0x1440"
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
@@ -164,20 +164,44 @@ tests:
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1440m
         exp_alerts: []
-  # Test: the most recent recovery test job succeeds - alert should NOT fire even after 1 day.
+  # Test: GrafanaPostgresqlRecoveryTestFailed do not fire after 2 failing jobs.
+  # Timeline:
+  # - minute 1  Job 001 fails.
+  # - hour   6  Job 002 fails.
+  # - hour  12  Job 003 succeeds.
   - interval: 1m
+    # Jobs are run every 6 hour (360 minutes), with a history limit set to 1 for both successful and failed jobs, no ttl is set so finished jobs stays until a next job with the same status replaces it, leading to failed job staying indefinitely regardless of newer successful jobs.
+    # kube_job_status_start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.
     input_series:
-      # start_time equals the time (in seconds) at which the job starts, so each series only appears from that point on.
-      # An older job starts at 60s (minute 1) and fails, then a newer job starts at 120s (minute 2) and succeeds.
+      # A job fails at minute 1.
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1 60+0x1444"
+        values: "_x1 60+0x360"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1 1+0x1444"
+        values: "_x1 1+0x360"
+      # A job fails at hour 6 (360 minutes or 21600 seconds).
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x2 120+0x1443"
-      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x2 1+0x1443"
+        values: "_x360 21600+0x360"
+      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x360 1+0x360"
+      # A job succeeds at hour 12 (720 minutes or 43200 seconds).
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x720 43200+0x360"
+      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x720 1+0x360"
+    # The alert never fires
     alert_rule_test:
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 1445m
+        eval_time: 60m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 360m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 720m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 720m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 780m
         exp_alerts: []

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -166,9 +166,9 @@ tests:
         exp_alerts: []
   # Test: GrafanaPostgresqlRecoveryTestFailed do not fire after 2 failing jobs.
   # Timeline:
-  # - minute 1  Job 001 fails.
+  # - minute 1  Job 001 fails.     Alert starts pending.
   # - hour   6  Job 002 fails.
-  # - hour  12  Job 003 succeeds.
+  # - hour  12  Job 003 succeeds.  Alert clears.
   - interval: 1m
     # Jobs are run every 6 hour (360 minutes), with a history limit set to 1 for both successful and failed jobs, no ttl is set so finished jobs stays until a next job with the same status replaces it, leading to failed job staying indefinitely regardless of newer successful jobs.
     # kube_job_status_start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -96,20 +96,22 @@ tests:
   # Test: the most recent recovery test job that failed started after the most recent one that succeeded, for over 1 day, triggers the alert. A newer successful job clears it.
   - interval: 1m
     input_series:
-      # An older job succeeded (start_time 100), then a newer job failed (start_time 200) and keeps failing.
+      # start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.
+      # An job starts at 60s (minute 1) and succeeds.
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "100+0x1500"
+        values: "_x1 60+0x1459"
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "1+0x1500"
+        values: "_x1 1+0x1459"
+      # A newer job starts at 120s (minute 2) and keeps failing.
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "200+0x1500"
+        values: "_x2 120+0x1458"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "1+0x1500"
-      # At minute 1450, a newer job succeeds (start_time 300), clearing the alert.
+        values: "_x2 1+0x1458"
+      # At minute 1450, an even newer job starts (start_time 87000s = 1450 minutes) and succeeds, clearing the alert.
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1450 300+0x50"
+        values: "_x1450 87000+0x10"
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1450 1+0x50"
+        values: "_x1450 1+0x10"
     alert_rule_test:
       # Before 13h, alert is still pending - not firing.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
@@ -136,18 +138,19 @@ tests:
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1460m
         exp_alerts: []
-  # Test: the most recent recovery test job succeeded - alert should NOT fire even after 1 day.
+  # Test: the most recent recovery test job succeeds - alert should NOT fire even after 1 day.
   - interval: 1m
     input_series:
-      # An older job failed (start_time 100), then a newer job succeeded (start_time 200).
+      # start_time equals the time (in seconds) at which the job starts, so each series only appears from that point on.
+      # An older job starts at 60s (minute 1) and fails, then a newer job starts at 120s (minute 2) and succeeds.
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "100+0x1500"
+        values: "_x1 60+0x1444"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "1+0x1500"
+        values: "_x1 1+0x1444"
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "200+0x1500"
+        values: "_x2 120+0x1443"
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "1+0x1500"
+        values: "_x2 1+0x1443"
     alert_rule_test:
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1445m

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -93,23 +93,29 @@ tests:
       - alertname: GrafanaPostgresqlArchivingFailure
         eval_time: 40m
         exp_alerts: []
-  # Test: all recovery jobs failed for over 1 day triggers alert, new successful job clears it.
+  # Test: the most recent recovery test job that failed started after the most recent one that succeeded, for over 1 day, triggers the alert. A newer successful job clears it.
   - interval: 1m
     input_series:
-      # Two failed jobs persist for 1500 minutes (~25h).
-      # At minute 1450, a new successful job appears.
-      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+      # An older job succeeded (start_time 100), then a newer job failed (start_time 200) and keeps failing.
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "100+0x1500"
+      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
         values: "1+0x1500"
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "200+0x1500"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
         values: "1+0x1500"
-      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1450 0+0x50"
+      # At minute 1450, a newer job succeeds (start_time 300), clearing the alert.
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1450 300+0x50"
+      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1450 1+0x50"
     alert_rule_test:
       # Before 1 day, alert is still pending - not firing.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1430m
         exp_alerts: []
-      # After 1 day of all jobs failing, alert fires.
+      # After 1 day of the latest job being a failure, alert fires.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1445m
         exp_alerts:
@@ -126,17 +132,22 @@ tests:
             exp_annotations:
               description: 'grafana-postgresql db automated recovery test failed.'
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/grafana/?INSTALLATION=golem&CLUSTER=golem
-      # After a successful job appears, alert clears.
+      # After a newer successful job appears, alert clears.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1460m
         exp_alerts: []
-  # Test: one job succeeded, one failed - alert should NOT fire even after 1 day.
+  # Test: the most recent recovery test job succeeded - alert should NOT fire even after 1 day.
   - interval: 1m
     input_series:
+      # An older job failed (start_time 100), then a newer job succeeded (start_time 200).
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "100+0x1500"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
         values: "1+0x1500"
-      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "0+0x1500"
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "200+0x1500"
+      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "1+0x1500"
     alert_rule_test:
       - alertname: GrafanaPostgresqlRecoveryTestFailed
         eval_time: 1445m

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -111,13 +111,13 @@ tests:
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
         values: "_x1450 1+0x50"
     alert_rule_test:
-      # Before 1 day, alert is still pending - not firing.
+      # Before 13h, alert is still pending - not firing.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 1430m
+        eval_time: 770m
         exp_alerts: []
-      # After 1 day of the latest job being a failure, alert fires.
+      # After 13h of the latest job being a failure, alert fires.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 1445m
+        eval_time: 790m
         exp_alerts:
           - exp_labels:
               area: platform

--- a/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/grafana.rules.test.yml
@@ -93,33 +93,59 @@ tests:
       - alertname: GrafanaPostgresqlArchivingFailure
         eval_time: 40m
         exp_alerts: []
-  # Test: the most recent recovery test job that failed started after the most recent one that succeeded, for over 1 day, triggers the alert. A newer successful job clears it.
+  # Test: GrafanaPostgresqlRecoveryTestFailed fires after 3 failed jobs (for 13h) and a newer successful job clears it.
+  # Timeline:
+  # - minute 1  Job 001 succeeds.
+  # - hour   6  Job 002 fails.    Alert starts pending.
+  # - hour  12  Job 003 fails.
+  # - hour  18  Job 004 fails.    Alert fires.
+  # - hour  24  Job 005 succeeds. Alert clears.
   - interval: 1m
+    # Jobs are run every 6 hour (360 minutes), with a history limit set to 1 for both successful and failed jobs, no ttl is set so finished jobs stays until a next job with the same status replaces it, leading to failed job staying indefinitely regardless of newer successful jobs.
+    # kube_job_status_start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.
     input_series:
-      # start_time equals the time (in seconds) at which the job started, so each series only appears from that point on.
-      # An job starts at 60s (minute 1) and succeeds.
+      # A job succeeds at minute 1 and stays until the next successful job in 1440 minutes (24 hours).
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1 60+0x1459"
+        values: "_x1 60+0x1440"
       - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-001", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1 1+0x1459"
-      # A newer job starts at 120s (minute 2) and keeps failing.
+        values: "_x1 1+0x1440"
+      # A job fails at hour 6 (360 minutes or 21600 seconds).
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x2 120+0x1458"
+        values: "_x360 21600+0x360"
       - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-002", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x2 1+0x1458"
-      # At minute 1450, an even newer job starts (start_time 87000s = 1450 minutes) and succeeds, clearing the alert.
+        values: "_x360 1+0x360"
+      # A job fails at hour 12 (720 minutes or 43200 seconds).
       - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1450 87000+0x10"
-      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
-        values: "_x1450 1+0x10"
+        values: "_x720 43200+0x360"
+      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-003", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x720 1+0x360"
+      # A job fails at hour 18 (1080 minutes or 64800 seconds).
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-004", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1080 64800+0x360"
+      - series: 'kube_job_failed{job_name="grafana-postgresql-recovery-test-004", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1080 1+0x360"
+      # A job succeeds at hour 24 (1440 minutes or 86400 seconds).
+      - series: 'kube_job_status_start_time{job_name="grafana-postgresql-recovery-test-005", namespace="monitoring", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1440 86400+0x360"
+      - series: 'kube_job_complete{job_name="grafana-postgresql-recovery-test-005", namespace="monitoring", condition="true", cluster_id="golem", installation="golem", pipeline="stable", provider="aws"}'
+        values: "_x1440 1+0x360"
     alert_rule_test:
-      # Before 13h, alert is still pending - not firing.
+      # Before third failure (13h after first failure), alert not firing.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 770m
+        eval_time: 60m
         exp_alerts: []
-      # After 13h of the latest job being a failure, alert fires.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 790m
+        eval_time: 360m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 720m
+        exp_alerts: []
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 1080m
+        exp_alerts: []
+      # After 13h of the first failure (6h + 13h = 1140 seconds), alert fires.
+      - alertname: GrafanaPostgresqlRecoveryTestFailed
+        eval_time: 1140m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -134,9 +160,9 @@ tests:
             exp_annotations:
               description: 'grafana-postgresql db automated recovery test failed.'
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/grafana/?INSTALLATION=golem&CLUSTER=golem
-      # After a newer successful job appears, alert clears.
+      # After a newer successful job, alert clears.
       - alertname: GrafanaPostgresqlRecoveryTestFailed
-        eval_time: 1460m
+        eval_time: 1440m
         exp_alerts: []
   # Test: the most recent recovery test job succeeds - alert should NOT fire even after 1 day.
   - interval: 1m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35274

Update the GrafanaPostgresqlRecoveryTestFailed with a new expression which detect when recovery test jobs are failing since more than 13h: 3 failing jobs in a row.