### PR TITLE
fix: fix remaining tenet links to ops-recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Point the `IRSAClaimNotReady` and `CAPATooManyReconciliations` `runbook_url` annotations at their runbooks instead of the retired `ops-recipes` pages.
+- Fix remaining Tenet links to ops-recipes.
 
 ### Fixed
 

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/certificate.management-cluster.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: ManagementClusterCertificateIsMissing
       annotations:
         description: '{{`Cannot renew Certificate for Secret {{ $labels.exported_namespace }}/{{ $labels.certificatename }} on {{ $labels.cluster_id }} because it is missing.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/managed-app-cert-manager/missing-certificate-for-secret/
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/management-cluster-less-than-three-workers/
       expr: |
         count(
           cert_exporter_secret_not_after{cluster_type="management_cluster", secretkey="tls.crt", certificatename=~"^capa-serving-cert$|^capi-serving-cert$|^capi-kubeadm-bootstrap-serving-cert$|^capi-kubeadm-control-plane-serving-cert$|^capv-serving-cert$|^capmox-serving-cert$|^caip-in-cluster-serving-cert$|^capvcd-serving-cert$|^capz-serving-cert$|^azureserviceoperator-serving-cert$|^aws-pod-identity-webhook$"}

--- a/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
+++ b/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/management-cluster.rules.yml
@@ -13,7 +13,7 @@ spec:
     - alert: ManagementClusterHasLessThanThreeNodes
       annotations:
         description: '{{`Management cluster {{ $labels.cluster_id }} has less than 3 nodes.`}}'
-        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/management-cluster-less-than-three-workers/
+        runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/management-cluster-less-than-three-workers/
       expr: sum(kube_node_info{cluster_type="management_cluster"} * on (node) group_left kube_node_labels{nodepool=~".+",cluster_type="management_cluster"}) by (cluster_id, installation, pipeline, provider) < 3
       for: 1h
       labels:

--- a/test/tests/providers/global/kaas/tenet/alerting-rules/certificate.management-cluster.rules.test.yml
+++ b/test/tests/providers/global/kaas/tenet/alerting-rules/certificate.management-cluster.rules.test.yml
@@ -27,6 +27,6 @@ tests:
               topic: security
             exp_annotations:
               description: 'Cannot renew Certificate for Secret giantswarm/capa-serving-cert on gauss because it is missing.'
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/managed-app-cert-manager/missing-certificate-for-secret/
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/management-cluster-less-than-three-workers/
       - alertname: ManagementClusterCertificateIsMissing
         eval_time: 55m


### PR DESCRIPTION
Ops-recipes have all been migrated to runbooks.
These Tenet alerts were still pointing to old ops-recipes, resulting in failing CI checks.