### PR TITLE
feat: add etcd WAL fsync latency alerts and tighten commit duration detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ManagementClusterEtcdWALFsyncDurationTooHigh` and `WorkloadClusterEtcdWALFsyncDurationTooHigh` alerts (`severity: notify`) firing when etcd WAL fsync p99 exceeds 0.5s for 15m, catching slow disk I/O before it cascades into leader elections and quorum loss.
+
+### Changed
+
+- Tighten `ManagementClusterEtcdCommitDurationTooHigh` and `WorkloadClusterEtcdCommitDurationTooHigh` from p95 > 1.0s to p99 > 0.25s (aligned with the upstream etcd mixin) for earlier detection of backend commit latency.
+
 ## [4.110.0] - 2026-07-01
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.management-cluster.rules.yml
@@ -26,7 +26,19 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high commit duration.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
-      expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider!="eks"}[5m])) > 1.0
+      expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider!="eks"}[5m])) > 0.25
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
+        severity: notify
+        team: tenet
+        topic: etcd
+    - alert: ManagementClusterEtcdWALFsyncDurationTooHigh
+      annotations:
+        description: '{{`Etcd ({{ $labels.pod }}) in cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high WAL fsync duration, indicating slow disk I/O that can cascade into leader elections and quorum loss.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+      expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider!="eks"}[5m])) > 0.5
       for: 15m
       labels:
         area: kaas

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.yml
@@ -28,7 +28,19 @@ spec:
       annotations:
         description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high commit duration.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
-      expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider!="eks"}[5m])) > 1.0
+      expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider!="eks"}[5m])) > 0.25
+      for: 15m
+      labels:
+        area: kaas
+        severity: notify
+        cancel_if_outside_working_hours: "true"
+        team: tenet
+        topic: etcd
+    - alert: WorkloadClusterEtcdWALFsyncDurationTooHigh
+      annotations:
+        description: '{{`Etcd ({{ $labels.pod }}) on workload cluster {{ $labels.installation }}/{{ $labels.cluster_id }} has a too high WAL fsync duration, indicating slow disk I/O that can cascade into leader elections and quorum loss.`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+      expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider!="eks"}[5m])) > 0.5
       for: 15m
       labels:
         area: kaas

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.management-cluster.rules.test.yml
@@ -47,3 +47,79 @@ tests:
             exp_annotations:
               description: "Etcd on cluster myinst/alpha has lost quorum: a majority of members report no leader."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+
+  # WAL fsync latency: a slow-disk instance (p99 ~8s) fires, a healthy one (p99 ~8ms) stays quiet
+  - interval: 1m
+    input_series:
+      # slow: all fsync observations land in the (4s, 8s] bucket -> p99 ~8s, well above the 0.5s threshold
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="0.5"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="4"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="+Inf"}'
+        values: "0+100x40"
+      # healthy: all fsync observations land in the (<=8ms] bucket -> p99 ~8ms, no alert
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="0.008"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="+Inf"}'
+        values: "0+100x40"
+    alert_rule_test:
+      - alertname: ManagementClusterEtcdWALFsyncDurationTooHigh
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "false"
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: slow
+              cluster_type: management_cluster
+              installation: myinst
+              provider: capa
+              pipeline: stable
+              pod: etcd-slow-0
+            exp_annotations:
+              description: "Etcd (etcd-slow-0) in cluster myinst/slow has a too high WAL fsync duration, indicating slow disk I/O that can cascade into leader elections and quorum loss."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+
+  # backend commit latency: a slow-disk instance (p99 ~8s) fires the tightened 0.25s threshold, a healthy one stays quiet
+  - interval: 1m
+    input_series:
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="0.25"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="4"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="+Inf"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="0.008"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="management_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="+Inf"}'
+        values: "0+100x40"
+    alert_rule_test:
+      - alertname: ManagementClusterEtcdCommitDurationTooHigh
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "false"
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: slow
+              cluster_type: management_cluster
+              installation: myinst
+              provider: capa
+              pipeline: stable
+              pod: etcd-slow-0
+            exp_annotations:
+              description: "Etcd (etcd-slow-0) in cluster myinst/slow has a too high commit duration."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/etcd.workload-cluster.rules.test.yml
@@ -40,3 +40,79 @@ tests:
             exp_annotations:
               description: "Etcd on workload cluster myinst/wc1 has lost quorum: a majority of members report no leader."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+
+  # WAL fsync latency: a slow-disk instance (p99 ~8s) fires, a healthy one (p99 ~8ms) stays quiet
+  - interval: 1m
+    input_series:
+      # slow: all fsync observations land in the (4s, 8s] bucket -> p99 ~8s, well above the 0.5s threshold
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="0.5"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="4"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="+Inf"}'
+        values: "0+100x40"
+      # healthy: all fsync observations land in the (<=8ms] bucket -> p99 ~8ms, no alert
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="0.008"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="+Inf"}'
+        values: "0+100x40"
+    alert_rule_test:
+      - alertname: WorkloadClusterEtcdWALFsyncDurationTooHigh
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: slow
+              cluster_type: workload_cluster
+              installation: myinst
+              provider: capa
+              pipeline: stable
+              pod: etcd-slow-0
+            exp_annotations:
+              description: "Etcd (etcd-slow-0) on workload cluster myinst/slow has a too high WAL fsync duration, indicating slow disk I/O that can cascade into leader elections and quorum loss."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/
+
+  # backend commit latency: a slow-disk instance (p99 ~8s) fires the tightened 0.25s threshold, a healthy one stays quiet
+  - interval: 1m
+    input_series:
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="0.25"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="4"}'
+        values: "0+0x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="slow", pod="etcd-slow-0", le="+Inf"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="0.008"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="8"}'
+        values: "0+100x40"
+      - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="capa", pipeline="stable", installation="myinst", cluster_id="fast", pod="etcd-fast-0", le="+Inf"}'
+        values: "0+100x40"
+    alert_rule_test:
+      - alertname: WorkloadClusterEtcdCommitDurationTooHigh
+        eval_time: 20m
+        exp_alerts:
+          - exp_labels:
+              area: kaas
+              cancel_if_outside_working_hours: "true"
+              severity: notify
+              team: tenet
+              topic: etcd
+              cluster_id: slow
+              cluster_type: workload_cluster
+              installation: myinst
+              provider: capa
+              pipeline: stable
+              pod: etcd-slow-0
+            exp_annotations:
+              description: "Etcd (etcd-slow-0) on workload cluster myinst/slow has a too high commit duration."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/etcd-troubleshooting/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4321

Adds early-warning detection for etcd disk I/O latency, the usual root cause that cascades into leader elections and quorum loss.

- New `ManagementClusterEtcdWALFsyncDurationTooHigh` / `WorkloadClusterEtcdWALFsyncDurationTooHigh` (severity notify): p99 of `etcd_disk_wal_fsync_duration_seconds` > 0.5s for 15m.
- Tighten `EtcdCommitDurationTooHigh` (MC + WC) from p95 > 1.0s to p99 > 0.25s, aligned with the upstream etcd mixin.

Thresholds validated against live fleet data (alba): healthy etcd sits in single-digit ms, worst 7-day peaks were 13ms fsync / 42ms commit — well below the thresholds. Added unit tests covering firing and healthy cases for all four alerts.