### PR TITLE
fix(cabbage): stop Envoy SDS timeout alerts paging for replaced pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `EnvoyProxySDSInitFetchTimeout` and `EnvoyProxyOAuth2SecretInitFetchTimeout` - no longer alert for proxy pods that no longer exist.
+
 ## [4.118.1] - 2026-09-03
 
 ### Changed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -157,6 +157,11 @@ spec:
       #   max_over_time(...[2h:1m])     holds the alert for 2h after the last increment. The wedge
       #     does not self-heal while the counter stays static, so a bare increase() would resolve
       #     after 15m with the proxy still broken.
+      #   and on(...) envoy_sds_init_fetch_timeout
+      #     drops the hold once the pod no longer exists. A still-wedged proxy stays Ready and
+      #     keeps exporting the counter, so this only removes series whose pod is gone — which is
+      #     exactly what restarting the pod (the documented fix) or a rollout does. Without it the
+      #     2h hold keeps paging for a proxy that was already replaced.
       # The oauth2/* exclusion keeps this alert on the TLS wedge it describes; OAuth2
       # client_secret/hmac_secret timeouts are a different failure, alerted separately.
       expr: |
@@ -167,6 +172,8 @@ spec:
             ) > 0
           )[2h:1m]
         )
+        and on(installation, cluster_id, namespace, pod)
+          envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"}
       for: 2m
       labels:
         area: platform
@@ -178,6 +185,8 @@ spec:
       annotations:
         description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching OAuth2 secret {{ $labels.envoy_xds_resource_name }} over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      # Same latching-counter handling as EnvoyProxySDSInitFetchTimeout above, including the
+      # on(...) guard that drops the 2h hold once the affected pod is gone.
       expr: |
         max_over_time(
           (
@@ -186,6 +195,8 @@ spec:
             ) > 0
           )[2h:1m]
         )
+        and on(installation, cluster_id, namespace, pod)
+          envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"}
       for: 5m
       labels:
         area: platform

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -76,6 +76,98 @@ tests:
       - alertname: EnvoyProxySDSInitFetchTimeout
         eval_time: 180m
 
+  # A proxy that wedged and was then REPLACED must stop paging immediately, even though the 2h
+  # max_over_time hold is still open. Restarting the pod is the documented fix, so once its series
+  # is gone there is nothing left to act on. A pod that is still wedged must keep paging.
+  - interval: 1m
+    input_series:
+      # wedged at 21m, then the pod is replaced and its series ends at 31m
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-replaced", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="myinstall", cluster_id="my-cluster"}'
+        values: "0x20 2x10"
+      # wedged at 21m and never restarted: still broken, must still page
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-internal-wedged", envoy_xds_resource_name="envoy-gateway-system/gateway-internal-https-tls", installation="myinstall", cluster_id="my-cluster"}'
+        values: "0x20 2+0x180"
+    alert_rule_test:
+      # both are wedged and both still exist: both page
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 25m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-replaced
+              envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
+              installation: myinstall
+              cluster_id: my-cluster
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-replaced timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-wedged
+              envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
+              installation: myinstall
+              cluster_id: my-cluster
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
+      # 45m: inside the 2h hold for both, but the replaced pod's series is gone, so only the
+      # still-wedged pod pages. Before the on(...) guard, both kept paging until 2h had passed.
+      - alertname: EnvoyProxySDSInitFetchTimeout
+        eval_time: 45m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "false"
+              namespace: envoy-gateway-system
+              pod: envoy-internal-wedged
+              envoy_xds_resource_name: envoy-gateway-system/gateway-internal-https-tls
+              installation: myinstall
+              cluster_id: my-cluster
+            exp_annotations:
+              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
+
+  # The same guard applies to the OAuth2 companion alert: a replaced pod stops notifying.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system", pod="envoy-external-replaced", envoy_xds_resource_name="oauth2/client_secret/dex-oauth2", installation="myinstall", cluster_id="my-cluster-2"}'
+        values: "0x20 1x10"
+    alert_rule_test:
+      # firing while the pod is still there (onset 21m + 5m for-window)
+      - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
+        eval_time: 28m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: notify
+              team: cabbage
+              topic: envoy-gateway
+              cancel_if_outside_working_hours: "true"
+              namespace: envoy-gateway-system
+              pod: envoy-external-replaced
+              envoy_xds_resource_name: oauth2/client_secret/dex-oauth2
+              installation: myinstall
+              cluster_id: my-cluster-2
+            exp_annotations:
+              description: "Envoy proxy envoy-external-replaced timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"
+      # pod replaced: cleared despite the 2h hold still being open
+      - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
+        eval_time: 45m
+
   # EnvoyProxyOAuth2SecretInitFetchTimeout: OAuth2 client/hmac secrets are a different (notify)
   # failure class and must not reach the paging alert.
   - interval: 1m


### PR DESCRIPTION
This PR stops `EnvoyProxySDSInitFetchTimeout` and `EnvoyProxyOAuth2SecretInitFetchTimeout` alerting for proxy pods that no longer exist.

## Why

`envoy_sds_init_fetch_timeout` is a latching counter, so #2097 added a `max_over_time(...[2h:1m])` hold to keep the alert up while a genuinely wedged proxy's counter sits static — a bare `increase()` would resolve after 15m with the proxy still broken.

That hold has no notion of pod lifetime. The documented remediation is *restarting the proxy pod*, and once that happens the pod's series goes stale — but the hold keeps the alert firing for the remainder of the 2h anyway. So the alert keeps paging precisely *after* the fix has been applied, and there is nothing an oncaller can act on.

This is not hypothetical, and not a per-cluster quirk. An `envoy-gateway` app rollout restarts the control plane, which wedges the existing proxies ([envoyproxy/gateway#9519](https://github.com/envoyproxy/gateway/issues/9519)), and the same rollout then replaces those very pods a minute or two later. The wedge is real but self-remediating, and the pages outlive it by ~2h. Sweeping the fleet during one such rollout today: **26 of 26 management clusters were firing, and every single firing series belonged to a pod that no longer existed — zero live wedged pods anywhere.** That is 100+ paging series, none actionable.

`severity: page` with `cancel_if_outside_working_hours: "false"` means this pages 24/7, fleet-wide.

## What changed

Both expressions now additionally require the pod to still be exporting the counter:

```promql
and on(installation, cluster_id, namespace, pod)
  envoy_sds_init_fetch_timeout{namespace="envoy-gateway-system"}
```

A wedged proxy stays `Ready` and keeps being scraped, so it keeps exporting the counter and keeps alerting — detection of the failure the alert exists for is unchanged. Only a pod whose series has gone stale drops out, which is exactly the state after a rollout or a manual restart.

## Alternatives dropped

- **Shorten or drop the 2h hold** — reintroduces the bug #2097 fixed: the alert would resolve after 15m with the proxy still wedged.
- **Join against `kube_pod_info`** — adds a cross-exporter dependency for something the metric itself already tells us.

## Trade-off

If proxy scraping breaks entirely, held alerts drop rather than persist. That seemed preferable to paging on pods that may not exist, and detecting absent scrape targets belongs in its own alert rather than as a side effect of this hold.

## Scope

Both alerts are fixed together: they are the same defect in the same expression pattern, introduced by the same mechanism, so fixing one would knowingly leave the other broken. `cancel_if_outside_working_hours: "false"` on the paging alert is left as-is — worth revisiting given the fleet-wide 24/7 blast radius, but that is a routing policy decision, not this bugfix.

## Tests

Added a case where two pods both wedge and one is then replaced: at 45m, inside the 2h hold, only the still-wedged pod alerts. Same for the OAuth2 companion.

Verified non-vacuous — with the guard stripped, both new 45m assertions FAIL. (`make test-rules` can't run end-to-end on macOS, so these were run with promtool against the templated `.spec` output, as the script does internally; CI `rules-tests` is green.)

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Consider [creating a dashboard](https://docs.giantswarm.io/tutorials/observability/data-exploration/creating-custom-dashboards/) — n/a, this reduces false alerts on existing rules and adds no new signal to monitor.
- [x] Request review from oncall area, as well as team — `team-cabbage` + `oncall-platform` (area: platform)
