### PR TITLE
chore: update tracing-pipeline runbook url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `GrafanaPostgresqlArchivingFailure` alert to avoid false positives
 - Split `FluxCriticalDeploymentNotSatisfied` into critical and non-critical part.
 - Polish Konfigure Operator alerts.
+- Updated tracing-pipeline runbook URL
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tracing-pipeline.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/tracing-pipeline.rules.yml
@@ -16,7 +16,7 @@ spec:
             dashboardQueryParams: "orgId=2"
             summary: Alloy OTLP exporter is failing to send spans.
             description: '{{`The Alloy OTLP exporter has failed to send {{ printf "%.1f" $value }}% of spans over the last 5 minutes.`}}'
-            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
           expr: |-
             (
               rate(otelcol_exporter_send_failed_spans_total{job="alloy-events"}[5m])
@@ -36,7 +36,7 @@ spec:
           annotations:
             summary: Alloy OTLP exporter enqueue failures exceed 100 spans/second over 5 minutes
             description: '{{`The Alloy OTLP exporter has failed to enqueue more than 100 spans per second on average over the last 5 minutes, indicating potential upstream issues.`}}'
-            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
             __dashboardUid__: 9b6d37c8603e19e8922133984faad93d 
             dashboardQueryParams: "orgId=2"
           expr: rate(otelcol_exporter_enqueue_failed_spans_total{job="alloy-events"}[5m]) > 100

--- a/test/tests/providers/global/platform/atlas/alerting-rules/tracing-pipeline.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/tracing-pipeline.rules.test.yml
@@ -53,7 +53,7 @@ tests:
               __dashboardUid__: 9b6d37c8603e19e8922133984faad93d
               dashboardQueryParams: "orgId=2"
               description: "The Alloy OTLP exporter has failed to send 15.0% of spans over the last 5 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
               summary: Alloy OTLP exporter is failing to send spans.
 
   # Test case 3: Exactly 10% failure rate (edge case) - should alert
@@ -82,7 +82,7 @@ tests:
               __dashboardUid__: 9b6d37c8603e19e8922133984faad93d
               dashboardQueryParams: "orgId=2"
               description: "The Alloy OTLP exporter has failed to send 10.0% of spans over the last 5 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
               summary: Alloy OTLP exporter is failing to send spans.
 
   # Test case 4: No spans being sent at all - should not divide by zero
@@ -124,7 +124,7 @@ tests:
               __dashboardUid__: 9b6d37c8603e19e8922133984faad93d
               dashboardQueryParams: "orgId=2"
               description: "The Alloy OTLP exporter has failed to send 17.6% of spans over the last 5 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
               summary: Alloy OTLP exporter is failing to send spans.
       # Should resolve after recovery
       - alertname: OTLPTraceForwardingErrors
@@ -176,7 +176,7 @@ tests:
               __dashboardUid__: 9b6d37c8603e19e8922133984faad93d
               dashboardQueryParams: "orgId=2"
               description: "The Alloy OTLP exporter has failed to enqueue more than 100 spans per second on average over the last 5 minutes, indicating potential upstream issues."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
               summary: Alloy OTLP exporter enqueue failures exceed 100 spans/second over 5 minutes
 
   # Test case 3: Exactly 6000 enqueue failures per 5min (edge case) - should not alert
@@ -216,7 +216,7 @@ tests:
               __dashboardUid__: 9b6d37c8603e19e8922133984faad93d
               dashboardQueryParams: "orgId=2"
               description: "The Alloy OTLP exporter has failed to enqueue more than 100 spans per second on average over the last 5 minutes, indicating potential upstream issues."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/tracing-pipeline/?INSTALLATION=golem&CLUSTER=golem
               summary: Alloy OTLP exporter enqueue failures exceed 100 spans/second over 5 minutes
       # Should resolve after failure rate drops
       - alertname: OTLPExporterEnqueueFailures


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/36978
This PR is a follow-up on https://github.com/giantswarm/giantswarm/pull/37035

Update runbook link for tracing-pipeline from ops-recipes to runbooks.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
