### PR TITLE
feat(cabbage): add envoy gateway config update alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EnvoyGatewayConfigUpdateRateTooHigh` alert (`severity: page`, working hours only) firing when Envoy Gateway regenerates its xDS config more than 1/min averaged over the last hour, catching config churn ([giantswarm#37146](https://github.com/giantswarm/giantswarm/issues/37146)).
+- Add `EnvoyProxyConfigUpdateRejected` alert (`severity: page`, working hours only) firing when an Envoy proxy NACKs a pushed xDS config and keeps serving the previous one, which is otherwise invisible (pods stay Ready, the Gateway reports Programmed).
+
 ## [4.113.0] - 2026-07-28
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -207,7 +207,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyGatewayConfigUpdateRateTooHigh
       annotations:
-        description: '{{`Envoy Gateway in cluster {{ $labels.cluster_id }} is regenerating its xDS configuration too often ({{ $value | printf "%.1f" }} updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes.`}}'
+        description: '{{`Envoy Gateway in cluster {{ $labels.cluster_id }} is regenerating its configuration too often ({{ $value | printf "%.1f" }} updates/min over the last hour).`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       # xds_snapshot_create_total is incremented once per xDS snapshot built from the xds-IR, which is
       # the Envoy Gateway equivalent of nginx writing a new config and reloading. The namespace matcher
@@ -223,7 +223,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxyConfigUpdateRejected
       annotations:
-        description: '{{`Envoy proxy {{ $labels.pod }} rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason.`}}'
+        description: '{{`Envoy proxy {{ $labels.pod }} rejected a configuration update in the last 15m and keeps serving its previous configuration.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       # Same latching-counter handling as EnvoyProxySDSInitFetchTimeout: the *_update_rejected counters
       # never decrease until the pod restarts, so a bare `> 0` would keep paging for a rejection that

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -205,3 +205,46 @@ spec:
         severity: notify
         team: cabbage
         topic: envoy-gateway
+    - alert: EnvoyGatewayConfigUpdateRateTooHigh
+      annotations:
+        description: '{{`Envoy Gateway in cluster {{ $labels.cluster_id }} is regenerating its xDS configuration too often ({{ $value | printf "%.1f" }} updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      # xds_snapshot_create_total is incremented once per xDS snapshot built from the xds-IR, which is
+      # the Envoy Gateway equivalent of nginx writing a new config and reloading. The namespace matcher
+      # is required: the metric name is generic and must only match the Envoy Gateway control plane.
+      # `max by` without `pod` collapses the control-plane replicas into one series per cluster.
+      expr: max by (cluster_id, installation, pipeline, provider, namespace) (rate(xds_snapshot_create_total{namespace="envoy-gateway-system", status="success"}[60m])) * 60 > 1
+      for: 15m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: cabbage
+        topic: envoy-gateway
+    - alert: EnvoyProxyConfigUpdateRejected
+      annotations:
+        description: '{{`Envoy proxy {{ $labels.pod }} rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason.`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      # Same latching-counter handling as EnvoyProxySDSInitFetchTimeout: the *_update_rejected counters
+      # never decrease until the pod restarts, so a bare `> 0` would keep paging for a rejection that
+      # happened days ago. increase(...[15m]) > 0 catches the rejection as it happens and
+      # max_over_time(...[2h:1m]) holds the alert for 2h, since a rejected config does not heal on its
+      # own while the counter stays static. Do not simplify this back to `> 0`.
+      # `or` rather than a sum: a proxy that exports only some of the four counters (e.g. no SDS
+      # resources) would make a sum-based expression evaluate to nothing.
+      expr: |
+        max_over_time(
+          (
+            increase(envoy_listener_manager_lds_update_rejected{namespace="envoy-gateway-system"}[15m]) > 0
+            or increase(envoy_cluster_manager_cds_update_rejected{namespace="envoy-gateway-system"}[15m]) > 0
+            or increase(envoy_http_rds_update_rejected{namespace="envoy-gateway-system"}[15m]) > 0
+            or increase(envoy_sds_update_rejected{namespace="envoy-gateway-system"}[15m]) > 0
+          )[2h:1m]
+        )
+      for: 5m
+      labels:
+        area: platform
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: cabbage
+        topic: envoy-gateway

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -166,7 +166,7 @@ tests:
               pipeline: stable
               provider: capa
             exp_annotations:
-              description: "Envoy Gateway in cluster my-cluster is regenerating its xDS configuration too often (3.0 updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes."
+              description: "Envoy Gateway in cluster my-cluster is regenerating its configuration too often (3.0 updates/min over the last hour)."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # EnvoyProxyConfigUpdateRejected: the proxy NACKs a pushed config and keeps serving the old one.
@@ -199,7 +199,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              description: "Envoy proxy envoy-internal-abc rejected a configuration update in the last 15m and keeps serving its previous configuration."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
       - alertname: EnvoyProxyConfigUpdateRejected
@@ -217,7 +217,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              description: "Envoy proxy envoy-internal-abc rejected a configuration update in the last 15m and keeps serving its previous configuration."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # the 2h hold has expired and the counter never incremented again: the alert self-clears
       - alertname: EnvoyProxyConfigUpdateRejected
@@ -246,5 +246,5 @@ tests:
               installation: myinstall
               cluster_id: my-cluster-2
             exp_annotations:
-              description: "Envoy proxy envoy-external-def rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              description: "Envoy proxy envoy-external-def rejected a configuration update in the last 15m and keeps serving its previous configuration."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -8,7 +8,7 @@ tests:
   # and is then held for 2h by max_over_time.
   - interval: 1m
     input_series:
-      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="myinstall", cluster_id="my-cluster"}'
         # healthy for 20m, then wedged (2) and the latched counter never moves again
         values: "0x20 2+0x180"
     alert_rule_test:
@@ -31,11 +31,11 @@ tests:
               namespace: envoy-gateway-system
               pod: envoy-internal-abc
               envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
       - alertname: EnvoyProxySDSInitFetchTimeout
         eval_time: 60m
@@ -49,11 +49,11 @@ tests:
               namespace: envoy-gateway-system
               pod: envoy-internal-abc
               envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # the 2h hold has expired and the counter never incremented again: the alert self-clears.
       # The state-based backstop for a proxy that is still wedged is a separate alert.
       - alertname: EnvoyProxySDSInitFetchTimeout
@@ -66,7 +66,7 @@ tests:
   # This is the spurious "firing forever" case the freshness window fixes.
   - interval: 1m
     input_series:
-      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-abc", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="myinstall", cluster_id="my-cluster"}'
         values: "3x180"
     alert_rule_test:
       - alertname: EnvoyProxySDSInitFetchTimeout
@@ -80,7 +80,7 @@ tests:
   # failure class and must not reach the paging alert.
   - interval: 1m
     input_series:
-      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-external-def", envoy_xds_resource_name="oauth2/client_secret/gazelle-dex-oauth2", installation="gazelle", cluster_id="operations"}'
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-external-def", envoy_xds_resource_name="oauth2/client_secret/dex-oauth2", installation="myinstall", cluster_id="my-cluster-2"}'
         values: "0x20 1+0x180"
     alert_rule_test:
       # within the 5m for-window after onset (increment first seen at 21m): not yet firing
@@ -98,12 +98,12 @@ tests:
               cancel_if_outside_working_hours: "true"
               namespace: envoy-gateway-system
               pod: envoy-external-def
-              envoy_xds_resource_name: oauth2/client_secret/gazelle-dex-oauth2
-              installation: gazelle
-              cluster_id: operations
+              envoy_xds_resource_name: oauth2/client_secret/dex-oauth2
+              installation: myinstall
+              cluster_id: my-cluster-2
             exp_annotations:
-              description: "Envoy proxy envoy-external-def timed out fetching OAuth2 secret oauth2/client_secret/gazelle-dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=gazelle&CLUSTER=operations&NAMESPACE=envoy-gateway-system"
+              description: "Envoy proxy envoy-external-def timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"
       # an OAuth2 secret must never trigger the paging TLS alert
       - alertname: EnvoyProxySDSInitFetchTimeout
         eval_time: 27m
@@ -113,7 +113,7 @@ tests:
   # EnvoyProxyListenersStuckWarming: a listener that never leaves warming state.
   - interval: 1m
     input_series:
-      - series: 'envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system", pod="envoy-internal-abc", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+      - series: 'envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system", pod="envoy-internal-abc", installation="myinstall", cluster_id="my-cluster"}'
         values: "0x20 1+0x40"
     alert_rule_test:
       # within the 15m for-window: not yet firing
@@ -131,11 +131,11 @@ tests:
               cancel_if_outside_working_hours: "true"
               namespace: envoy-gateway-system
               pod: envoy-internal-abc
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # EnvoyGatewayConfigUpdateRateTooHigh: xDS config churn on the control plane.
   - interval: 1m

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -136,3 +136,115 @@ tests:
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+
+  # EnvoyGatewayConfigUpdateRateTooHigh: xDS config churn on the control plane.
+  - interval: 1m
+    input_series:
+      - series: 'xds_snapshot_create_total{namespace="envoy-gateway-system", status="success", pod="envoy-gateway-abc", installation="ferret", cluster_id="shd-mgmt-1-use1", pipeline="stable", provider="capa"}'
+        # quiet for an hour, then a sustained burst of 3 snapshots/min
+        values: "0x60 3+3x119"
+    alert_rule_test:
+      # no churn at all: silent
+      - alertname: EnvoyGatewayConfigUpdateRateTooHigh
+        eval_time: 60m
+      # burst started, but the hourly average has not crossed 1/min yet
+      - alertname: EnvoyGatewayConfigUpdateRateTooHigh
+        eval_time: 75m
+      # the 60m rate window is now entirely inside the burst: 3/min, sustained past the 15m for-window
+      - alertname: EnvoyGatewayConfigUpdateRateTooHigh
+        eval_time: 180m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+              pipeline: stable
+              provider: capa
+            exp_annotations:
+              description: "Envoy Gateway in cluster shd-mgmt-1-use1 is regenerating its xDS configuration too often (3.0 updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+
+  # EnvoyProxyConfigUpdateRejected: the proxy NACKs a pushed config and keeps serving the old one.
+  # Like the SDS timeout counters, *_update_rejected latches, so the alert triggers on the increment
+  # and is then held for 2h.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_listener_manager_lds_update_rejected{namespace="envoy-gateway-system", pod="envoy-internal-abc", gateway_name="giantswarm-default", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+        values: "0x20 1+0x180"
+    alert_rule_test:
+      # not firing while the proxy accepts every update
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 15m
+      # within the 5m for-window after onset (increment first seen at 21m): not yet firing
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 24m
+      # sustained past the for-window
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 27m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              gateway_name: giantswarm-default
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+      # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 60m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-abc
+              gateway_name: giantswarm-default
+              installation: ferret
+              cluster_id: shd-mgmt-1-use1
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+      # the 2h hold has expired and the counter never incremented again: the alert self-clears
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 160m
+
+  # EnvoyProxyConfigUpdateRejected also covers the other xDS types via the `or` chain.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_http_rds_update_rejected{namespace="envoy-gateway-system", pod="envoy-external-def", gateway_name="giantswarm-external", installation="gazelle", cluster_id="operations"}'
+        values: "0x20 1+0x60"
+    alert_rule_test:
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 15m
+      - alertname: EnvoyProxyConfigUpdateRejected
+        eval_time: 27m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-external-def
+              gateway_name: giantswarm-external
+              installation: gazelle
+              cluster_id: operations
+            exp_annotations:
+              description: "Envoy proxy envoy-external-def rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=gazelle&CLUSTER=operations&NAMESPACE=envoy-gateway-system"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -140,7 +140,7 @@ tests:
   # EnvoyGatewayConfigUpdateRateTooHigh: xDS config churn on the control plane.
   - interval: 1m
     input_series:
-      - series: 'xds_snapshot_create_total{namespace="envoy-gateway-system", status="success", pod="envoy-gateway-abc", installation="ferret", cluster_id="shd-mgmt-1-use1", pipeline="stable", provider="capa"}'
+      - series: 'xds_snapshot_create_total{namespace="envoy-gateway-system", status="success", pod="envoy-gateway-abc", installation="myinstall", cluster_id="my-cluster", pipeline="stable", provider="capa"}'
         # quiet for an hour, then a sustained burst of 3 snapshots/min
         values: "0x60 3+3x119"
     alert_rule_test:
@@ -161,20 +161,20 @@ tests:
               topic: envoy-gateway
               cancel_if_outside_working_hours: "true"
               namespace: envoy-gateway-system
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
               pipeline: stable
               provider: capa
             exp_annotations:
-              description: "Envoy Gateway in cluster shd-mgmt-1-use1 is regenerating its xDS configuration too often (3.0 updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              description: "Envoy Gateway in cluster my-cluster is regenerating its xDS configuration too often (3.0 updates/min over the last hour). xDS updates are applied hot, so the concern is not the cost of the updates themselves but the config churn upstream: flapping Gateway API resources, a hot-looping controller, or a flood of route changes."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # EnvoyProxyConfigUpdateRejected: the proxy NACKs a pushed config and keeps serving the old one.
   # Like the SDS timeout counters, *_update_rejected latches, so the alert triggers on the increment
   # and is then held for 2h.
   - interval: 1m
     input_series:
-      - series: 'envoy_listener_manager_lds_update_rejected{namespace="envoy-gateway-system", pod="envoy-internal-abc", gateway_name="giantswarm-default", installation="ferret", cluster_id="shd-mgmt-1-use1"}'
+      - series: 'envoy_listener_manager_lds_update_rejected{namespace="envoy-gateway-system", pod="envoy-internal-abc", gateway_name="giantswarm-default", installation="myinstall", cluster_id="my-cluster"}'
         values: "0x20 1+0x180"
     alert_rule_test:
       # not firing while the proxy accepts every update
@@ -196,11 +196,11 @@ tests:
               namespace: envoy-gateway-system
               pod: envoy-internal-abc
               gateway_name: giantswarm-default
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
       - alertname: EnvoyProxyConfigUpdateRejected
         eval_time: 60m
@@ -214,11 +214,11 @@ tests:
               namespace: envoy-gateway-system
               pod: envoy-internal-abc
               gateway_name: giantswarm-default
-              installation: ferret
-              cluster_id: shd-mgmt-1-use1
+              installation: myinstall
+              cluster_id: my-cluster
             exp_annotations:
               description: "Envoy proxy envoy-internal-abc rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=ferret&CLUSTER=shd-mgmt-1-use1&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # the 2h hold has expired and the counter never incremented again: the alert self-clears
       - alertname: EnvoyProxyConfigUpdateRejected
         eval_time: 160m
@@ -226,7 +226,7 @@ tests:
   # EnvoyProxyConfigUpdateRejected also covers the other xDS types via the `or` chain.
   - interval: 1m
     input_series:
-      - series: 'envoy_http_rds_update_rejected{namespace="envoy-gateway-system", pod="envoy-external-def", gateway_name="giantswarm-external", installation="gazelle", cluster_id="operations"}'
+      - series: 'envoy_http_rds_update_rejected{namespace="envoy-gateway-system", pod="envoy-external-def", gateway_name="giantswarm-external", installation="myinstall", cluster_id="my-cluster-2"}'
         values: "0x20 1+0x60"
     alert_rule_test:
       - alertname: EnvoyProxyConfigUpdateRejected
@@ -243,8 +243,8 @@ tests:
               namespace: envoy-gateway-system
               pod: envoy-external-def
               gateway_name: giantswarm-external
-              installation: gazelle
-              cluster_id: operations
+              installation: myinstall
+              cluster_id: my-cluster-2
             exp_annotations:
               description: "Envoy proxy envoy-external-def rejected an xDS configuration update (NACK) in the last 15m and keeps serving its previous configuration, while the Gateway still reports Programmed and the pod stays Ready. Check the *_update_rejected counters on the proxy admin /stats and the envoy-gateway logs for the rejection reason."
-              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=gazelle&CLUSTER=operations&NAMESPACE=envoy-gateway-system"
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37146

`IngressControllerConfigReloadRateTooHigh` gave us a signal for nginx config churn. Envoy Gateway has the same blind spot, plus one nginx does not have.

### `EnvoyGatewayConfigUpdateRateTooHigh` (page, working hours)

```
max by (cluster_id, installation, pipeline, provider, namespace) (rate(xds_snapshot_create_total{namespace="envoy-gateway-system", status="success"}[60m])) * 60 > 1
```

`xds_snapshot_create_total` increments once per config snapshot the control plane builds, which is what the nginx reload counter measures. Baseline over 14 days on the only installation currently exporting these metrics: `0` for most hours, peak `0.68`/min, so the 1/min threshold carries over with headroom.

The `namespace` matcher is required because the metric name is generic. `max by` without `pod` collapses the control-plane replicas into one series per cluster.

### `EnvoyProxyConfigUpdateRejected` (page, working hours)

The proxy refuses a pushed config and keeps serving the previous one, while the Gateway still reports `Programmed` and the pod stays Ready. Covers LDS/CDS/RDS/SDS via `or` rather than a sum, so a proxy exporting only some of the four counters still matches.

These counters latch, so the rule reuses the `increase(...[15m]) > 0` plus `max_over_time(...[2h:1m])` hold already established by `EnvoyProxySDSInitFetchTimeout`. All four counters are `0` on every proxy today, so there is no false-positive risk.

`envoy_*_update_failure` is deliberately not used: it counts stream disconnects and already sits at 18-92 per pod from ordinary control-plane restarts.

### Notes

- Both alerts set `cancel_if_outside_working_hours: "true"` literally, matching the other Envoy Gateway alerts in this file, rather than the `workingHoursOnly` helper (which only renders `"true"` on the `stable-testing` pipeline).
- The rationale for each metric choice lives in code comments above the expressions, so the alert descriptions stay short.
- Drive-by: the existing tests in this file used real installation and cluster names. They now use the generic placeholders already common across the test suite.

### Testing

Unit tests added for both alerts. `make test-rules`, `make test-runbooks`, `make test-inhibitions` and `make pint PINT_TEAM_FILTER=cabbage` all pass. Both expressions were also checked against live data.