### PR TITLE
fix: polishing up the KO alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Point `ClusterCertificateExpirationMetricsMissing` runbook URL to the migrated `absent-metrics` runbook.
 - Improved `GrafanaPostgresqlArchivingFailure` alert to avoid false positives
 - Split `FluxCriticalDeploymentNotSatisfied` into critical and non-critical part.
+- Polish Konfigure Operator alerts.
 
 ### Removed
 

--- a/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/konfigure-operator.rules.yml
+++ b/helm/prometheus-rules/templates/platform/honeybadger/alerting-rules/konfigure-operator.rules.yml
@@ -27,7 +27,7 @@ spec:
             description: |-
               This is temporary alert meant to test the theory of possible non-200 responses causing
               configuration wipe-out. See the https://github.com/giantswarm/giantswarm/issues/36392
-          expr: konfigure_operator_schema_fetch_total{status_code!~"200|0"} > 0
+          expr: increase(konfigure_operator_schema_fetch_total{status_code!~"200|0"}[1d]) > 0
           labels:
             area: platform
             cancel_if_outside_working_hours: "true"
@@ -39,7 +39,7 @@ spec:
             description: |-
               This is temporary alert meant to test the theory of possible non-200 responses causing
               configuration wipe-out. See the https://github.com/giantswarm/giantswarm/issues/36392
-          expr: konfigure_operator_schema_fetch_total{status_code!~"200|0"} > 0
+          expr: increase(konfigure_operator_schema_fetch_total{status_code!~"200|0"}[1d]) > 0
           labels:
             area: platform
             severity: notify


### PR DESCRIPTION
Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/observability/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
