### PR TITLE
fix(cabbage): only page on fresh Envoy SDS init fetch timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EnvoyProxyOAuth2SecretInitFetchTimeout` alert (`severity: notify`, working hours only) for SDS init fetch timeouts on OAuth2 `client_secret`/`hmac_secret` resources. These break OIDC authentication on the routes covered by the affected `SecurityPolicy` until the proxy pod is restarted, but they are a different (non-paging) failure class than the TLS listener wedge, so they are now alerted separately instead of paging via `EnvoyProxySDSInitFetchTimeout`.
+
+### Changed
+
+- Make `EnvoyProxySDSInitFetchTimeout` fire on *fresh* SDS timeouts only. `envoy_sds_init_fetch_timeout` is a latching counter, so the previous `> 0` expression kept paging forever for a timeout that may have happened days ago (observed on `gazelle`: 14 firing series for timeouts last incremented on 2026-07-24, on healthy proxy pods). The alert now uses `increase(...[15m]) > 0` held for 2h via `max_over_time(...[2h:1m])`, and only matches non-OAuth2 SDS resources, matching the "TLS secret" failure its description covers.
+
 ## [4.112.0] - 2026-07-28
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -148,17 +148,49 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxySDSInitFetchTimeout
       annotations:
-        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching TLS secret {{ $labels.envoy_xds_resource_name }} over SDS and has not recovered. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519).`}}'
+        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching TLS secret {{ $labels.envoy_xds_resource_name }} over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519).`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
-      expr: envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"} > 0
-      # envoy_sds_init_fetch_timeout is a latching counter: once incremented it stays >0 until
-      # the pod restarts, and the wedged state never self-heals. A long `for` therefore buys no
-      # flap protection, it only delays the page — keep it short so we page before customer impact.
+      # envoy_sds_init_fetch_timeout is a latching counter: once incremented it stays >0 until the
+      # pod restarts. A bare `> 0` therefore keeps paging for a timeout that may have happened days
+      # ago and had no lasting impact, so trigger on a *fresh* increment instead:
+      #   increase(...[15m]) > 0        detects the timeout as it happens.
+      #   max_over_time(...[2h:1m])     holds the alert for 2h after the last increment. The wedge
+      #     does not self-heal while the counter stays static, so a bare increase() would resolve
+      #     after 15m with the proxy still broken.
+      # The oauth2/* exclusion keeps this alert on the TLS wedge it describes; OAuth2
+      # client_secret/hmac_secret timeouts are a different failure, alerted separately.
+      expr: |
+        max_over_time(
+          (
+            increase(
+              envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", envoy_xds_resource_name!~"oauth2/.*"}[15m]
+            ) > 0
+          )[2h:1m]
+        )
       for: 2m
       labels:
         area: platform
         cancel_if_outside_working_hours: "false"
         severity: page
+        team: cabbage
+        topic: envoy-gateway
+    - alert: EnvoyProxyOAuth2SecretInitFetchTimeout
+      annotations:
+        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching OAuth2 secret {{ $labels.envoy_xds_resource_name }} over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      expr: |
+        max_over_time(
+          (
+            increase(
+              envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", envoy_xds_resource_name=~"oauth2/.*"}[15m]
+            ) > 0
+          )[2h:1m]
+        )
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: notify
         team: cabbage
         topic: envoy-gateway
     - alert: EnvoyProxyListenersStuckWarming

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -3,17 +3,19 @@ rule_files:
   - envoy-gateway.rules.yml
 
 tests:
-  # EnvoyProxySDSInitFetchTimeout: counter stays >0 from onset until pod restart.
+  # EnvoyProxySDSInitFetchTimeout: a *fresh* TLS secret fetch timeout.
+  # The counter latches (stays >0 until the pod restarts), so the alert triggers on the increment
+  # and is then held for 2h by max_over_time.
   - interval: 1m
     input_series:
       - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
-        # healthy for 20m, then wedged (2) and never recovers
-        values: "0x20 2+0x40"
+        # healthy for 20m, then wedged (2) and the latched counter never moves again
+        values: "0x20 2+0x180"
     alert_rule_test:
       # not firing while healthy
       - alertname: EnvoyProxySDSInitFetchTimeout
         eval_time: 15m
-      # within the 2m for-window after onset (counter first >0 at 21m): not yet firing
+      # within the 2m for-window after onset (increment first seen at 21m): not yet firing
       - alertname: EnvoyProxySDSInitFetchTimeout
         eval_time: 22m
       # sustained past the for-window: firing ~2m after onset
@@ -32,11 +34,11 @@ tests:
               installation: ferret
               cluster_id: shd-mgmt-1-use1
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS and has not recovered. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
-      # still firing well into the outage
+      # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
       - alertname: EnvoyProxySDSInitFetchTimeout
-        eval_time: 45m
+        eval_time: 60m
         exp_alerts:
           - exp_labels:
               area: platform
@@ -50,8 +52,63 @@ tests:
               installation: ferret
               cluster_id: shd-mgmt-1-use1
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS and has not recovered. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+      # the 2h hold has expired and the counter never incremented again: the alert self-clears.
+      # The state-based backstop for a proxy that is still wedged is a separate alert.
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 160m
+      # a TLS secret must never trigger the OAuth2 companion alert
+      - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
+        eval_time: 23m
+
+  # A latched counter that timed out long ago and never incremented again must not page.
+  # This is the spurious "firing forever" case the freshness window fixes.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        values: "3x180"
+    alert_rule_test:
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 30m
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 120m
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 180m
+
+  # EnvoyProxyOAuth2SecretInitFetchTimeout: OAuth2 client/hmac secrets are a different (notify)
+  # failure class and must not reach the paging alert.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-external-def", envoy_xds_resource_name="oauth2/client_secret/gazelle-dex-oauth2", installation="gazelle", cluster_id="operations"}'
+        values: "0x20 1+0x180"
+    alert_rule_test:
+      # within the 5m for-window after onset (increment first seen at 21m): not yet firing
+      - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
+        eval_time: 24m
+      # sustained past the for-window
+      - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
+        eval_time: 27m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: notify
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-external-def
+              envoy_xds_resource_name: oauth2/client_secret/gazelle-dex-oauth2
+              installation: gazelle
+              cluster_id: operations
+            exp_annotations:
+              description: "Envoy proxy envoy-external-def timed out fetching OAuth2 secret oauth2/client_secret/gazelle-dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=gazelle&CLUSTER=operations&NAMESPACE=envoy-gateway-system"
+      # an OAuth2 secret must never trigger the paging TLS alert
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 27m
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 60m
 
   # EnvoyProxyListenersStuckWarming: a listener that never leaves warming state.
   - interval: 1m


### PR DESCRIPTION
## Problem

`envoy_sds_init_fetch_timeout` is a **latching counter**: once Envoy increments it, it stays `> 0` until the proxy pod restarts. The counter never goes back down and never resets on recovery.

`EnvoyProxySDSInitFetchTimeout` used a bare threshold:

```promql
envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"} > 0
```

so a single timeout that happened days ago pages forever, regardless of whether it had any lasting impact.

There is also a scope mismatch: the expression matched *every* SDS resource, while its own description talks about a "TLS secret" wedge.

## Live evidence (gazelle)

This is not hypothetical — the alert is firing on `gazelle` right now:

- **14 firing series.**
- **All of them are OAuth2 resources** (`oauth2/client_secret/*`, `oauth2/hmac_secret/*`) — none are the TLS listener secrets the alert description is about.
- The counters were **last incremented on 2026-07-24**; they have been static ever since.
- The affected proxy pods are **healthy**: TLS handshakes are succeeding and `envoy_listener_manager_total_listeners_warming` is 0.

So the paging alert is 100% noise on that installation, and it will stay noisy until somebody restarts pods for an unrelated reason.

## What changes

### 1. `EnvoyProxySDSInitFetchTimeout` now tracks *fresh* timeouts

```promql
max_over_time(
  (
    increase(
      envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", envoy_xds_resource_name!~"oauth2/.*"}[15m]
    ) > 0
  )[2h:1m]
)
```

- `increase(...[15m]) > 0` — detects the timeout **as it happens**, instead of forever after.
- `max_over_time(...[2h:1m])` — **holds** the alert for 2h after the last increment. This matters because the wedge does not self-heal while the counter stays static, so a bare `increase()` would resolve after 15m with the proxy still broken.
- `envoy_xds_resource_name!~"oauth2/.*"` — keeps this paging alert on the TLS listener wedge it actually describes.

`for: 2m` is unchanged. The `description` annotation now says "over SDS within the last 15m" instead of "over SDS and has not recovered", which is what the expression now means.

> Note: the regex is written without a leading `^` because `pint`'s `promql/regexp` check fails on redundant anchors (Prometheus matchers are already fully anchored). `oauth2/.*` is equivalent to the originally intended `^oauth2/.*`.

### 2. New companion alert `EnvoyProxyOAuth2SecretInitFetchTimeout`

The OAuth2 class isn't silently dropped. An SDS timeout on an OAuth2 `client_secret`/`hmac_secret` *does* break OIDC on the routes covered by that `SecurityPolicy` until the proxy pod is restarted — but it does not warrant waking somebody up, so it ships as `severity: notify` (working hours only, `for: 5m`) with the mirrored `oauth2/.*` matcher.

## Validation

Against gazelle's Mimir:

- The new expression returns **EMPTY on gazelle now** → the 14 spurious firing series clear.
- **Replayed over the real 07-24 increments** (10:00Z and 12:00Z on the `operations` WC), it fires with **all 4 series** and holds **continuously until ~14:50Z**, then self-clears.
- `[10m]` as the inner window produced a **one-sample dip** at the increment boundary; `[15m]` is flat. That is why the window is 15m.

Local test suite (all green):

- `make test-rules test_filter=envoy-gateway` → `Congratulations! Rules have been checked and tested`
- `make test-rules` (full, all providers) → `Congratulations! Rules have been checked and tested`
- `make pint` → `Problems found Information=2` (below `--min-severity=warning`), exit 0
- `make test-inhibitions` → exit 0
- `make test-runbooks` → exit 0

`test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml` gained coverage for: the fresh-increment onset and the 2h hold past the 15m `increase()` window, the self-clear after the hold expires, the stale-latched-counter case (must not page — the gazelle bug), OAuth2 resources not reaching the paging alert, and the new notify alert's own onset.

## Known trade-off

The 2h hold means a **genuine unresolved wedge stops paging after 2h**. That is deliberate — the alternative is the current forever-paging behaviour. The state-based backstop for a proxy that is still wedged is a separate `EnvoyProxyTLSHandshakesFailing` alert being developed on branch `add-envoy-proxy-tls-handshakes-failing-alert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
