### PR TITLE
fix: Raise CAPATooManyReconciliations threshold to 4000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise `CAPATooManyReconciliations` threshold from 1500 to 4000 reconciliations per 10m. A recent removal of a watch filter on the `awsmachine` controller means CAPI now cascades reconciles across the full AWSMachine fleet on more events, pushing sustained rates on busy installations (e.g. `alba`, ~2000-2700/10m) above the old threshold with no corresponding errors. The alert should reflect this until the watch filter is restored.
+
 ## [4.113.0] - 2026-07-28
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
@@ -65,8 +65,8 @@ spec:
       annotations:
         description: '{{`The {{ $labels.controller }} in CAPA is reconciling too frequently.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/capa-too-many-reconciliations/
-      # Computes the absolute number of reconciliation loops over the past 10 minutes (600 seconds). Fires as soon as that count exceeds 1000. 1.667 reconciliations/second on average.
-      expr: increase(controller_runtime_reconcile_total{app="cluster-api-provider-aws"}[10m]) > 1500
+      # Computes the absolute number of reconciliation loops over the past 10 minutes (600 seconds). Fires as soon as that count exceeds 4000. 6.667 reconciliations/second on average.
+      expr: increase(controller_runtime_reconcile_total{app="cluster-api-provider-aws"}[10m]) > 4000
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
## Summary
- A recently removed watch filter on the `awsmachine` CAPA controller causes it to cascade reconciles across the full AWSMachine fleet on more CAPI events.
- On `alba` this pushed the sustained rate to ~2000-2700 reconciles/10m with zero errors, well above the current 1500 threshold, causing frequent paging with no actionable issue.
- Raises `CAPATooManyReconciliations` from `> 1500` to `> 4000` reconciles/10m to give headroom over the current elevated-but-healthy baseline until the watch filter is restored.
