### PR TITLE
fix(cabbage): make alert descriptions readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrote all cabbage alert descriptions to a single line naming what broke and where.
+
+### Fixed
+
+- `EnvoyHighDownstreamRequestTimeoutRate`, `EnvoyClusterCircuitBreakerTripped` and `EnvoyControllerNotReconcilingGateway` - descriptions no longer render a literal `\n` and a full label dump.
+- `CoreDNSMaxHPAReplicasReached` - description now names the HPA instead of rendering an empty deployment name.
+- `ExternalDNSCantAccessRegistry`, `ExternalDNSCantAccessSource` and `ExternalDNSDown` - removed a stray bracket from the descriptions.
+
 ## [4.119.1] - 2026-09-06
 
 ### Fixed

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/cilium.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: CiliumBPFMapAlmostFull
       annotations:
-        description: '{{`Cilium BPF map is about to fill up.`}}'
+        description: '{{`Cilium BPF map {{ $labels.map_name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is over 80% full.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-bpf-map/
       expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 80
       for: 15m
@@ -24,7 +24,7 @@ spec:
         topic: cilium
     - alert: CiliumBPFMapFull
       annotations:
-        description: '{{`Cilium BPF map is about filled up.`}}'
+        description: '{{`Cilium BPF map {{ $labels.map_name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} is over 95% full.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-bpf-map/
       expr: avg(cilium_bpf_map_pressure) by (cluster_id, installation, pipeline, provider, map_name) * 100 > 95
       for: 15m
@@ -35,7 +35,7 @@ spec:
         topic: cilium
     - alert: CiliumAPITooSlow
       annotations:
-        description: '{{`Cilium API processing time is >50s pod="{{ $labels.pod }}" node="{{ $labels.node }}" method="{{ $labels.method}}" path="{{ $labels.path }}"`}}'
+        description: '{{`Cilium API calls on {{ $labels.pod }} ({{ $labels.node }}) take over 50s: {{ $labels.method }} {{ $labels.path }}.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-performance-issues/#slow-cilium-api
       expr: avg(rate(cilium_agent_api_process_time_seconds_sum{}[5m])/rate(cilium_agent_api_process_time_seconds_count{}[5m]) > 50) by (cluster_id, node, pod, method, path, installation, pipeline, provider)
       for: 20m
@@ -47,7 +47,7 @@ spec:
         topic: cilium
     - alert: CiliumNetworkPolicyFailed
       annotations:
-        description: '{{`Too many Cilium Network Policy errors.`}}'
+        description: '{{`Cilium is failing to import network policies on {{ $labels.installation }}/{{ $labels.cluster_id }}.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/unsupported-cilium-network-policy/
       # cilium_policy_change_total - for cilium >=1.15
       # cilium_policy_import_errors_total - for cilium <1.15
@@ -106,7 +106,7 @@ spec:
         topic: cilium
     - alert: CiliumHubbleTLSCertificateWillExpireSoon
       annotations:
-        description: '{{`Hubble TLS certificate {{ $labels.secretkey }} in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} will expire in less than 30 days. Hubble certificate renewal is broken on this cluster; hubble-relay will lose flow data when the certificate expires.`}}'
+        description: '{{`Hubble TLS certificate {{ $labels.secretkey }} in Secret {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} expires in less than 30 days.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
       # Covers leaf certs (tls.crt) and the embedded Cilium CA copy (ca.crt) in the hubble secrets.
       # With the cronJob renewal method leafs are re-issued every 4 months with 12 months validity,
@@ -122,7 +122,7 @@ spec:
         topic: cilium
     - alert: CiliumHubbleCertificateRenewalJobFailed
       annotations:
-        description: '{{`Hubble certificate renewal job {{ $labels.namespace }}/{{ $labels.job_name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} failed. Certgen may be refusing to renew leaf certificates because the Cilium CA is close to expiry.`}}'
+        description: '{{`Hubble certificate renewal job {{ $labels.namespace }}/{{ $labels.job_name }} on {{ $labels.installation }}/{{ $labels.cluster_id }} failed.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
       expr: kube_job_failed{namespace="kube-system", job_name=~"hubble-generate-certs.*", condition="true"} == 1
       for: 15m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/coredns.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: CoreDNSDeploymentNotSatisfied
       annotations:
-        description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`CoreDNS Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has less than half of its replicas available.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
       expr: |
         sum(kube_deployment_status_replicas_available{namespace="kube-system", deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) / (sum(kube_deployment_status_replicas_available{namespace="kube-system", deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider) + sum(kube_deployment_status_replicas_unavailable{namespace="kube-system", deployment=~"coredns.*"}) by (cluster_id, deployment, installation, namespace, pipeline, provider))* 100 < 51
@@ -62,5 +62,5 @@ spec:
         team: cabbage
         topic: dns
       annotations:
-        description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled to its maximum replica count for too long.`}}'
+        description: '{{`CoreDNS HPA {{ $labels.namespace }}/{{ or $labels.horizontalpodautoscaler $labels.hpa }} has been at its maximum replica count for over 2h.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/coredns-max-replicas/

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/dns.rules.yml
@@ -25,7 +25,7 @@ spec:
         topic: network
     - alert: DNSCheckErrorRateTooHigh
       annotations:
-        description: '{{`DNS check error rate is too high for {{ or $labels.pod $labels.instance }}.`}}'
+        description: '{{`DNS check error rate for {{ or $labels.pod $labels.instance }} is {{ $value | printf "%.3f" }} errors/s.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/network-error/
       expr: rate(dns_error_total[15m]) > 0.015
       for: 15m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/envoy-gateway.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: EnvoyGatewayDeploymentNotSatisfied
       annotations:
-        description: '{{`Envoy Gateway Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`Envoy Gateway Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has less than half of its replicas available.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
       expr: kube_deployment_status_replicas_available{namespace="envoy-gateway-system", deployment="envoy-gateway"} / (kube_deployment_status_replicas_available{namespace="envoy-gateway-system", deployment="envoy-gateway"} + kube_deployment_status_replicas_unavailable{namespace="envoy-gateway-system", deployment="envoy-gateway"}) * 100 <= 50
       for: 10m
@@ -24,7 +24,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxyDeploymentNotSatisfied
       annotations:
-        description: '{{`Envoy Proxy Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`Envoy Proxy Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has less than half of its replicas available.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
       expr: envoy_proxy_deployment_status_replicas_available / (envoy_proxy_deployment_status_replicas_available + envoy_proxy_deployment_status_replicas_unavailable) * 100 <= 50
       for: 10m
@@ -36,7 +36,7 @@ spec:
         topic: envoy-gateway
     # - alert: EnvoyHighDownstreamHTTP5xxErrorRate
     #   annotations:
-    #     description: '{{`More than 5% of downstream HTTP responses are 5xx on {{ $labels.pod }} ({{ $value | printf "%.1f" }}%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+    #     description: '{{`More than 5% of downstream HTTP responses on {{ $labels.pod }} are 5xx ({{ $value | printf "%.1f" }}%).`}}'
     #     runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
     #   expr: |
     #     sum(
@@ -59,7 +59,7 @@ spec:
     #     topic: envoy-gateway
     # - alert: EnvoyHighClusterUpstream5xxErrorRate
     #   annotations:
-    #     description: '{{`More than 5% of upstream requests return 5xx in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+    #     description: '{{`More than 5% of upstream requests to Envoy cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }} return 5xx ({{ $value | printf "%.1f" }}%).`}}'
     #     runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
     #   expr: | 
     #     rate(
@@ -82,7 +82,7 @@ spec:
     #     topic: envoy-gateway
     - alert: EnvoyHighDownstreamRequestTimeoutRate
       annotations:
-        description: '{{`More than 10% of downstream requests timeout for gateway {{ $labels.gateway_name }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+        description: '{{`More than 10% of downstream requests to gateway {{ $labels.gateway_name }} are timing out ({{ $value | printf "%.1f" }}%).`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       expr: |
         sum(
@@ -102,7 +102,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyClusterCircuitBreakerTripped
       annotations:
-        description: '{{`Circuit breaker is open for cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+        description: '{{`Circuit breaker is open for Envoy cluster {{ $labels.envoy_cluster_name }} on {{ $labels.pod }}.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       expr: envoy_cluster_circuit_breakers_cx_open == 1 or envoy_cluster_circuit_breakers_rq_open == 1
       for: 10m
@@ -114,7 +114,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyControllerNotReconcilingGateway
       annotations:
-        description: '{{`Envoy Gateway controller is having issues reconciling {{ $labels.name }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`}}'
+        description: '{{`Envoy Gateway controller cannot reconcile Gateway {{ $labels.namespace }}/{{ $labels.name }}.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       expr: | 
           # Option A: accepted but config never reached the proxy
@@ -148,8 +148,11 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxySDSInitFetchTimeout
       annotations:
-        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching TLS secret {{ $labels.envoy_xds_resource_name }} over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519).`}}'
+        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching TLS secret {{ $labels.envoy_xds_resource_name }} over SDS; new TLS handshakes fail until the pod is restarted.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
+      # The wedged proxy keeps reporting Ready, so it does not self-heal: the pod must be restarted.
+      # This typically follows an Envoy Gateway control-plane restart (envoyproxy/gateway#9519).
+      #
       # envoy_sds_init_fetch_timeout is a latching counter: once incremented it stays >0 until the
       # pod restarts. A bare `> 0` therefore keeps paging for a timeout that may have happened days
       # ago and had no lasting impact, so trigger on a *fresh* increment instead:
@@ -183,7 +186,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxyOAuth2SecretInitFetchTimeout
       annotations:
-        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching OAuth2 secret {{ $labels.envoy_xds_resource_name }} over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted.`}}'
+        description: '{{`Envoy proxy {{ $labels.pod }} timed out fetching OAuth2 secret {{ $labels.envoy_xds_resource_name }} over SDS; OIDC authentication fails until the pod is restarted.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       # Same latching-counter handling as EnvoyProxySDSInitFetchTimeout above, including the
       # on(...) guard that drops the 2h hold once the affected pod is gone.
@@ -206,7 +209,7 @@ spec:
         topic: envoy-gateway
     - alert: EnvoyProxyListenersStuckWarming
       annotations:
-        description: '{{`Envoy proxy {{ $labels.pod }} has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives.`}}'
+        description: '{{`Envoy proxy {{ $labels.pod }} has listeners stuck warming for over 15m and is not serving its latest configuration.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}`}}'
       expr: envoy_listener_manager_total_listeners_warming{namespace="envoy-gateway-system"} > 0
       for: 15m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/external-dns.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: ExternalDNSCantAccessRegistry
       annotations:
-        description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access registry (cloud service provider DNS service).`}}'
+        description: '{{`external-dns in {{ $labels.namespace }} cannot access the provider DNS registry.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/external-dns-cant-access-registry/
       expr: rate(external_dns_registry_errors_total{provider=~"capa|capz|eks|aks"}[2m]) > 0
       for: 15m
@@ -24,7 +24,7 @@ spec:
         topic: external-dns
     - alert: ExternalDNSCantAccessSource
       annotations:
-        description: '{{`external-dns in namespace {{ $labels.namespace }}) can''t access source (Service or Ingress resource).`}}'
+        description: '{{`external-dns in {{ $labels.namespace }} cannot access Service and Ingress resources.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/external-dns-cant-access-source/
       expr: rate(external_dns_source_errors_total{provider=~"capa|capz|eks|aks"}[2m]) > 0
       for: 15m
@@ -36,7 +36,7 @@ spec:
         topic: external-dns
     - alert: ExternalDNSDown
       annotations:
-        description: '{{`external-dns in namespace {{ $labels.namespace }}) is down.`}}'
+        description: '{{`external-dns in {{ $labels.namespace }} is down.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/external-dns-down/
       expr: label_replace(up{container="external-dns", provider=~"capa|capz|eks|aks"}, "ip", "$1.$2.$3.$4", "node", "ip-(\\d+)-(\\d+)-(\\d+)-(\\d+).*") == 0
       for: 15m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/ingress-controller.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: IngressControllerDeploymentNotSatisfied
       annotations:
-        description: '{{`Ingress Controller Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`Ingress Controller Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has less than half of its replicas available.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/managed-app-nginx-ic/
       expr: managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} / (managed_app_deployment_status_replicas_available{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~".*(ingress-nginx|nginx-ingress-controller).*"}) * 100 <= 50
       for: 10m
@@ -24,7 +24,7 @@ spec:
         topic: ingress
     - alert: IngressControllerMemoryUsageTooHigh
       annotations:
-        description: '{{`Ingress Controller {{ $labels.pod }} memory usage is too high.`}}'
+        description: '{{`Ingress Controller {{ $labels.pod }} on {{ $labels.node }} is using {{ $value | printf "%.0f" }}% of node memory.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/managed-app-nginx-ic/
       expr: sum by (node, pod, cluster_id, installation, pipeline, provider) (container_memory_usage_bytes{pod=~".*(ingress-nginx|nginx-ingress-controller).*", container=""}) / ignoring (pod) group_left sum (node_memory_MemTotal_bytes) by (node, cluster_id, installation, pipeline, provider) * 100 > 33
       for: 3m
@@ -36,7 +36,7 @@ spec:
         topic: ingress
     - alert: IngressControllerReplicaSetNumberTooHigh
       annotations:
-        description: '{{`Ingress Controller in namespace {{ $labels.namespace}} has {{ $value }} replica sets.`}}'
+        description: '{{`Ingress Controller in namespace {{ $labels.namespace }} has {{ $value }} replica sets.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/high-number-replicasets/
       expr: count(kube_replicaset_spec_replicas{replicaset=~".*(ingress-nginx|nginx-ingress-controller).*"}) by (cluster_id, installation, pipeline, provider, namespace) > 15
       for: 2m
@@ -48,7 +48,7 @@ spec:
         topic: ingress
     - alert: IngressControllerServiceHasNoEndpoints
       annotations:
-        description: '{{`Ingress Controller has no live endpoints.`}}'
+        description: '{{`Ingress Controller on {{ $labels.installation }}/{{ $labels.cluster_id }} has no live endpoints.`}}'
         runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/ingress-controller-no-live-endpoints/
       expr: count by (cluster_id, installation, pipeline, provider) (kube_endpoint_address_available{endpoint=~".*(ingress-nginx|nginx-ingress-controller).*"}) == 0
       for: 2m

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/internet-egress.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/internet-egress.rules.yml
@@ -51,7 +51,7 @@ spec:
     - alert: ClusterInternetEgressUnavailable
       annotations:
         description: |-
-          {{`{{ $value | humanizePercentage }} of nodes on {{ $labels.installation }}/{{ $labels.cluster_id }} cannot reach {{ $labels.target }}. A single availability zone losing egress looks like 33-50% here. Other domains still reachable means an allowlist-style block of this domain rather than a full loss of egress.`}}
+          {{`{{ $value | humanizePercentage }} of nodes on {{ $labels.installation }}/{{ $labels.cluster_id }} cannot reach {{ $labels.target }}.`}}
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/internet-egress-unavailable/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
       expr: |
         (

--- a/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
+++ b/helm/prometheus-rules/templates/platform/cabbage/alerting-rules/kong.rules.yml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KongNonProdDeploymentNotSatisfied
       annotations:
-        description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`Kong Deployment {{ $labels.namespace }}/{{ $labels.deployment }} (non-production) has less than 60% of its replicas available.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
       expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id!~"p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id!~"p.*"}) < 0.6
       for: 30m
@@ -36,7 +36,7 @@ spec:
         topic: kong
     - alert: KongProductionDeploymentNotSatisfied
       annotations:
-        description: '{{`Kong Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        description: '{{`Kong Deployment {{ $labels.namespace }}/{{ $labels.deployment }} (production) has less than 60% of its replicas available.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/deployment-not-satisfied/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.namespace }}&KIND=deployment&NAME={{ $labels.deployment }}`}}'
       expr: managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"p.*"} / (managed_app_deployment_status_replicas_available{managed_app=~"kong.*", cluster_id=~"p.*"} + managed_app_deployment_status_replicas_unavailable{managed_app=~"kong.*", cluster_id=~"p.*"}) < 0.6
       for: 30m

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -15,7 +15,6 @@ platform/atlas/alerting-rules/storage.rules.yml
 platform/atlas/recording-rules/grafana-cloud.rules.yml
 platform/atlas/recording-rules/loki-mixins.rules.yml
 platform/atlas/recording-rules/mimir-mixins.rules.yml
-platform/cabbage/alerting-rules/coredns.rules.yml
 platform/cabbage/alerting-rules/external-dns.rules.yml
 platform/cabbage/alerting-rules/dns.rules.yml
 platform/cabbage/recording-rules/gs-managed-app-deployment-status.rules.yml

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/cilium.rules.test.yml
@@ -6,7 +6,7 @@ tests:
   - interval: 1m
     input_series:
       # For the first 60min: test with 1 pod: none, up, down
-      - series: 'cilium_bpf_map_pressure{map_name="policy_00001"}'
+      - series: 'cilium_bpf_map_pressure{map_name="policy_00001", installation="alba", cluster_id="odp01"}'
         values: "_x20 20+0x20 90+0x20"
     alert_rule_test:
       - alertname: CiliumBPFMapAlmostFull
@@ -23,12 +23,14 @@ tests:
               topic: cilium
               cancel_if_outside_working_hours: "true"
               map_name: "policy_00001"
+              installation: alba
+              cluster_id: odp01
             exp_annotations:
-              description: "Cilium BPF map is about to fill up."
+              description: "Cilium BPF map policy_00001 on alba/odp01 is over 80% full."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-bpf-map/
   - interval: 1m
     input_series:
-      - series: 'cilium_bpf_map_pressure{map_name="policy_00001"}'
+      - series: 'cilium_bpf_map_pressure{map_name="policy_00001", installation="alba", cluster_id="odp01"}'
         values: "_x20 20+0x20 90+0x20 98+0x20"
     alert_rule_test:
       - alertname: CiliumBPFMapFull
@@ -44,18 +46,20 @@ tests:
               team: cabbage
               topic: cilium
               map_name: "policy_00001"
+              installation: alba
+              cluster_id: odp01
             exp_annotations:
-              description: "Cilium BPF map is about filled up."
+              description: "Cilium BPF map policy_00001 on alba/odp01 is over 95% full."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-bpf-map/
   # CiliumNetworkPolicyFailed for 1.15+ (cilium_policy_change_total{outcome="fail.*"})
   - interval: 1m
     input_series:
       # For the first 60min: test with 1 pod: none, up, down
-      - series: 'cilium_policy_change_total{outcome="fail"}'
+      - series: 'cilium_policy_change_total{outcome="fail", installation="alba", cluster_id="odp01"}'
         values: "_x20 0+0x20 0+100x30 _x1000"
-      - series: 'cilium_policy_change_total{outcome="success"}'
+      - series: 'cilium_policy_change_total{outcome="success", installation="alba", cluster_id="odp01"}'
         values: "_x120 1+10000x50 _x1000"
-      - series: 'cilium_policy_import_errors_total{}'
+      - series: 'cilium_policy_import_errors_total{installation="alba", cluster_id="odp01"}'
         values: "_x220 0+0x20 0+100x30 _x1000"
     alert_rule_test:
       # cilium_policy_change_total{outcome="fail"}
@@ -72,8 +76,10 @@ tests:
               team: cabbage
               topic: cilium
               cancel_if_outside_working_hours: "true"
+              installation: alba
+              cluster_id: odp01
             exp_annotations:
-              description: "Too many Cilium Network Policy errors."
+              description: "Cilium is failing to import network policies on alba/odp01."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/unsupported-cilium-network-policy/
       # cilium_policy_change_total{outcome="success"}
       - alertname: CiliumNetworkPolicyFailed
@@ -96,8 +102,10 @@ tests:
               team: cabbage
               topic: cilium
               cancel_if_outside_working_hours: "true"
+              installation: alba
+              cluster_id: odp01
             exp_annotations:
-              description: "Too many Cilium Network Policy errors."
+              description: "Cilium is failing to import network policies on alba/odp01."
               runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/unsupported-cilium-network-policy/
   # CiliumHubbleTLSCertificateWillExpireSoon
   - interval: 1m
@@ -126,7 +134,7 @@ tests:
               installation: alba
               cluster_id: odp01
             exp_annotations:
-              description: "Hubble TLS certificate tls.crt in Secret kube-system/hubble-server-certs on alba/odp01 will expire in less than 30 days. Hubble certificate renewal is broken on this cluster; hubble-relay will lose flow data when the certificate expires."
+              description: "Hubble TLS certificate tls.crt in Secret kube-system/hubble-server-certs on alba/odp01 expires in less than 30 days."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION=alba&CLUSTER=odp01"
   # CiliumHubbleCertificateRenewalJobFailed
   - interval: 1m
@@ -158,5 +166,5 @@ tests:
               installation: alba
               cluster_id: odp01
             exp_annotations:
-              description: "Hubble certificate renewal job kube-system/hubble-generate-certs-a1b2c on alba/odp01 failed. Certgen may be refusing to renew leaf certificates because the Cilium CA is close to expiry."
+              description: "Hubble certificate renewal job kube-system/hubble-generate-certs-a1b2c on alba/odp01 failed."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/cilium-hubble-tls-certificates/?INSTALLATION=alba&CLUSTER=odp01"

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/coredns.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/coredns.rules.test.yml
@@ -1,0 +1,52 @@
+---
+rule_files:
+  - coredns.rules.yml
+tests:
+  # old kube-state-metrics metric names (hpa label)
+  - interval: 1m
+    input_series:
+      - series: 'kube_hpa_status_current_replicas{namespace="kube-system", hpa="coredns"}'
+        values: "10+0x200"
+      - series: 'kube_hpa_spec_max_replicas{namespace="kube-system", hpa="coredns"}'
+        values: "10+0x200"
+      - series: 'kube_hpa_spec_min_replicas{namespace="kube-system", hpa="coredns"}'
+        values: "2+0x200"
+    alert_rule_test:
+      - alertname: CoreDNSMaxHPAReplicasReached
+        eval_time: 150m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: dns
+              cancel_if_outside_working_hours: "true"
+              namespace: kube-system
+              hpa: coredns
+            exp_annotations:
+              description: "CoreDNS HPA kube-system/coredns has been at its maximum replica count for over 2h."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/coredns-max-replicas/
+  # new kube-state-metrics metric names (horizontalpodautoscaler label)
+  - interval: 1m
+    input_series:
+      - series: 'kube_horizontalpodautoscaler_status_current_replicas{namespace="kube-system", horizontalpodautoscaler="coredns"}'
+        values: "10+0x200"
+      - series: 'kube_horizontalpodautoscaler_spec_max_replicas{namespace="kube-system", horizontalpodautoscaler="coredns"}'
+        values: "10+0x200"
+      - series: 'kube_horizontalpodautoscaler_spec_min_replicas{namespace="kube-system", horizontalpodautoscaler="coredns"}'
+        values: "2+0x200"
+    alert_rule_test:
+      - alertname: CoreDNSMaxHPAReplicasReached
+        eval_time: 150m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              severity: page
+              team: cabbage
+              topic: dns
+              cancel_if_outside_working_hours: "true"
+              namespace: kube-system
+              horizontalpodautoscaler: coredns
+            exp_annotations:
+              description: "CoreDNS HPA kube-system/coredns has been at its maximum replica count for over 2h."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/coredns-max-replicas/

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/envoy-gateway.rules.test.yml
@@ -34,7 +34,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS; new TLS handshakes fail until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # still firing well after the 15m increase() window closed, thanks to the 2h max_over_time hold
       - alertname: EnvoyProxySDSInitFetchTimeout
@@ -52,7 +52,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-abc timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS; new TLS handshakes fail until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # the 2h hold has expired and the counter never incremented again: the alert self-clears.
       # The state-based backstop for a proxy that is still wedged is a separate alert.
@@ -104,7 +104,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-replaced timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-replaced timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS; new TLS handshakes fail until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
           - exp_labels:
               area: platform
@@ -118,7 +118,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS; new TLS handshakes fail until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
       # 45m: inside the 2h hold for both, but the replaced pod's series is gone, so only the
       # still-wedged pod pages. Before the on(...) guard, both kept paging until 2h had passed.
@@ -137,7 +137,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS within the last 15m. New TLS handshakes on its listeners fail while the pod still reports Ready, so it will not self-heal — the proxy pod must be restarted. Typically follows an Envoy Gateway control-plane restart (see envoyproxy/gateway#9519)."
+              description: "Envoy proxy envoy-internal-wedged timed out fetching TLS secret envoy-gateway-system/gateway-internal-https-tls over SDS; new TLS handshakes fail until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # The same guard applies to the OAuth2 companion alert: a replaced pod stops notifying.
@@ -162,7 +162,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster-2
             exp_annotations:
-              description: "Envoy proxy envoy-external-replaced timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
+              description: "Envoy proxy envoy-external-replaced timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS; OIDC authentication fails until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"
       # pod replaced: cleared despite the 2h hold still being open
       - alertname: EnvoyProxyOAuth2SecretInitFetchTimeout
@@ -194,7 +194,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster-2
             exp_annotations:
-              description: "Envoy proxy envoy-external-def timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS within the last 15m. OIDC authentication on the routes covered by that SecurityPolicy may fail until the proxy pod is restarted."
+              description: "Envoy proxy envoy-external-def timed out fetching OAuth2 secret oauth2/client_secret/dex-oauth2 over SDS; OIDC authentication fails until the pod is restarted."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster-2&NAMESPACE=envoy-gateway-system"
       # an OAuth2 secret must never trigger the paging TLS alert
       - alertname: EnvoyProxySDSInitFetchTimeout
@@ -226,7 +226,7 @@ tests:
               installation: myinstall
               cluster_id: my-cluster
             exp_annotations:
-              description: "Envoy proxy envoy-internal-abc has had listeners stuck in warming state for over 15m, so its latest configuration is not being served (it may still be serving the previous config). A persistently warming listener that never becomes active points at an xDS resource (e.g. an SDS secret) that never arrives."
+              description: "Envoy proxy envoy-internal-abc has listeners stuck warming for over 15m and is not serving its latest configuration."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/envoy-gateway/?INSTALLATION=myinstall&CLUSTER=my-cluster&NAMESPACE=envoy-gateway-system"
 
   # EnvoyGatewayConfigUpdateRateTooHigh: Gateway API resource churn on the control plane.

--- a/test/tests/providers/global/platform/cabbage/alerting-rules/internet-egress.rules.test.yml
+++ b/test/tests/providers/global/platform/cabbage/alerting-rules/internet-egress.rules.test.yml
@@ -38,7 +38,7 @@ tests:
         eval_time: 30m
         exp_alerts:
           - exp_annotations:
-              description: "37.5% of nodes on myinstall/myinstall cannot reach http-giantswarm. A single availability zone losing egress looks like 33-50% here. Other domains still reachable means an allowlist-style block of this domain rather than a full loss of egress."
+              description: "37.5% of nodes on myinstall/myinstall cannot reach http-giantswarm."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/internet-egress-unavailable/?INSTALLATION=myinstall&CLUSTER=myinstall"
             exp_labels:
               alertname: "ClusterInternetEgressUnavailable"
@@ -80,7 +80,7 @@ tests:
         eval_time: 30m
         exp_alerts:
           - exp_annotations:
-              description: "100% of nodes on myinstall/myinstall cannot reach http-giantswarm. A single availability zone losing egress looks like 33-50% here. Other domains still reachable means an allowlist-style block of this domain rather than a full loss of egress."
+              description: "100% of nodes on myinstall/myinstall cannot reach http-giantswarm."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/internet-egress-unavailable/?INSTALLATION=myinstall&CLUSTER=myinstall"
             exp_labels:
               alertname: "ClusterInternetEgressUnavailable"
@@ -173,7 +173,7 @@ tests:
         eval_time: 30m
         exp_alerts:
           - exp_annotations:
-              description: "100% of nodes on myinstall/myinstall cannot reach egress-github. A single availability zone losing egress looks like 33-50% here. Other domains still reachable means an allowlist-style block of this domain rather than a full loss of egress."
+              description: "100% of nodes on myinstall/myinstall cannot reach egress-github."
               runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/internet-egress-unavailable/?INSTALLATION=myinstall&CLUSTER=myinstall"
             exp_labels:
               alertname: "ClusterInternetEgressUnavailable"


### PR DESCRIPTION
Cabbage alert descriptions had drifted in both directions. Some carried three sentences of root cause, remediation and upstream links; others said no more than "Cilium BPF map is about to fill up" while the query already grouped by the map name. `EnvoyProxySDSInitFetchTimeout` was the clearest case: every firing series repeated a paragraph explaining the upstream bug, so a wedge affecting two proxies and two secrets produced four long paragraphs an oncaller had to read past to find the pod names.

This settles on one rule: a description is a single line naming what broke and where. Anything the oncaller has to *do* or *understand* belongs in the runbook, which all of these already link. Nothing was simply deleted. The `envoyproxy/gateway#9519` reference and the "the proxy stays Ready so it will not self-heal" detail moved into the comment above the SDS query, and the egress interpretation guidance was already in that rule's comment block.

Three descriptions were also rendering wrong, which is what prompted looking at the rest.

`EnvoyHighDownstreamRequestTimeoutRate`, `EnvoyClusterCircuitBreakerTripped` and `EnvoyControllerNotReconcilingGateway` all ended in `\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}`. In a single-quoted YAML scalar `\n` is a literal backslash-n rather than a line break, so it never broke the line, and `{{ $labels }}` dumped the whole Go label map inline after it. The two commented-out `Envoy*5xxErrorRate` rules had the same tail and would have shipped it if uncommented, so they are fixed too.

`CoreDNSMaxHPAReplicasReached` read `CoreDNS Deployment {{ $labels.namespace }}/{{ $labels.deployment }}`, but its query is built on `kube_hpa_*` / `kube_horizontalpodautoscaler_*`, which never produce a `deployment` label. It rendered with an empty name. It now uses `{{ or $labels.horizontalpodautoscaler $labels.hpa }}`, covering both kube-state-metrics metric generations the query already handles, and matching the `or` idiom `dns.rules.yml` uses.

The three external-dns descriptions carried a stray closing bracket: `external-dns in namespace {{ $labels.namespace }}) is down.`

Beyond that: the two Kong deployment alerts had byte-identical descriptions, so a page could not tell you which fired; `CiliumBPFMapAlmostFull` and `CiliumBPFMapFull` dropped the `map_name` their queries group by, and the latter said "is about filled up"; and "is not satisfied" appeared in five alerts as internal jargon for "fewer than half the replicas are available".

Two notes on the tests.

The cilium BPF-map and network-policy input series had no `installation` or `cluster_id` labels, so the new descriptions would have asserted against `on /`. Those labels are now on the input series and on `exp_labels`.

`coredns.rules.yml` was in `test/conf/promtool_ignore`, meaning the HPA bug above had no coverage at all. It is delisted and now has a test covering `CoreDNSMaxHPAReplicasReached` under both metric names. This is slightly wider than a description cleanup and is easy to drop if reviewers would rather keep it separate. The remaining cabbage gaps are untouched and pre-existing: `dns.rules.yml`, `external-dns.rules.yml` and the recording rules stay in `promtool_ignore`, and `kong.rules.yml` is checked but has no test file.

No alert query, threshold, severity or routing label changes, so nothing changes about what fires or who it wakes.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider creating a dashboard — not applicable, no new alerts
- [ ] Request review from oncall area, as well as team
