### PR TITLE
feat: Add EnvoyProxyTLSHandshakesFailing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EnvoyProxyTLSHandshakesFailing` alert (`severity: page`, 24/7, `for: 5m`) firing when an Envoy proxy listener errors on TLS connections at a meaningful rate while zero handshakes succeed. Unlike `EnvoyProxySDSInitFetchTimeout`, which only catches an SDS secret that never arrived, this observes the actual serving path and is cause-agnostic: it catches any "listener up, serving broken" state — expired or mis-issued certificate, SDS starvation, or a wedged proxy. Two incidents (2026-07-17 and 2026-07-28) saw Envoy stop serving while the Deployment reported 2/2 Ready and the Gateway stayed `Programmed: True`, so every deployed alert stayed silent. The error rate is floored at 0.05/s rather than `> 0`, because on an idle listener a single stray probe satisfies `> 0` while `rate(handshake) == 0` is legitimately true — the unfloored form would have paged ~10 times in 7 days across gazelle and ferret, twice on production workload clusters.
+
 ## [4.112.0] - 2026-07-28
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -173,3 +173,39 @@ spec:
         severity: notify
         team: cabbage
         topic: envoy-gateway
+    - alert: EnvoyProxyTLSHandshakesFailing
+      annotations:
+        description: '{{`Envoy proxy {{ $labels.pod }} is failing every TLS handshake on listener {{ $labels.envoy_listener_address }}: connections are erroring while not a single handshake succeeds, so the listener still accepts connections but serves nothing. The pod can stay Ready and the Gateway Programmed throughout, so this does not self-heal — the proxy pod most likely must be restarted. Cause-agnostic: an expired or mis-issued certificate, an SDS secret that never arrived, or an otherwise wedged proxy.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      expr: |
+        # Cause-agnostic "listener up, serving broken" detector: TLS connections error at a
+        # meaningful rate while *zero* handshakes succeed on the same listener.
+        rate(envoy_listener_ssl_connection_error{namespace="envoy-gateway-system"}[10m]) > 0.05
+          and
+        rate(envoy_listener_ssl_handshake{namespace="envoy-gateway-system"}[10m]) == 0
+      # Both series carry an identical label set (they come from the same scrape target and are
+      # both labelled per pod and envoy_listener_address), so the implicit full-label match of
+      # `and` joins them exactly. Do NOT switch this to an explicit
+      # `and on(pod, namespace, cluster_id, installation, pipeline, provider)` like the other
+      # alerts here use: that would drop envoy_listener_address from the match and let an error
+      # on one listener pair up with an idle sibling listener on the same pod.
+      #
+      # The 0.05/s floor (~3 errors/min) is what makes this safe on idle listeners, where a
+      # single stray probe or aborted connection keeps `rate(...) > 0` true for a whole rate
+      # window while `rate(handshake) == 0` is legitimately true. Measured over 7d on gazelle
+      # and ferret, the error rate seen while handshakes were zero peaked at 0.0093/s, so this
+      # keeps a ~5x margin; a listener that actually serves traffic runs at 0.1-1.1 handshakes/s
+      # and would produce errors well above the floor if it started failing them all.
+      # The unhardened `rate(error) > 0` form would have paged ~10 times in those 7 days,
+      # including twice on production workload clusters.
+      #
+      # NOTE: do NOT use envoy_listener_ssl_no_certificate for this. Despite the name it counts
+      # handshakes where the *client* presented no certificate, and on our proxies it equals the
+      # total handshake count exactly — it would fire permanently.
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "false"
+        severity: page
+        team: cabbage
+        topic: envoy-gateway

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -79,3 +79,94 @@ tests:
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+
+  # EnvoyProxyTLSHandshakesFailing — healthy proxy: handshakes vastly dominate a non-zero
+  # trickle of connection errors. Modelled on the real gazelle/operations baseline
+  # (282362 handshakes vs 1204 errors). Note the error rate here (4/min = 0.067/s) is above
+  # the alert's 0.05/s floor on purpose: it is the `rate(handshake) == 0` conjunct, not the
+  # floor, that must keep this healthy proxy silent.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_listener_ssl_handshake{namespace="envoy-gateway-system", pod="envoy-operations-xyz", envoy_listener_address="0.0.0.0_10443", installation="gazelle", cluster_id="operations"}'
+        values: "0+1000x90"
+      - series: 'envoy_listener_ssl_connection_error{namespace="envoy-gateway-system", pod="envoy-operations-xyz", envoy_listener_address="0.0.0.0_10443", installation="gazelle", cluster_id="operations"}'
+        values: "0+4x90"
+    alert_rule_test:
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 30m
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 60m
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 90m
+
+  # EnvoyProxyTLSHandshakesFailing — idle listener false-positive guard. No successful
+  # handshakes at all (so `rate(handshake) == 0` is legitimately true the whole time) plus two
+  # stray errors, e.g. a port scan or an aborted connection. 1 error per 10m is 0.0017/s, well
+  # under the 0.05/s floor, so this must stay silent. The unhardened `rate(error) > 0` draft
+  # would have fired here — this is the case that produced real false pages on gazelle/ferret.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_listener_ssl_handshake{namespace="envoy-gateway-system", pod="envoy-idle-abc", envoy_listener_address="0.0.0.0_10443", installation="ferret", cluster_id="prod-wrkld-3-use1"}'
+        values: "0x90"
+      - series: 'envoy_listener_ssl_connection_error{namespace="envoy-gateway-system", pod="envoy-idle-abc", envoy_listener_address="0.0.0.0_10443", installation="ferret", cluster_id="prod-wrkld-3-use1"}'
+        values: "0x40 1x20 2x30"
+    alert_rule_test:
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 45m
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 50m
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 65m
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 85m
+
+  # EnvoyProxyTLSHandshakesFailing — the incident: the proxy serves normally, then every TLS
+  # handshake starts failing. The handshake counter goes flat while the error counter climbs.
+  # rate(handshake[10m]) reaches 0 at t=39m (last increase was at t=30m), so with `for: 5m`
+  # the alert fires from t=44m and stays firing, as the state does not self-heal.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_listener_ssl_handshake{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_listener_address="0.0.0.0_10443", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        values: "0+60x30 1800+0x60"
+      - series: 'envoy_listener_ssl_connection_error{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_listener_address="0.0.0.0_10443", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        values: "0+0x30 60+60x60"
+    alert_rule_test:
+      # healthy: handshakes still succeeding
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 35m
+      # sustained past the for-window
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 50m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              envoy_listener_address: 0.0.0.0_10443
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc is failing every TLS handshake on listener 0.0.0.0_10443: connections are erroring while not a single handshake succeeds, so the listener still accepts connections but serves nothing. The pod can stay Ready and the Gateway Programmed throughout, so this does not self-heal — the proxy pod most likely must be restarted. Cause-agnostic: an expired or mis-issued certificate, an SDS secret that never arrived, or an otherwise wedged proxy."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+      # still firing well into the outage
+      - alertname: EnvoyProxyTLSHandshakesFailing
+        eval_time: 80m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              envoy_listener_address: 0.0.0.0_10443
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc is failing every TLS handshake on listener 0.0.0.0_10443: connections are erroring while not a single handshake succeeds, so the listener still accepts connections but serves nothing. The pod can stay Ready and the Gateway Programmed throughout, so this does not self-heal — the proxy pod most likely must be restarted. Cause-agnostic: an expired or mis-issued certificate, an SDS secret that never arrived, or an otherwise wedged proxy."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"


### PR DESCRIPTION
Two incidents (2026-07-17 and 2026-07-28) saw Envoy proxies stop serving correctly while every deployed alert stayed silent: the Deployment reported 2/2 Ready and the Gateway stayed Programmed: True throughout. Nothing currently deployed observes the actual serving path, and the existing EnvoyProxySDSInitFetchTimeout only catches one specific cause (an SDS cert that never arrived).

This alert is cause-agnostic: it catches any "listener up, serving broken" state -- expired cert, mis-issued cert, SDS starvation, anything -- by looking for TLS connection errors while zero handshakes succeed.

The error rate is floored at 0.05/s rather than the obvious `> 0`. On an idle listener a single stray probe or aborted connection keeps `rate(error) > 0` true for a whole rate window while `rate(handshake) == 0` is legitimately true, so the unfloored form would have paged ~10 times over 7 days across gazelle and ferret, twice on production workload clusters. Measured over that window the error rate seen while handshakes were zero peaked at 0.0093/s, so the floor keeps a ~5x margin while staying far below the 0.1-1.1 handshakes/s of any listener that actually serves traffic.

The two series carry an identical label set, so the implicit full-label match of `and` joins them exactly; an explicit
`and on(pod, namespace, ...)` would be wrong here as it would drop envoy_listener_address and let an error on one listener pair up with an idle sibling listener on the same pod.

Unit tests cover the healthy gazelle baseline, the idle-listener false-positive case that drove the floor, and the incident itself.

Before adding a new alerting rule into this repository you should consider creating an SLO rules instead.
SLO helps you both increase the quality of your monitoring and reduce the alert noise.

* How to create a SLO rule: https://github.com/giantswarm/sloth-rules#how-to-create-a-slo
* Documentation: https://intranet.giantswarm.io/docs/observability/slo-alerting/

---
Towards: https://github.com/giantswarm/...

This PR ...

### Checklist

- [ ] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) ([guidelines](https://intranet.giantswarm.io/docs/product/ux/guidelines/dashboards/)) (if it does not exist already) to help oncallers monitor the status of the issue.
- [ ] Request review from oncall area, as well as team (e.g: `oncall-kaas-cloud` GitHub group).
