### PR TITLE
feat(cabbage): add IngressControllerConfigReloadRateTooHigh alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Envoy Gateway alerts `EnvoyProxySDSInitFetchTimeout` (page, 24/7) and `EnvoyProxyListenersStuckWarming` (notify) to detect proxies that silently stop serving after an SDS secret fetch never completes — a state that does not self-heal and was previously invisible (pods stay Ready, control plane reports Programmed). See [envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519).
-- Add `IngressControllerConfigReloadRateTooHigh` alert (`severity: notify`, working hours only) firing when nginx ingress config reloads exceed 1/min averaged over the last hour, catching config flapping.
+- Add `IngressControllerConfigReloadRateTooHigh` alert (`severity: page`, working hours only) firing when nginx ingress config reloads exceed 1/min averaged over the last hour, catching config flapping.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Envoy Gateway alerts `EnvoyProxySDSInitFetchTimeout` (page, 24/7) and `EnvoyProxyListenersStuckWarming` (notify) to detect proxies that silently stop serving after an SDS secret fetch never completes — a state that does not self-heal and was previously invisible (pods stay Ready, control plane reports Programmed). See [envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519).
+- Add `IngressControllerConfigReloadRateTooHigh` alert (`severity: notify`, working hours only) firing when nginx ingress config reloads exceed 1/min averaged over the last hour, catching config flapping.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -67,7 +67,7 @@ spec:
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"
-        severity: notify
+        severity: page
         team: cabbage
         topic: ingress
     - alert: IngressControllerDown

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -66,7 +66,7 @@ spec:
       for: 15m
       labels:
         area: platform
-        cancel_if_outside_working_hours: "true"
+        cancel_if_outside_working_hours: {{ include "workingHoursOnly" . }}
         severity: page
         team: cabbage
         topic: ingress

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -58,6 +58,18 @@ spec:
         severity: page
         team: cabbage
         topic: ingress
+    - alert: IngressControllerConfigReloadRateTooHigh
+      annotations:
+        description: '{{`Ingress Controller {{ $labels.controller_class }} in cluster {{ $labels.cluster_id }} is reloading its config too often ({{ $value | printf "%.1f" }} reloads/min over the last hour).`}}'
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/managed-app-nginx-ic/
+      expr: max by (cluster_id, installation, pipeline, provider, namespace, controller_class) (rate(nginx_ingress_controller_success[60m])) * 60 > 1
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: cabbage
+        topic: ingress
     - alert: IngressControllerDown
       annotations:
         description: '{{`Ingress Controller in namespace {{ $labels.namespace }}) is down.`}}'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37146

## What

Add the `IngressControllerConfigReloadRateTooHigh` alert (team cabbage, `severity: notify`, working hours only).

It fires when the nginx ingress controller reloads its config more than once per minute averaged over the last hour, catching config flapping that drives repeated nginx reloads.

## Why

`nginx_ingress_controller_config_hash` and the reload-timestamp gauge are both point-in-time samples, so at a 1-minute scrape they cannot observe more than one change per minute and undercount flapping. `nginx_ingress_controller_success` is a counter that accumulates every successful reload between scrapes, so `rate()` recovers the true reload frequency regardless of scrape interval.

While investigating, an internal ingress controller was observed doing ~5-6 reloads/min sustained, which this alert would have caught.

```promql
max by (cluster_id, installation, pipeline, provider, namespace, controller_class) (
  rate(nginx_ingress_controller_success[60m])
) * 60 > 1
```
