### PR TITLE
feat(cabbage): add Hubble TLS certificate expiry and certgen job failure alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `CiliumHubbleTLSCertificateWillExpireSoon` alert (`severity: page`, working hours only) firing when a Hubble TLS certificate secret (`hubble-server-certs`, `hubble-relay-client-certs`, `hubble-relay-server-certs`, `hubble-ui-client-certs` — leaf and embedded CA) expires in less than 30 days, on both management and workload clusters. The previous catch-all secret alert only covered management clusters, so Hubble cert expiry on workload clusters broke hubble-relay unnoticed ([giantswarm#37201](https://github.com/giantswarm/giantswarm/issues/37201)).
+- Add `CiliumHubbleCertificateRenewalJobFailed` alert (`severity: page`, working hours only) firing when a `hubble-generate-certs` certgen job fails — including certgen refusing to renew leaf certificates because the Cilium CA is close to expiry (early CA warning, since certgen never rotates the CA).
+
 - Add Envoy Gateway alerts `EnvoyProxySDSInitFetchTimeout` (page, 24/7) and `EnvoyProxyListenersStuckWarming` (notify) to detect proxies that silently stop serving after an SDS secret fetch never completes — a state that does not self-heal and was previously invisible (pods stay Ready, control plane reports Programmed). See [envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519).
 - Add `IngressControllerConfigReloadRateTooHigh` alert (`severity: page`, working hours only) firing when nginx ingress config reloads exceed 1/min averaged over the last hour, catching config flapping.
 

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -104,3 +104,32 @@ spec:
         severity: page
         team: cabbage
         topic: cilium
+    - alert: CiliumHubbleTLSCertificateWillExpireSoon
+      annotations:
+        description: '{{`Hubble TLS certificate {{ $labels.secretkey }} in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} will expire in less than 30 days. Hubble certificate renewal is broken on this cluster; hubble-relay will lose flow data when the certificate expires.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+      # Covers leaf certs (tls.crt) and the embedded Cilium CA copy (ca.crt) in the hubble secrets.
+      # With the cronJob renewal method leafs are re-issued every 4 months with 12 months validity,
+      # so anything closer than 30 days to expiry means renewal is broken (or the cluster is still
+      # on the legacy helm method, which never renews).
+      expr: (cert_exporter_secret_not_after{name=~"hubble-server-certs|hubble-relay-client-certs|hubble-relay-server-certs|hubble-ui-client-certs"} - time()) < 30 * 24 * 60 * 60
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: cabbage
+        topic: cilium
+    - alert: CiliumHubbleCertificateRenewalJobFailed
+      annotations:
+        description: '{{`Hubble certificate renewal job {{ $labels.namespace }}/{{ $labels.job_name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} failed. Certgen may be refusing to renew leaf certificates because the Cilium CA is close to expiry.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+      expr: kube_job_failed{namespace="kube-system", job_name=~"hubble-generate-certs.*", condition="true"} == 1
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        cancel_if_kube_state_metrics_down: "true"
+        severity: page
+        team: cabbage
+        topic: cilium

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -99,3 +99,64 @@ tests:
             exp_annotations:
               description: "Too many Cilium Network Policy errors."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/unsupported-cilium-network-policy/
+  # CiliumHubbleTLSCertificateWillExpireSoon
+  - interval: 1m
+    input_series:
+      # hubble cert: valid for 40 days during the first hour, then 20 days remaining
+      - series: 'cert_exporter_secret_not_after{name="hubble-server-certs", exported_namespace="kube-system", secretkey="tls.crt", installation="alba", cluster_id="odp01"}'
+        values: "3456000+0x59 1728000+0x120"
+      # non-hubble cert about to expire: must NOT match the name filter
+      - series: 'cert_exporter_secret_not_after{name="some-other-certs", exported_namespace="kube-system", secretkey="tls.crt", installation="alba", cluster_id="odp01"}'
+        values: "864000+0x180"
+    alert_rule_test:
+      - alertname: CiliumHubbleTLSCertificateWillExpireSoon
+        eval_time: 30m
+      - alertname: CiliumHubbleTLSCertificateWillExpireSoon
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: cilium
+              cancel_if_outside_working_hours: "true"
+              name: hubble-server-certs
+              exported_namespace: kube-system
+              secretkey: tls.crt
+              installation: alba
+              cluster_id: odp01
+            exp_annotations:
+              description: "Hubble TLS certificate tls.crt in Secret kube-system/hubble-server-certs on alba/odp01 will expire in less than 30 days. Hubble certificate renewal is broken on this cluster; hubble-relay will lose flow data when the certificate expires."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION=alba&CLUSTER=odp01"
+  # CiliumHubbleCertificateRenewalJobFailed
+  - interval: 1m
+    input_series:
+      # certgen job starts failing after 30 minutes
+      - series: 'kube_job_failed{namespace="kube-system", job_name="hubble-generate-certs-a1b2c", condition="true", installation="alba", cluster_id="odp01"}'
+        values: "0+0x29 1+0x90"
+      # failed job with another name: must NOT match the job_name filter
+      - series: 'kube_job_failed{namespace="kube-system", job_name="some-other-job", condition="true", installation="alba", cluster_id="odp01"}'
+        values: "1+0x120"
+    alert_rule_test:
+      - alertname: CiliumHubbleCertificateRenewalJobFailed
+        eval_time: 20m
+      - alertname: CiliumHubbleCertificateRenewalJobFailed
+        eval_time: 35m
+      - alertname: CiliumHubbleCertificateRenewalJobFailed
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: cilium
+              cancel_if_outside_working_hours: "true"
+              cancel_if_kube_state_metrics_down: "true"
+              namespace: kube-system
+              job_name: hubble-generate-certs-a1b2c
+              condition: "true"
+              installation: alba
+              cluster_id: odp01
+            exp_annotations:
+              description: "Hubble certificate renewal job kube-system/hubble-generate-certs-a1b2c on alba/odp01 failed. Certgen may be refusing to renew leaf certificates because the Cilium CA is close to expiry."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION=alba&CLUSTER=odp01"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37201

### What

- `CiliumHubbleTLSCertificateWillExpireSoon` (page, working hours): fires when any Hubble TLS cert secret (`hubble-server-certs`, `hubble-relay-client-certs`, `hubble-relay-server-certs`, `hubble-ui-client-certs`) is <30 days from expiry — covering both the leaf (`tls.crt`) and the embedded Cilium CA copy (`ca.crt`). No `cluster_type` filter, so workload clusters are covered.
- `CiliumHubbleCertificateRenewalJobFailed` (page, working hours): fires when a `hubble-generate-certs` certgen job fails. With `--ca-enforce-validity-throughout-leaves-duration` (wired in the upcoming cilium-app cronJob-method change), certgen fails ~1 year before the CA stops covering new leafs — this alert is the CA early-warning path, since certgen never rotates the CA (cilium/certgen#500).

### Why

Hubble TLS certs broke hubble-relay on alba/odp01 (leaf expiry) and alligator/deu02 (CA expiry) with zero paging: `cert_exporter_secret_not_after` series for the hubble secrets exist on WCs, but the catch-all `CertificateSecretWillExpireInLessThanTwoWeeks` is scoped to `cluster_type="management_cluster"`. `cilium-ca` itself is an Opaque secret cert-exporter can't see, hence the job-failure alert as the CA signal.

The 30d threshold cannot false-positive in steady state: the cronJob method re-issues 12-month leafs every 4 months (≥8 months headroom), and it also catches clusters still on the never-renewing `helm` method during rollout.

Runbook: giantswarm/giantswarm#37228

### Testing

- promtool unit tests for both alerts (firing + name-filter non-matching cases)
- `promtool check rules` + `pint lint` on the rendered output pass (only pre-existing-style regex warnings)