### PR TITLE
feat: splitting into two alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved `GrafanaPostgresqlArchivingFailure` alert to avoid false positives
+- Split `FluxCriticalDeploymentNotSatisfied` into critical and non-critical part.
 
 ## [4.107.1] - 2026-06-11
 

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/flux.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/flux.rules.yml
@@ -10,15 +10,27 @@ spec:
   groups:
   - name: fluxcd
     rules:
-    - alert: FluxDeploymentNotSatisfied
+    - alert: FluxCriticalDeploymentNotSatisfied
       annotations:
         description: '{{`Flux deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace="flux-giantswarm"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace="flux-giantswarm", deployment!="flux-giantswarm-flux-ksm"} > 0
       for: 30m
       labels:
         area: platform
         cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: honeybadger
+        topic: managementcluster
+    - alert: FluxNonCriticalDeploymentNotSatisfied
+      annotations:
+        description: '{{`Flux deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace="flux-giantswarm", deployment="flux-giantswarm-flux-ksm"} > 0
+      for: 30m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: honeybadger
         topic: managementcluster


### PR DESCRIPTION
### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [x] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
