### PR TITLE
fix: narrow the DeploymentNotSatisfiedBumblebee namespace selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Narrow the `DeploymentNotSatisfiedBumblebee` namespace selector to `agent-platform`. The `agent.*-platform` pattern covered the migration window; every installation now runs the platform in `agent-platform`.
+
 ## [4.117.0] - 2026-08-25
 
 ### Removed

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/deployment.management-cluster.rules.yml
@@ -110,7 +110,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"agent.*-platform|kagent|mcp-kubernetes"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", namespace=~"agent-platform|kagent|mcp-kubernetes"} > 0
       for: 60m
       labels:
         area: platform


### PR DESCRIPTION
## Problem

The selector matched `agent.*-platform` so it covered both the old `agentic-platform` namespace and the new `agent-platform` while the fleet migrated. All 12 installations are cut over ([giantswarm#36869](https://github.com/giantswarm/giantswarm/issues/36869)) and the old namespace is deleted everywhere, so the wildcard now only widens the match for no reason.

## Change

Pin the selector to `agent-platform`.