### PR TITLE
feat(tenet): pre-aggregate apiserver_request_total for the availability SLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `gs_slo:apiserver_request_errors:rate5m` and `gs_slo:apiserver_request_total:rate5m` recording rules, pre-aggregating `apiserver_request_total` per cluster for the apiserver-availability SLI.
+
 ## [4.115.0] - 2026-08-24
 
 ### Added

--- a/helm/prometheus-rules/templates/kaas/tenet/recording-rules/apiserver-slo.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/recording-rules/apiserver-slo.rules.yml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: apiserver-slo.recording.rules
+  namespace: {{ .Values.namespace  }}
+spec:
+  groups:
+  # Pre-aggregate `apiserver_request_total` per cluster so the apiserver-availability SLI can be
+  # computed from these instead of scanning every raw series over its window.
+  # The grouping labels and metric selectors must stay in sync with
+  # areas/kaas/teams/tenet/apiserver/slos/availability.yaml in giantswarm/sloth-rules.
+  - interval: 1m
+    name: apiserver-slo.recording
+    rules:
+      - expr: |
+          sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) (rate(apiserver_request_total{code=~"(5..|429)"}[5m]))
+        record: gs_slo:apiserver_request_errors:rate5m
+      - expr: |
+          sum by (cluster_id, cluster_type, customer, installation, pipeline, provider, region) (rate(apiserver_request_total[5m]))
+        record: gs_slo:apiserver_request_total:rate5m

--- a/test/tests/providers/global/kaas/tenet/recording-rules/apiserver-slo.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/recording-rules/apiserver-slo.rules.test.yml
@@ -1,0 +1,39 @@
+---
+rule_files:
+  - apiserver-slo.rules.yml
+
+tests:
+  # The pre-aggregation must keep clusters separate and must sum 5xx and 429 into the error
+  # rate, so that errors/total reproduces the ratio the SLI used to compute from raw data.
+  - interval: 1m
+    input_series:
+      # workload cluster: 600 req/min OK, 60 req/min 5xx, 60 req/min 429 => total 12/s, errors 2/s
+      - series: 'apiserver_request_total{code="200", cluster_id="test-wc", cluster_type="workload_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+        values: "0+600x20"
+      - series: 'apiserver_request_total{code="500", cluster_id="test-wc", cluster_type="workload_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+        values: "0+60x20"
+      - series: 'apiserver_request_total{code="429", cluster_id="test-wc", cluster_type="workload_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+        values: "0+60x20"
+      # management cluster: 300 req/min OK only => total 5/s, no error series at all
+      - series: 'apiserver_request_total{code="200", cluster_id="test-mc", cluster_type="management_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+        values: "0+300x20"
+    promql_expr_test:
+      - expr: gs_slo:apiserver_request_errors:rate5m
+        eval_time: 10m
+        exp_samples:
+          - labels: 'gs_slo:apiserver_request_errors:rate5m{cluster_id="test-wc", cluster_type="workload_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+            value: 2
+      - expr: gs_slo:apiserver_request_total:rate5m
+        eval_time: 10m
+        exp_samples:
+          - labels: 'gs_slo:apiserver_request_total:rate5m{cluster_id="test-mc", cluster_type="management_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+            value: 5
+          - labels: 'gs_slo:apiserver_request_total:rate5m{cluster_id="test-wc", cluster_type="workload_cluster", customer="test-customer", installation="test-installation", pipeline="testing", provider="$provider", region="test-region"}'
+            value: 12
+      # This is the expression the SLI evaluates once chained. A cluster with no errors must
+      # yield no sample here rather than 0, so the SLI's `or` fallback keeps working.
+      - expr: sum(avg_over_time(gs_slo:apiserver_request_errors:rate5m[5m])) by (cluster_id) / sum(avg_over_time(gs_slo:apiserver_request_total:rate5m[5m])) by (cluster_id)
+        eval_time: 10m
+        exp_samples:
+          - labels: '{cluster_id="test-wc"}'
+            value: 0.16666666666666666


### PR DESCRIPTION
## TLDR

This pre-aggregates metrics so we can optimize the Sloth SLO rules.

## Why

The apiserver-availability SLI ([`giantswarm/sloth-rules`](https://github.com/giantswarm/sloth-rules/blob/main/areas/kaas/teams/tenet/apiserver/slos/availability.yaml)) computes `errorQuery`/`totalQuery` straight from `apiserver_request_total`, and Sloth expands that into eight windows (5m, 30m, 1h, 2h, 6h, 1d, 3d, plus an optimized 30d). Seven of them query the raw metric, so the 3d window has to fetch roughly 100k series × 3 days of samples in a single query.

On one large installation that exceeds `max_fetched_chunks_per_query`, which accounted for **515 of ~519 rule evaluation failures per day** (`cortex_querier_queries_rejected_total{reason="max-fetched-chunks-per-query"}`; every other rejection reason was 0). `slo:sli_error:ratio_rate3d` has been left with gaps, and the limit has already been raised three times — 2M → 3M → 4M → 6M. Raising it again just resets the same treadmill.

Refs: https://github.com/giantswarm/giantswarm/issues/35143

## What

Pre-aggregate the SLI's numerator and denominator per cluster, once a minute:

- `gs_slo:apiserver_request_errors:rate5m`
- `gs_slo:apiserver_request_total:rate5m`

The SLI can then read ~1 series per cluster over its window (~25 series × 864 samples for 3d) instead of ~100k series of raw chunks. This is the chaining that Sloth's own `optimized-rules` feature applies, but only to the largest window — hence doing it explicitly.

The rules deliberately mirror the SLI exactly: the same seven grouping labels, the same bare `apiserver_request_total` selector (no `app` or `verb` filter), and the same `code=~"(5..|429)"` error selector. A cluster with no matching error series still produces no sample, which keeps the SLI's `or clamp_min(1 - sum(up{job="apiserver"}), 0)` fallback behaving as before.

## Rollout

**This PR must merge first**, and needs ~3 days of history before `slo:sli_error:ratio_rate3d` is fully accurate. The window degrades gracefully in the meantime — it averages the samples that do exist — rather than going blank, but the 3d burn rate will read slightly optimistic during the ramp.

The companion change is in `giantswarm/sloth-rules` and should not merge until this has accumulated history.

## Verification

`promtool test rules` on the new unit test covers per-cluster separation, 5xx and 429 summing into the error rate, and the no-error-series case that keeps the `or` fallback intact. Full `make test` has not been run locally — CI will be the first pint/rules run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)