### PR TITLE
feat(atlas): replace LoggingAgentDown with a node coverage alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ClusterInternetEgressUnavailable` alert (`severity: page`, 24/7) firing when at least 20% of a cluster's nodes cannot reach one of the probed internet domains.
+- Add `LoggingAgentMissingOnNode` alert (`severity: page`) firing when a node has no running `alloy-logs` pod.
 - Add `WorkloadClusterAuditLogVolumeSpike` alert (`severity: notify`, working hours only) firing when a single kube-apiserver user on a workload cluster sustains a high API audit event rate.
+
+### Removed
+
+- Remove `LoggingAgentDown` alert, superseded by `LoggingAgentMissingOnNode`.
 
 ### Changed
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/alloy.rules.yml
@@ -46,19 +46,25 @@ spec:
             cancel_if_outside_working_hours: "true"
     - name: alloy.logs
       rules:
-        # This alert lists the existing logging-agent pods (to extract the node label and inhibit if the node is not ready)
-        # and join the pods with the not running containers
-        - alert: LoggingAgentDown
+        # Every node is expected to run a logging agent.
+        - alert: LoggingAgentMissingOnNode
           annotations:
             __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
             dashboardQueryParams: "orgId=2"
-            description: '{{`Scraping of all logging-agent pods to check if one failed every 30 minutes.`}}'
+            description: '{{`Node {{ $labels.node }} has no running logging-agent pod, its logs are not being collected.`}}'
             runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+            summary: Node without a logging agent.
           expr: |-
-            kube_pod_info{pod=~"alloy-logs.*"}
-            * on(cluster_id, pod)
-              group_left ()
-              up{job="alloy-logs", container="alloy"} == 0
+            (
+              max by (cluster_id, cluster_type, installation, pipeline, provider, node) (kube_node_info)
+              unless on (cluster_id, node) (
+                kube_pod_info{pod=~"alloy-logs-.*"}
+                * on (cluster_id, pod)
+                  group_left ()
+                  (up{job="alloy-logs", container="alloy"} == 1)
+              )
+            )
+            and on (cluster_id) (count by (cluster_id) (up{job="alloy-logs"}) > 0)
           for: 30m
           labels:
             area: platform
@@ -68,6 +74,8 @@ spec:
             cancel_if_outside_working_hours: "true"
             cancel_if_node_unschedulable: "true"
             cancel_if_node_not_ready: "true"
+            cancel_if_kube_state_metrics_down: "true"
+            cancel_if_monitoring_agent_down: "true"
     - name: alloy.events
       rules:
         - alert: TracingAndEventAgentDown

--- a/test/tests/providers/global/platform/atlas/alerting-rules/alloy.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/alloy.rules.test.yml
@@ -69,66 +69,60 @@ tests:
       - alertname: AlloyUnhealthyComponents
         eval_time: 80m
 
-  # Test LoggingAgentDown
+  # Test LoggingAgentMissingOnNode
   - interval: 1m
     input_series:
-      # For the first 80min: test with 1 pod: none, up, down
-      - series: 'up{container="alloy", cluster_id="golem", cluster_type="management_cluster", installation="golem", job="alloy-logs", pod="alloy-logs-1xxxx", provider="capa", pipeline="testing"}'
-        values: "_x20 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="golem", cluster_type="management_cluster", installation="golem", pod="alloy-logs-1xxxx", node="ip-10-0-5-1.eu-west-1.compute.internal", provider="capa", pipeline="testing"}
+      # Node 1: healthy logging agent for the whole test, never alerts.
+      - series: 'kube_node_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", node="ip-10-0-5-1.eu-west-1.compute.internal"}'
         values: "1x180"
-      # From 80min: test with 2 pods: 1 up and 1 down, 2 up, 2 down.
-      - series: 'up{container="alloy", cluster_id="golem", cluster_type="management_cluster", installation="golem", job="alloy-logs", pod="alloy-logs-2xxxx", provider="capa", pipeline="testing"}'
-        values: "_x80 1+0x40 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="golem", cluster_type="management_cluster", installation="golem", pod="alloy-logs-2xxxx", node="ip-10-0-5-2.eu-west-1.compute.internal", provider="capa", pipeline="testing"}
+      - series: 'kube_pod_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-1xxxx", node="ip-10-0-5-1.eu-west-1.compute.internal"}'
         values: "1x180"
-      - series: 'up{container="alloy", cluster_type="management_cluster", cluster_id="golem", installation="golem", job="alloy-logs", pod="alloy-logs-3xxxx", provider="capa", pipeline="testing"}'
-        values: "_x80 0+0x40 1+0x20 0+0x40"
-      - series: kube_pod_info{cluster_id="golem", cluster_type="management_cluster", installation="golem", pod="alloy-logs-3xxxx", node="ip-10-0-5-3.eu-west-1.compute.internal", provider="capa", pipeline="testing"}
+      - series: 'up{container="alloy", job="alloy-logs", cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-1xxxx"}'
+        values: "1x180"
+      # Node 2: agent evicted at t=60, back at t=120. The pod object lingers, so kube_pod_info
+      # continues, but the pod leaves the Service endpoints so the `up` series stops rather than
+      # going to 0.
+      - series: 'kube_node_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", node="ip-10-0-5-2.eu-west-1.compute.internal"}'
+        values: "1x180"
+      - series: 'kube_pod_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-2xxxx", node="ip-10-0-5-2.eu-west-1.compute.internal"}'
+        values: "1x180"
+      - series: 'up{container="alloy", job="alloy-logs", cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-2xxxx"}'
+        values: "1+0x60 _x59 1+0x60"
+      # Node 3: never got a pod at all, e.g. a taint the DaemonSet does not tolerate.
+      # No kube_pod_info and no `up` series exist for it.
+      - series: 'kube_node_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", node="ip-10-0-5-3.eu-west-1.compute.internal"}'
+        values: "1x180"
+      # Node 4: pod stays in the endpoints but its scrape starts failing (up == 0) at t=60.
+      # A failing scrape must leave the node uncovered, same as a missing pod.
+      - series: 'kube_node_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", node="ip-10-0-5-4.eu-west-1.compute.internal"}'
+        values: "1x180"
+      - series: 'kube_pod_info{cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-4xxxx", node="ip-10-0-5-4.eu-west-1.compute.internal"}'
+        values: "1x180"
+      - series: 'up{container="alloy", job="alloy-logs", cluster_id="mycluster", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", pod="alloy-logs-4xxxx"}'
+        values: "1+0x60 0+0x119"
+      # A cluster running no logging agent at all. The guard must keep this quiet.
+      - series: 'kube_node_info{cluster_id="nologs", cluster_type="workload_cluster", installation="myinstall", provider="capa", pipeline="testing", node="ip-10-0-9-1.eu-west-1.compute.internal"}'
         values: "1x180"
     alert_rule_test:
-      - alertname: LoggingAgentDown
-        eval_time: 10m
-      - alertname: LoggingAgentDown
-        eval_time: 30m
-      - alertname: LoggingAgentDown
-        eval_time: 71m
+      # Node 3 is uncovered from the start but `for: 30m` has not elapsed yet.
+      - alertname: LoggingAgentMissingOnNode
+        eval_time: 20m
+      # Node 3 only. Node 2 is still healthy.
+      - alertname: LoggingAgentMissingOnNode
+        eval_time: 40m
         exp_alerts:
           - exp_labels:
               area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_node_unschedulable: "true"
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
               cancel_if_node_not_ready: "true"
-              cluster_id: golem
-              cluster_type: management_cluster
-              installation: golem
-              node: ip-10-0-5-1.eu-west-1.compute.internal
-              pipeline: testing
-              pod: alloy-logs-1xxxx
-              provider: capa
-              severity: page
-              team: atlas
-              topic: observability
-            exp_annotations:
-              __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
-              dashboardQueryParams: "orgId=2"
-              description: "Scraping of all logging-agent pods to check if one failed every 30 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=golem&CLUSTER=golem
-      # Tests with 2 pods
-      - alertname: LoggingAgentDown
-        eval_time: 111m
-        exp_alerts:
-          - exp_labels:
-              area: platform
-              cancel_if_outside_working_hours: "true"
               cancel_if_node_unschedulable: "true"
-              cancel_if_node_not_ready: "true"
-              cluster_id: golem
-              cluster_type: management_cluster
-              installation: golem
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
               node: ip-10-0-5-3.eu-west-1.compute.internal
               pipeline: testing
-              pod: alloy-logs-3xxxx
               provider: capa
               severity: page
               team: atlas
@@ -136,24 +130,26 @@ tests:
             exp_annotations:
               __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
               dashboardQueryParams: "orgId=2"
-              description: "Scraping of all logging-agent pods to check if one failed every 30 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=golem&CLUSTER=golem
-      - alertname: LoggingAgentDown
-        eval_time: 121m
-      - alertname: LoggingAgentDown
-        eval_time: 180m
+              description: "Node ip-10-0-5-3.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
+      # Node 2 (evicted), node 3 (never scheduled) and node 4 (scrape failing).
+      # The `nologs` cluster stays quiet.
+      - alertname: LoggingAgentMissingOnNode
+        eval_time: 110m
         exp_alerts:
           - exp_labels:
               area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_node_unschedulable: "true"
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
               cancel_if_node_not_ready: "true"
-              cluster_id: golem
-              cluster_type: management_cluster
-              installation: golem
+              cancel_if_node_unschedulable: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
               node: ip-10-0-5-2.eu-west-1.compute.internal
               pipeline: testing
-              pod: alloy-logs-2xxxx
               provider: capa
               severity: page
               team: atlas
@@ -161,19 +157,21 @@ tests:
             exp_annotations:
               __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
               dashboardQueryParams: "orgId=2"
-              description: "Scraping of all logging-agent pods to check if one failed every 30 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=golem&CLUSTER=golem
+              description: "Node ip-10-0-5-2.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
           - exp_labels:
               area: platform
-              cancel_if_outside_working_hours: "true"
-              cancel_if_node_unschedulable: "true"
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
               cancel_if_node_not_ready: "true"
-              cluster_id: golem
-              cluster_type: management_cluster
-              installation: golem
+              cancel_if_node_unschedulable: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
               node: ip-10-0-5-3.eu-west-1.compute.internal
               pipeline: testing
-              pod: alloy-logs-3xxxx
               provider: capa
               severity: page
               team: atlas
@@ -181,8 +179,79 @@ tests:
             exp_annotations:
               __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
               dashboardQueryParams: "orgId=2"
-              description: "Scraping of all logging-agent pods to check if one failed every 30 minutes."
-              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=golem&CLUSTER=golem
+              description: "Node ip-10-0-5-3.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
+          - exp_labels:
+              area: platform
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_node_not_ready: "true"
+              cancel_if_node_unschedulable: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
+              node: ip-10-0-5-4.eu-west-1.compute.internal
+              pipeline: testing
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
+              dashboardQueryParams: "orgId=2"
+              description: "Node ip-10-0-5-4.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
+      # Node 2 recovered at t=120. Nodes 3 and 4 are still uncovered.
+      - alertname: LoggingAgentMissingOnNode
+        eval_time: 160m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_node_not_ready: "true"
+              cancel_if_node_unschedulable: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
+              node: ip-10-0-5-3.eu-west-1.compute.internal
+              pipeline: testing
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
+              dashboardQueryParams: "orgId=2"
+              description: "Node ip-10-0-5-3.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
+          - exp_labels:
+              area: platform
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_node_not_ready: "true"
+              cancel_if_node_unschedulable: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: mycluster
+              cluster_type: workload_cluster
+              installation: myinstall
+              node: ip-10-0-5-4.eu-west-1.compute.internal
+              pipeline: testing
+              provider: capa
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              __dashboardUid__: 53c1ecddc3a1d5d4b8d6cd0c23676c31
+              dashboardQueryParams: "orgId=2"
+              description: "Node ip-10-0-5-4.eu-west-1.compute.internal has no running logging-agent pod, its logs are not being collected."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/alloy/?INSTALLATION=myinstall&CLUSTER=mycluster
+              summary: Node without a logging agent.
 
   # Test MonitoringAgentDown
   - interval: 1m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/shared-configs/pull/715

This PR replaces `LoggingAgentDown` with `LoggingAgentMissingOnNode`, which pages when a node has no
running `alloy-logs` pod.

## Why

`LoggingAgentDown` joined `kube_pod_info` against `up{job="alloy-logs"} == 0`. It needed an `up`
series to compare against zero — but `alloy-logs` is scraped through a **ServiceMonitor**, so
targets come from Endpoints. A pod that is evicted, Pending, or never scheduled leaves Endpoints
entirely, and its `up` series goes **absent, not `0`**. The join produced nothing, so the alert
could not fire. A node could stop shipping logs entirely with nothing firing, and this has been
observed on a production workload cluster where agents were evicted under node memory pressure.

`kube_daemonset_status_*` cannot close the gap either: `desiredNumberScheduled` counts only the
nodes a DaemonSet is *eligible* for, so a node carrying a taint the DaemonSet does not tolerate is
excluded from `desired` rather than reported as missing.

This matters now because of giantswarm/shared-configs#715, which enables Alloy node filtering.
Today clustering hides the gap: pod-log targets are sharded across agents by a hash ring and any
agent can tail any node's pods through the API, so an orphaned node is still collected. Node
filtering removes that failover and turns a missing agent into silent log loss.

## How

Coverage-based rather than liveness-based — it asks whether a node *has* a scrapeable agent, rather
than whether an agent's scrape is failing:

```
max by (...) (kube_node_info)
unless on (cluster_id, node) (
  kube_pod_info{pod=~"alloy-logs-.*"}
  * on (cluster_id, pod) group_left () (up{job="alloy-logs", container="alloy"} == 1)
)
and on (cluster_id) (count by (cluster_id) (up{job="alloy-logs"}) > 0)
```

- Uses the documented approach for per-cluster metric absence under Mimir (README, `Absent`
  function) rather than `absent()`, and follows the `<per-node> unless on (node) <per-node>` idiom
  already used by `WorkloadClusterControlPlaneNodeMissing`.
- `max by (...)` strips `kube_node_info`'s high-cardinality labels while keeping `node`, which the
  `cancel_if_node_*` inhibitions need — they match on `equal: [cluster_id, node]`.
- `up == 1`, so a pod that exists but fails scraping does not count as covering its node.
- The `and on (cluster_id)` guard limits the alert to clusters already running `alloy-logs`, so
  clusters with logging disabled and clusters mid-bootstrap stay quiet.
- `for: 30m` plus `cancel_if_node_unschedulable` / `cancel_if_node_not_ready` absorb node rolls.

`cancel_if_outside_working_hours: "true"`, as on the alert it replaces. Worth a reviewer's opinion:
silent log loss is unrecoverable beyond kubelet log retention, so `{{ include "workingHoursOnly" . }}`
would be defensible if we want this to wake on-call on `stable`.

## Why removing `LoggingAgentDown` is safe

Everything it caught, the new alert catches. A pod with `up == 0` fails the `up == 1` join, so its
node reports as uncovered and `LoggingAgentMissingOnNode` fires — at the same `for: 30m` and the
same severity. There is a dedicated test case for exactly this (node 4), so the claim is pinned
rather than asserted.

On-call loses the `pod` label and gains `node`, which is the more actionable of the two here.
Nothing else references the alert: no dashboards, no silences in `alerting-config`, no inhibition
config (it was only ever an inhibition *target*).

Both alerts go quiet if *every* `alloy-logs` pod in a cluster disappears — the old one for want of
an `up` series, the new one via the cluster guard. That is a cluster-wide outage already covered by
`LogForwardingErrors` and `KubeDaemonSetCreatedMetricMissing`, and paging once per node for it would
be worse. No regression, just unchanged.

**Why not an SLO:** this is a binary per-node coverage condition, not a success-ratio SLI. There is
no request stream to compute good/bad events over — a node either has a collector or it does not,
and any non-zero uncollected-node count is already a problem.

## Tests

Six cases: healthy node, evicted pod (`up` stops while `kube_pod_info` continues), never-scheduled
node, failing scrape (`up == 0`, the case the removed alert covered), the cluster-guard, and
recovery.

`make test-rules test_filter=alloy`, `make test-inhibitions` and `make test-runbooks` all pass.
`make pint PINT_TEAM_FILTER=atlas` reports one pre-existing unrelated failure (a LogQL expression in
`mimir.logs.yml` that pint parses as PromQL); no pint problems in `alloy.rules.yml`.

## Follow-ups, not in this PR

- `TracingAndEventAgentDown` has the identical absent-vs-zero blind spot for `alloy-events`.
- A `#loggingagentmissingonnode` section on the existing alloy runbook page.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) — reuses the existing Alloy logs dashboard (`53c1ecddc3a1d5d4b8d6cd0c23676c31`); a dedicated node-coverage panel may still be worth adding.
- [ ] Request review from oncall area, as well as team (`@giantswarm/team-atlas` + oncall area) — pending, PR is still a draft.
