### PR TITLE
feat: add Envoy Gateway SDS-starvation and stuck-warming alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Envoy Gateway alerts `EnvoyProxySDSInitFetchTimeout` (page, 24/7) and `EnvoyProxyListenersStuckWarming` (notify) to detect proxies that silently stop serving after an SDS secret fetch never completes — a state that does not self-heal and was previously invisible (pods stay Ready, control plane reports Programmed). See [envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519).
+
 ### Changed
 
 - Exclude `aks` clusters from the etcd and etcd-volume alerts (`etcd.workload-cluster`, `etcd.management-cluster`, `storage.workload-cluster`, `storage.management-cluster`), matching the existing `eks` exclusion: AKS control planes are Azure-managed and expose no etcd metrics, so `WorkloadClusterEtcdMetricsMissing` would page for every AKS cluster.

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -146,3 +146,27 @@ spec:
         severity: page
         team: cabbage
         topic: envoy-gateway
+    - alert: EnvoyProxySDSInitFetchTimeout
+      annotations:
+        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching TLS secret {{ $labels.envoy_xds_resource_name }} over SDS and has not recovered. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519).`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      expr: envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"} > 0
+      for: 10m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: cabbage
+        topic: envoy-gateway
+    - alert: EnvoyProxyListenersStuckWarming
+      annotations:
+        description: '{{`Envoy proxy {{ $labels.pod }} has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      expr: envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system"} > 0
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: cabbage
+        topic: envoy-gateway

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -1,0 +1,63 @@
+---
+rule_files:
+  - envoy-gateway.rules.yml
+
+tests:
+  # EnvoyProxySDSInitFetchTimeout: counter stays >0 from onset until pod restart.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        # healthy for 20m, then wedged (2) and never recovers
+        values: "0x20 2+0x40"
+    alert_rule_test:
+      # not firing while healthy
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 15m
+      # within the 10m for-window after onset: not yet firing
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 25m
+      # sustained past the for-window: firing, and still firing well into the outage
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 45m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS and has not recovered. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+
+  # EnvoyProxyListenersStuckWarming: a listener that never leaves warming state.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system", pod="envoy-internal-abc", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        values: "0x20 1+0x40"
+    alert_rule_test:
+      # within the 15m for-window: not yet firing
+      - alertname: EnvoyProxyListenersStuckWarming
+        eval_time: 30m
+      # sustained past 15m: firing
+      - alertname: EnvoyProxyListenersStuckWarming
+        eval_time: 40m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: notify
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"


### PR DESCRIPTION
Towards: https://github.com/envoyproxy/gateway/issues/9519

Adds two Envoy Gateway alerts (Cabbage) that detect a proxy silently no longer serving because a TLS secret never arrived over SDS — a state that does **not** self-heal (recovery needs a proxy pod restart) and was invisible to our existing alerts: the pods stay `Ready` (their probes only hit Envoy's admin `/ready`) and the control plane reports the Gateway `Programmed`.

### Background

On a management cluster, all HTTPS traffic through the internal gateway went down for ~14 minutes with no page. Root cause: an Envoy Gateway control-plane pod reschedule re-armed a long-standing delta-xDS SDS re-subscription gap; a later listener/cluster update made the proxies open new SDS subscriptions for their TLS secrets that were never answered, and after the 15s `initial_fetch_timeout` the listeners stopped serving. Full write-up and metric evidence in envoyproxy/gateway#9519.

### Alerts

- **`EnvoyProxySDSInitFetchTimeout`** — `severity: page`, 24/7 (`cancel_if_outside_working_hours: "false"`).
  `expr: envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"} > 0` for `10m`.
  Healthy proxies are always `0` (verified across all 134 proxy series in the fleet at time of writing). The counter stays elevated for the entire outage until the pod is restarted, so the alert fires per-pod for the full duration — including the "only one replica wedged" case — rather than blipping at onset like a rate-based expression would. The metric carries `envoy_xds_resource_name`, so the description names the exact failing secret.
- **`EnvoyProxyListenersStuckWarming`** — `severity: notify`.
  `expr: envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system"} > 0` for `15m`.
  Safety net for the failure mode once `initial_fetch_timeout: 0` is set on the SDS config source (proposed upstream): the listener then stays warming and the proxy keeps serving the previous config (stale-but-up) instead of activating without a cert — a warn-level condition rather than a hard outage.

Both reuse the existing `envoy-gateway` runbook.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add Unit tests (both alerts: onset timing, labels, annotations — pass `promtool test rules` locally)
- [x] Follow Alert structure
- [ ] Consider creating a dashboard (existing Envoy Gateway dashboards cover the proxy metrics)
- [ ] Request review from oncall area, as well as team (`oncall-cabbage`)
