### PR TITLE
fix(phoenix): raise CAPATooManyReconciliations threshold to 5000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `EnvoyGatewayConfigUpdateRateTooHigh` alert (`severity: page`, working hours only) firing when Envoy Gateway regenerates its xDS config more than 1/min averaged over the last hour, catching config churn ([giantswarm#37146](https://github.com/giantswarm/giantswarm/issues/37146)).
 - Add `EnvoyProxyConfigUpdateRejected` alert (`severity: page`, working hours only) firing when an Envoy proxy NACKs a pushed xDS config and keeps serving the previous one, which is otherwise invisible (pods stay Ready, the Gateway reports Programmed).
 
+### Changed
+
+- Update `CAPATooManyReconciliations` alert with higher threshold from 1500 to 5000. The healthy baseline is fleet-proportional (the awsmachine controller resyncs all AWSMachines and their owner Machines every 10m), and the largest CAPA fleet (~1100 machines) has a 90-day max of ~3000 reconciliations per 10m, keeping the alert flapping since 2026-07-30. A genuine hot loop still crosses 5000 within one evaluation window.
+
 ## [4.113.0] - 2026-07-28
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/phoenix/alerting-rules/capa.management-cluster.rules.yml
@@ -65,8 +65,9 @@ spec:
       annotations:
         description: '{{`The {{ $labels.controller }} in CAPA is reconciling too frequently.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/capa-too-many-reconciliations/
-      # Computes the absolute number of reconciliation loops over the past 10 minutes (600 seconds). Fires as soon as that count exceeds 1000. 1.667 reconciliations/second on average.
-      expr: increase(controller_runtime_reconcile_total{app="cluster-api-provider-aws"}[10m]) > 1500
+      # Computes the absolute number of reconciliation loops over the past 10 minutes (600 seconds). Fires as soon as that count exceeds 5000 (8.33 reconciliations/second on average).
+      # The healthy baseline is fleet-proportional: the awsmachine controller resyncs every AWSMachine (and its owner Machine) each 10m sync-period, so an MC with N machines legitimately does up to ~3xN reconciliations per 10m. Sized against the largest CAPA fleet (~1100 machines, 90d max ~3000/10m); a real hot loop (>=10 reconciles/s = 6000/10m) still crosses this within one window.
+      expr: increase(controller_runtime_reconcile_total{app="cluster-api-provider-aws"}[10m]) > 5000
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Raising the `CAPATooManyReconciliations` threshold from 1500 to 5000 (follow-up to #1779).

The healthy baseline is fleet-proportional: the awsmachine controller resyncs every AWSMachine and its owner Machine each 10m sync-period, so an MC with N machines legitimately does up to ~3xN reconciliations per 10m.

Data from the largest CAPA fleet (1061 machines — `MachinePoolMachines=true` gives every MachinePool instance an AWSMachine):

- 90-day max of the firing series (`awsmachine`/`success`): ~2976 per 10m, p99 ~2814. All reconciles succeed; no errors, no requeue storms, API write rates flat.
- The alert has been flapping near-continuously since 2026-07-30, when a routine pod reschedule re-phased the two informer resync waves and doubled workqueue adds (~1050 -> ~2100 per 10m) with no change in versions, config, or object counts.

5000 clears the observed max with ~1.7x headroom and stays quiet until a fleet reaches ~1700-1800 machines, while a genuine hot loop (>=10 reconciles/s = 6000/10m) still crosses it within one evaluation window. Also updates the stale comment above the expr (it still described the old 1000 threshold).

https://claude.ai/code/session_01AYd3YPBSoW4jyVbsWiWapR