### PR TITLE
feat: add etcd quorum loss alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ManagementClusterEtcdQuorumLost` and `WorkloadClusterEtcdQuorumLost` alerts that fire when a majority of etcd members report no leader (quorum loss). Shipped as `severity: notify` for an initial observation period before promoting to `page`.
+
 ### Changed
 
 - Improved `GrafanaPostgresqlArchivingFailure` alert to avoid false positives

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
@@ -76,6 +76,7 @@ spec:
       for: 2m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
         team: tenet
         topic: etcd

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
@@ -68,6 +68,17 @@ spec:
         severity: page
         team: tenet
         topic: etcd
+    - alert: ManagementClusterEtcdQuorumLost
+      annotations:
+        description: '{{`Etcd on cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has lost quorum: a majority of members report no leader.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+      expr: count by (cluster_id, installation, pipeline, provider)(etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider!="eks"} == 0) / count by (cluster_id, installation, pipeline, provider)(etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider!="eks"}) > 0.5
+      for: 2m
+      labels:
+        area: kaas
+        severity: notify
+        team: tenet
+        topic: etcd
     - alert: ManagementClusterEtcdMetricsMissing
       annotations:
         description: '{{`Etcd metrics missing for {{ $labels.cluster_id }}.`}}'

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
@@ -69,6 +69,17 @@ spec:
         severity: page
         team: tenet
         topic: etcd
+    - alert: WorkloadClusterEtcdQuorumLost
+      annotations:
+        description: '{{`Etcd on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has lost quorum: a majority of members report no leader.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+      expr: count by (cluster_id, installation, pipeline, provider)(etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider!="eks"} == 0) / count by (cluster_id, installation, pipeline, provider)(etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider!="eks"}) > 0.5
+      for: 2m
+      labels:
+        area: kaas
+        severity: notify
+        team: tenet
+        topic: etcd
     - alert: WorkloadClusterEtcdMetricsMissing
       annotations:
         description: '{{`Etcd metrics missing for cluster {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
@@ -77,6 +77,7 @@ spec:
       for: 2m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: notify
         team: tenet
         topic: etcd

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
@@ -36,6 +36,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: kaas
+              cancel_if_outside_working_hours: "false"
               severity: notify
               team: tenet
               topic: etcd

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
@@ -1,0 +1,48 @@
+rule_files:
+  - etcd.management-cluster.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      # alpha: quorum lost - 2 of 3 members report no leader - should fire after 2m
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="alpha", pod="etcd-alpha-0"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="alpha", pod="etcd-alpha-1"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="alpha", pod="etcd-alpha-2"}'
+        values: "1+0x10"
+      # beta: single member without a leader (1 of 3) - not quorum loss - should NOT fire
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="beta", pod="etcd-beta-0"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="beta", pod="etcd-beta-1"}'
+        values: "1+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="beta", pod="etcd-beta-2"}'
+        values: "1+0x10"
+      # gamma: transient leader election - 2 of 3 lose the leader for 1m only (< 2m for) - should NOT fire
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="gamma", pod="etcd-gamma-0"}'
+        values: "0 1+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="gamma", pod="etcd-gamma-1"}'
+        values: "0 1+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="gamma", pod="etcd-gamma-2"}'
+        values: "1+0x10"
+    alert_rule_test:
+      # before 2m the true quorum loss is still pending - nothing fires
+      - alertname: ManagementClusterEtcdQuorumLost
+        eval_time: 1m
+        exp_alerts: []
+      # after 2m only alpha (real quorum loss) fires; beta and gamma stay quiet
+      - alertname: ManagementClusterEtcdQuorumLost
+        eval_time: 5m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: alpha
+              installation: myinst
+              provider: capa
+              pipeline: stable
+            exp_annotations:
+              description: "Etcd on cluster myinst/alpha has lost quorum: a majority of members report no leader."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
@@ -29,6 +29,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: kaas
+              cancel_if_outside_working_hours: "false"
               severity: notify
               team: tenet
               topic: etcd

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
@@ -1,0 +1,41 @@
+rule_files:
+  - etcd.workload-cluster.rules.yml
+
+tests:
+  - interval: 1m
+    input_series:
+      # wc1: quorum lost - 2 of 3 etcd members report no leader - should fire after 2m
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc1", pod="etcd-wc1-0"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc1", pod="etcd-wc1-1"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc1", pod="etcd-wc1-2"}'
+        values: "1+0x10"
+      # a non-etcd component (e.g. loki's dskit ring) can also expose etcd_server_has_leader.
+      # the app="etcd" whitelist must exclude it: if counted, the denominator would become 4,
+      # dropping the ratio to exactly 0.5 (not > 0.5) and suppressing the alert - so this guards the selector
+      - series: 'etcd_server_has_leader{app="loki", cluster_type="workload_cluster", provider="capa", pipeline="stable", container="loki", installation="myinst", cluster_id="wc1", pod="loki-wc1-0"}'
+        values: "1+0x10"
+      # wc2: single member without a leader (1 of 3) - not quorum loss - should NOT fire
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc2", pod="etcd-wc2-0"}'
+        values: "0+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc2", pod="etcd-wc2-1"}'
+        values: "1+0x10"
+      - series: 'etcd_server_has_leader{app="etcd", cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="wc2", pod="etcd-wc2-2"}'
+        values: "1+0x10"
+    alert_rule_test:
+      - alertname: WorkloadClusterEtcdQuorumLost
+        eval_time: 5m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: wc1
+              installation: myinst
+              provider: capa
+              pipeline: stable
+            exp_annotations:
+              description: "Etcd on workload cluster myinst/wc1 has lost quorum: a majority of members report no leader."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4158

Adds `ManagementClusterEtcdQuorumLost` and `WorkloadClusterEtcdQuorumLost`, firing when a majority of etcd members report no leader (`count(has_leader==0)/count(has_leader) > 0.5`, `for: 2m`). Detects true quorum loss in ~2 minutes instead of relying on the per-member `EtcdHasNoLeader` (35m on workload clusters), while staying quiet during rolling upgrades and transient elections.

Uses an `app="etcd"` whitelist rather than a `container!="loki"` blacklist: other dskit components (loki, formerly promtail) can also expose `etcd_server_has_leader`, and for a ratio alert a stray series dilutes the denominator and could suppress a real page.

Shipped as `severity: notify` for an initial observation period before promoting to `page`. Includes unit tests (quorum loss fires; single-member loss, transient elections, and non-etcd series stay excluded). Verified against production data (alba, 75 etcd members).