### PR TITLE
feat: add DeploymentNotSatisfiedBumblebee alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `DeploymentNotSatisfiedBumblebee` paging on unavailable deployments in the bumblebee namespaces (`agentic-platform`, `kagent`, `mcp-kubernetes`, `mcp-runbooks`).
+- Add `DeploymentNotSatisfiedBumblebee` paging on unavailable deployments in the bumblebee namespaces (`agentic-platform`, `kagent`, `mcp-kubernetes`).
 
 ## [4.110.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `DeploymentNotSatisfiedBumblebee` paging on unavailable deployments in the bumblebee namespaces (`agentic-platform`, `kagent`, `mcp-kubernetes`, `mcp-runbooks`).
+
 ## [4.110.0] - 2026-07-01
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -114,7 +114,8 @@ spec:
       for: 60m
       labels:
         area: platform
-        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        # Business-hours only for now; move to OOBH (page via the platform area) once bumblebee on-call is established.
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: bumblebee
         topic: managementcluster

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -106,3 +106,15 @@ spec:
         severity: page
         team: shield
         topic: managementcluster
+    - alert: DeploymentNotSatisfiedBumblebee
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"agentic-platform|kagent|mcp-kubernetes|mcp-runbooks"} > 0
+      for: 60m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: page
+        team: bumblebee
+        topic: managementcluster

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -110,7 +110,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"agentic-platform|kagent|mcp-kubernetes|mcp-runbooks"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"agentic-platform|kagent|mcp-kubernetes"} > 0
       for: 60m
       labels:
         area: platform


### PR DESCRIPTION
Pages team bumblebee on unavailable management-cluster deployments in the bumblebee-owned namespaces: `agentic-platform`, `kagent`, `mcp-kubernetes`, `mcp-runbooks`.

Matches by **namespace** rather than deployment name, because bumblebee owns entire namespaces with heavy per-customer fan-out (`dex-<customer>`, `mcp-kubernetes-<customer>`) and irregular names (the `mcp-pro` ns has a `pro` deployment). Namespace matching also covers valkey sidecars and future components without enumeration.

Deliberately excludes `mcp-prometheus` and `mcp-pagerduty` (atlas-owned) and `mcp-pro` / `agent-sandbox-system` (ownership unconfirmed). Uses the `workingHoursOnly` helper like the sibling alerts, so on stable it reaches PagerDuty and routes via the bumblebee schedule (business hours) / platform area (out-of-hours).

Added to the existing `deployment.management-cluster.rules.yml` alongside the other `DeploymentNotSatisfied<Team>` alerts.