### PR TITLE
fix: point ClusterCertificateExpirationMetricsMissing runbook to migrated absent-metrics runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Point `ClusterCertificateExpirationMetricsMissing` runbook URL to the migrated `absent-metrics` runbook.
 - Improved `GrafanaPostgresqlArchivingFailure` alert to avoid false positives
 - Split `FluxCriticalDeploymentNotSatisfied` into critical and non-critical part.
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.workload-cluster.rules.yml
@@ -26,7 +26,7 @@ spec:
     - alert: ClusterCertificateExpirationMetricsMissing
       annotations:
         description: '{{`Certificate metrics are missing for cluster {{ $labels.cluster_id }}.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/absent-metrics/
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/absent-metrics/
       expr: max(up{cluster_id!="", cluster_type="workload_cluster"}) by (cluster_id, installation, pipeline, provider) unless on (cluster_id) count (cert_exporter_not_after{cluster_type="workload_cluster"}) by (cluster_id, installation, pipeline, provider) > 0
       for: 30m
       labels:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36980

The `absent-metrics` ops-recipe is being migrated to a runbook and removed (giantswarm/giantswarm#37039). This repoints the `ClusterCertificateExpirationMetricsMissing` alert's `runbook_url` from the old `/ops-recipes/absent-metrics/` path to the new `/runbooks/absent-metrics/` path.

The content PR also adds a redirect alias on the new runbook, so already-deployed alerts keep working until this change is released.