### PR TITLE
chore: increase LokiRestartingTooOften threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `LokiRestartingTooOften` - increased threshold
+
 ## [4.118.0] - 2026-08-31
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/loki.rules.yml
@@ -19,7 +19,7 @@ spec:
       expr: |
         increase(
           kube_pod_container_status_restarts_total{cluster_type="management_cluster", namespace="loki"}[1h]
-        ) > 5
+        ) > 10
       for: 5m
       labels:
         area: platform


### PR DESCRIPTION
Receiving false alerts for Loki when we release changes, so let's align with the MimirRestartingTooOften threshold.