### PR TITLE
fix(kong): put runbook anchor after the query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the `KongOOMKill` runbook URL: the anchor was placed before the query string, so the runbook never received its variables.
+
 ## [4.117.0] - 2026-08-25
 
 ### Removed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -25,7 +25,7 @@ spec:
     - alert: KongOOMKill
       annotations:
         description: '{{`Kong container {{ $labels.namespace }}/{{ $labels.pod }}/{{ $labels.container }} is being OOMKilled.`}}'
-        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kong-debugging/#kongoomkill?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&POD={{ $labels.pod }}`}}'
+        runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kong-debugging/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&POD={{ $labels.pod }}#kongoomkill`}}'
       expr: kube_pod_container_status_restarts_total{namespace=~"kong.*"} - kube_pod_container_status_restarts_total{namespace=~"kong.*"} offset 1h >= 5 AND ignoring(reason) kube_pod_container_status_last_terminated_reason{namespace=~"kong.*", reason="OOMKilled"} > 0
       for: 10m
       labels:


### PR DESCRIPTION
The `KongOOMKill` `runbook_url` was:

```
.../runbooks/kong-debugging/#kongoomkill?INSTALLATION={{ $labels.installation }}&...
```

Everything after `#` is the fragment, so the parameter list never became a query string. The runbook page reads its variables from `window.location.search`, which was empty, so the on-call landed on a runbook with no values filled in.

Moved the anchor to the end, after the query string.

`make test-runbooks` passes. The check strips the query string before the fragment, so it was green either way.

Towards https://github.com/giantswarm/giantswarm/issues/37215