### PR TITLE
fix(cabbage): base envoy gateway config churn alert on status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Base `EnvoyGatewayConfigUpdateRateTooHigh` on `status_update_total` instead of `xds_snapshot_create_total`, and lower it to `severity: notify`. Envoy Gateway rebuilds its whole xDS snapshot on every backend endpoint change, so ordinary pod rollouts drove the old expression to 6.6/min and paged on clusters where no Gateway API resource had changed. Unlike nginx, which updates endpoints without reloading, the snapshot counter is not a config-churn signal.
+
 ## [4.114.0] - 2026-08-20
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -207,18 +207,28 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyGatewayConfigUpdateRateTooHigh
       annotations:
-        description: '{{`Envoy Gateway in cluster {{ $labels.cluster_id }} is regenerating its configuration too often ({{ $value | printf "%.1f" }} updates/min over the last hour).`}}'
+        description: '{{`Envoy Gateway configuration in cluster {{ $labels.cluster_id }} is changing too often ({{ $value | printf "%.1f" }} resource updates/min over the last hour).`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
-      # xds_snapshot_create_total is incremented once per xDS snapshot built from the xds-IR, which is
-      # the Envoy Gateway equivalent of nginx writing a new config and reloading. The namespace matcher
-      # is required: the metric name is generic and must only match the Envoy Gateway control plane.
-      # `max by` without `pod` collapses the control-plane replicas into one series per cluster.
-      expr: max by (cluster_id, installation, pipeline, provider, namespace) (rate(xds_snapshot_create_total{namespace="envoy-gateway-system", status="success"}[60m])) * 60 > 1
+      # Envoy Gateway writes a status back only when a Gateway API resource actually changes, so
+      # status_update_total tracks config churn: Gateways, HTTPRoutes and policies being added,
+      # removed or edited. The fleet-wide per-cluster peak over 7 days is 0.4/min, so 1/min is a
+      # generous threshold.
+      #
+      # This used to key off xds_snapshot_create_total, which is far too noisy to alert on: Envoy
+      # Gateway rebuilds the whole xDS snapshot whenever a backend EndpointSlice changes, so ordinary
+      # pod rollouts drove it to 6.6/min on a cluster where no Gateway API resource changed at all.
+      # nginx updates its endpoints in-process without reloading, which is why its reload counter
+      # works as a config-churn signal and the snapshot counter does not.
+      #
+      # The namespace matcher is required: the metric name is generic and must only match the Envoy
+      # Gateway control plane. sum-then-max adds up the resource kinds while keeping the control-plane
+      # replicas from double counting.
+      expr: max by (cluster_id, installation, pipeline, provider, namespace) (sum by (cluster_id, installation, pipeline, provider, namespace, pod) (rate(status_update_total{namespace="envoy-gateway-system", status="success"}[60m]))) * 60 > 1
       for: 15m
       labels:
         area: platform
         cancel_if_outside_working_hours: "true"
-        severity: page
+        severity: notify
         team: cabbage
         topic: envoy-gateway
     - alert: EnvoyProxyConfigUpdateRejected

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -137,17 +137,24 @@ tests:
               description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
-  # EnvoyGatewayConfigUpdateRateTooHigh: xDS config churn on the control plane.
+  # EnvoyGatewayConfigUpdateRateTooHigh: Gateway API resource churn on the control plane.
+  # The rates of every kind add up, and only status="success" counts.
   - interval: 1m
     input_series:
-      - series: 'xds_snapshot_create_total{namespace="envoy-gateway-system", status="success", pod="envoy-gateway-abc", installation="myinstall", cluster_id="my-cluster", pipeline="stable", provider="capa"}'
-        # quiet for an hour, then a sustained burst of 3 snapshots/min
-        values: "0x60 3+3x119"
+      - series: 'status_update_total{namespace="envoy-gateway-system", status="success", kind="HTTPRoute", pod="envoy-gateway-abc", installation="myinstall", cluster_id="my-cluster", pipeline="stable", provider="capa"}'
+        # quiet for an hour, then a sustained 2 updates/min
+        values: "0x60 2+2x119"
+      - series: 'status_update_total{namespace="envoy-gateway-system", status="success", kind="Gateway", pod="envoy-gateway-abc", installation="myinstall", cluster_id="my-cluster", pipeline="stable", provider="capa"}'
+        # ... plus 1 update/min on another kind, for 3/min in total
+        values: "0x60 1+1x119"
+      - series: 'status_update_total{namespace="envoy-gateway-system", status="no_action", kind="HTTPRoute", pod="envoy-gateway-abc", installation="myinstall", cluster_id="my-cluster", pipeline="stable", provider="capa"}'
+        # reconciles that changed no status must not count towards churn
+        values: "0+10x179"
     alert_rule_test:
       # no churn at all: silent
       - alertname: EnvoyGatewayConfigUpdateRateTooHigh
         eval_time: 60m
-      # burst started, but the hourly average has not crossed 1/min yet
+      # churn started, but the hourly average has not crossed 1/min yet
       - alertname: EnvoyGatewayConfigUpdateRateTooHigh
         eval_time: 75m
       # the 60m rate window is now entirely inside the burst: 3/min, sustained past the 15m for-window
@@ -156,7 +163,7 @@ tests:
         exp_alerts:
           - exp_labels:
               area: platform
-              severity: page
+              severity: notify
               team: cabbage
               topic: envoy-gateway
               cancel_if_outside_working_hours: "true"
@@ -166,7 +173,7 @@ tests:
               pipeline: stable
               provider: capa
             exp_annotations:
-              description: "Envoy Gateway in cluster my-cluster is regenerating its configuration too often (3.0 updates/min over the last hour)."
+              description: "Envoy Gateway configuration in cluster my-cluster is changing too often (3.0 resource updates/min over the last hour)."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # EnvoyProxyConfigUpdateRejected: the proxy NACKs a pushed config and keeps serving the old one.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37146

Follow-up to #2112. `EnvoyGatewayConfigUpdateRateTooHigh` paged on a cluster where no Gateway API resource had changed at all.

### What went wrong

`xds_snapshot_create_total` tracks pod churn, not config churn. Envoy Gateway rebuilds the whole xDS snapshot whenever a backend EndpointSlice changes, so the snapshot rate is a direct function of pod creations in the cluster:

| pods created in trailing hour | snapshot rate |
|---|---|
| ~15 (baseline) | 0/min |
| 44 | 0.81/min |
| 69-76 | 1.15-1.36/min (pages) |
| 164 | 6.6/min |

Nothing in the configuration was changing during any of it:

- `status_update_total` rate stayed at 0.4/min against 6.6/min of snapshots. Envoy Gateway writes a status back only when a Gateway API resource changes, so no Gateway, HTTPRoute or policy was touched.
- `envoy_cluster_manager_cds_update_success`, `envoy_http_rds_update_success` and `envoy_sds_update_success` were flat at 0/min. No cluster, route or secret definition changed.
- `envoy_cluster_membership_change` sat at 3.76/min: endpoints joining and leaving.

nginx updates its endpoint list in-process without reloading, so `nginx_ingress_controller_success` counts only genuine config reloads. The snapshot counter carries an extra term nginx's does not, and the 1/min threshold did not transfer. The original validation was done against a quiet installation with no backend churn to expose this.

Fleet-wide the old expression crossed the threshold in roughly 30 of 168 hourly samples over 7 days.

### Fix

Key off `status_update_total{status="success"}`, which increments only when a Gateway API resource actually changes - which is what the original issue was about, a flood of ingress changes. Fleet-wide per-cluster peak over 7 days is 0.39/min, including during the 6.6/min snapshot episode, so `> 1` keeps ~2.5x headroom.

```
max by (cluster_id, installation, pipeline, provider, namespace) (sum by (cluster_id, installation, pipeline, provider, namespace, pod) (rate(status_update_total{namespace="envoy-gateway-system", status="success"}[60m]))) * 60 > 1
```

sum-then-max adds up the resource kinds while keeping multi-replica control planes from double counting. `status="no_action"` reconciles are excluded, and the unit test covers that.

Also dropped to `severity: notify`. Config churn is an early indicator, and the incident this came from was diagnosed after the fact rather than paged on.

`EnvoyProxyConfigUpdateRejected` is unchanged and has not fired.

### Testing

Unit test updated, including a `no_action` series that must not count. `make test-rules`, `make test-runbooks` and `make pint PINT_TEAM_FILTER=cabbage` pass. The new expression was checked against 7 days of live data across the fleet.