### PR TITLE
fix(bumblebee): keep agent platform alerts stable across exporter pod replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AgentPlatformHelmReleaseNotReady` and `KagentControllerDown` no longer resolve and re-fire when the `flux-ksm` or `kube-state-metrics` pod is replaced.
+
 ## [4.119.0] - 2026-09-06
 
 ### Added

--- a/helm/prometheus-rules/templates/platform/bumblebee/alerting-rules/agent-platform.rules.yml
+++ b/helm/prometheus-rules/templates/platform/bumblebee/alerting-rules/agent-platform.rules.yml
@@ -30,12 +30,21 @@ spec:
     # agent-platform-connectivity, agent-platform-mcps, muster, klaus-gateway,
     # valkey, dicebear) and the stand-alone ones in flux-giantswarm (tunnelport,
     # mcp-kubernetes, mcp-capi, sre-agent, backstage) resolve to bumblebee.
+    #
+    # The alerts aggregate the exporter's series down to the labels that
+    # routing, the description and the runbook URL use. Scrape-target labels
+    # such as `pod` and `instance` would otherwise be part of the alert's
+    # identity, and every replacement of the flux-ksm or kube-state-metrics
+    # pod would resolve the alert and open a new one. `max by` rather than
+    # `max without`, so that a new exporter label cannot creep back in.
     - alert: AgentPlatformHelmReleaseNotReady
       annotations:
         description: '{{`Agent platform HelmRelease {{ $labels.exported_namespace }}/{{ $labels.name }} on {{ $labels.installation }} has not been Ready for over an hour.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/agent-platform-helmrelease-not-ready/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}&NAMESPACE={{ $labels.exported_namespace }}&HELMRELEASE_NAME={{ $labels.name }}`}}'
       expr: |
-        gotk_resource_info{job="flux-ksm", ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace="flux-giantswarm", team="bumblebee"} > 0
+        max by (cluster_id, cluster_type, installation, pipeline, provider, exported_namespace, name, team, ready) (
+          gotk_resource_info{job="flux-ksm", ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace="flux-giantswarm", team="bumblebee"}
+        ) > 0
         unless on (cluster_id, exported_namespace, name)
         ALERTS{alertname="FluxGiantswarmHelmReleaseFailed", team="bumblebee", pipeline=~"stable|stable-testing"}
       for: 1h
@@ -55,7 +64,9 @@ spec:
         description: '{{`kagent-controller in {{ $labels.namespace }} on {{ $labels.installation }} has had no available replica for 30 minutes; agents on this installation are down.`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kagent-controller-down/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
       expr: |
-        kube_deployment_status_replicas_available{cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller"} == 0
+        max by (cluster_id, cluster_type, installation, pipeline, provider, namespace, deployment) (
+          kube_deployment_status_replicas_available{cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller"}
+        ) == 0
         and on (cluster_id, namespace, deployment)
         kube_deployment_spec_replicas{cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller"} > 0
         unless on (cluster_id, namespace, deployment)

--- a/test/tests/providers/global/platform/bumblebee/alerting-rules/agent-platform.rules.test.yml
+++ b/test/tests/providers/global/platform/bumblebee/alerting-rules/agent-platform.rules.test.yml
@@ -35,12 +35,67 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: graveler
               cluster_type: management_cluster
-              customresource_kind: HelmRelease
               exported_namespace: flux-giantswarm
               installation: graveler
-              job: flux-ksm
               name: kagent
-              namespace: flux-giantswarm
+              pipeline: testing
+              provider: $provider
+              ready: "False"
+              severity: page
+              team: bumblebee
+              topic: agent-platform
+            exp_annotations:
+              description: "Agent platform HelmRelease flux-giantswarm/kagent on graveler has not been Ready for over an hour."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/agent-platform-helmrelease-not-ready/?INSTALLATION=graveler&CLUSTER=graveler&NAMESPACE=flux-giantswarm&HELMRELEASE_NAME=kagent"
+  # flux-ksm is rescheduled while the HelmRelease is not Ready: the old pod's
+  # series ends and the new pod's begins with different `pod` and `instance`
+  # labels. The alert keeps its identity across the hand-over and stays firing
+  # instead of resolving and starting its `for` period over.
+  - interval: 1m
+    input_series:
+      - series: 'gotk_resource_info{job="flux-ksm", ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace="flux-giantswarm", name="kagent", team="bumblebee", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", namespace="flux-giantswarm", service="flux-giantswarm-flux-ksm", pod="flux-giantswarm-flux-ksm-5d8c7b9f4-aaaaa", endpoint="http", container="kube-state-metrics", instance="10.0.0.1:8080", node="ip-10-0-0-1.eu-west-1.compute.internal"}'
+        values: "1x70 _x50"
+      - series: 'gotk_resource_info{job="flux-ksm", ready="False", customresource_kind="HelmRelease", cluster_type="management_cluster", exported_namespace="flux-giantswarm", name="kagent", team="bumblebee", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", namespace="flux-giantswarm", service="flux-giantswarm-flux-ksm", pod="flux-giantswarm-flux-ksm-5d8c7b9f4-bbbbb", endpoint="http", container="kube-state-metrics", instance="10.0.0.2:8080", node="ip-10-0-0-2.eu-west-1.compute.internal"}'
+        values: "_x67 1x53"
+    alert_rule_test:
+      # Firing from the first pod alone.
+      - alertname: AgentPlatformHelmReleaseNotReady
+        eval_time: 65m
+        exp_alerts:
+          - exp_labels:
+              alertname: AgentPlatformHelmReleaseNotReady
+              all_pipelines: "true"
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: graveler
+              cluster_type: management_cluster
+              exported_namespace: flux-giantswarm
+              installation: graveler
+              name: kagent
+              pipeline: testing
+              provider: $provider
+              ready: "False"
+              severity: page
+              team: bumblebee
+              topic: agent-platform
+            exp_annotations:
+              description: "Agent platform HelmRelease flux-giantswarm/kagent on graveler has not been Ready for over an hour."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/agent-platform-helmrelease-not-ready/?INSTALLATION=graveler&CLUSTER=graveler&NAMESPACE=flux-giantswarm&HELMRELEASE_NAME=kagent"
+      # Only the second pod's series exists now. Had `pod` been part of the
+      # alert's labels, the alert would be pending here until 128m.
+      - alertname: AgentPlatformHelmReleaseNotReady
+        eval_time: 75m
+        exp_alerts:
+          - exp_labels:
+              alertname: AgentPlatformHelmReleaseNotReady
+              all_pipelines: "true"
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: graveler
+              cluster_type: management_cluster
+              exported_namespace: flux-giantswarm
+              installation: graveler
+              name: kagent
               pipeline: testing
               provider: $provider
               ready: "False"
@@ -81,12 +136,9 @@ tests:
               cancel_if_outside_working_hours: "true"
               cluster_id: gazelle
               cluster_type: management_cluster
-              customresource_kind: HelmRelease
               exported_namespace: flux-giantswarm
               installation: gazelle
-              job: flux-ksm
               name: agent-platform-connectivity
-              namespace: flux-giantswarm
               pipeline: stable
               provider: $provider
               ready: "False"
@@ -126,7 +178,6 @@ tests:
               cluster_type: management_cluster
               deployment: kagent-controller
               installation: graveler
-              job: kube-state-metrics
               namespace: kagent
               pipeline: testing
               provider: $provider
@@ -150,7 +201,65 @@ tests:
               cluster_type: management_cluster
               deployment: kagent-controller
               installation: graveler
-              job: kube-state-metrics
+              namespace: kagent
+              pipeline: testing
+              provider: $provider
+              severity: page
+              team: bumblebee
+              topic: agent-platform
+            exp_annotations:
+              description: "kagent-controller in kagent on graveler has had no available replica for 30 minutes; agents on this installation are down."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kagent-controller-down/?INSTALLATION=graveler&CLUSTER=graveler"
+  # kube-state-metrics is rescheduled during the outage: the old pod's series
+  # end and the new pod's begin with different `pod` and `instance` labels. The
+  # alert keeps its identity across the hand-over and stays firing.
+  - interval: 1m
+    input_series:
+      - series: 'kube_deployment_status_replicas_available{job="kube-state-metrics", cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", service="kube-prometheus-stack-kube-state-metrics", pod="kube-prometheus-stack-kube-state-metrics-7c9d8f6b5-aaaaa", endpoint="http", container="kube-state-metrics", instance="10.0.0.1:8080", node="ip-10-0-0-1.eu-west-1.compute.internal"}'
+        values: "0x40 _x40"
+      - series: 'kube_deployment_spec_replicas{job="kube-state-metrics", cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", service="kube-prometheus-stack-kube-state-metrics", pod="kube-prometheus-stack-kube-state-metrics-7c9d8f6b5-aaaaa", endpoint="http", container="kube-state-metrics", instance="10.0.0.1:8080", node="ip-10-0-0-1.eu-west-1.compute.internal"}'
+        values: "1x40 _x40"
+      - series: 'kube_deployment_status_replicas_available{job="kube-state-metrics", cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", service="kube-prometheus-stack-kube-state-metrics", pod="kube-prometheus-stack-kube-state-metrics-7c9d8f6b5-bbbbb", endpoint="http", container="kube-state-metrics", instance="10.0.0.2:8080", node="ip-10-0-0-2.eu-west-1.compute.internal"}'
+        values: "_x37 0x43"
+      - series: 'kube_deployment_spec_replicas{job="kube-state-metrics", cluster_type="management_cluster", namespace="kagent", deployment="kagent-controller", cluster_id="graveler", installation="graveler", pipeline="testing", provider="$provider", service="kube-prometheus-stack-kube-state-metrics", pod="kube-prometheus-stack-kube-state-metrics-7c9d8f6b5-bbbbb", endpoint="http", container="kube-state-metrics", instance="10.0.0.2:8080", node="ip-10-0-0-2.eu-west-1.compute.internal"}'
+        values: "_x37 1x43"
+    alert_rule_test:
+      # Firing from the first pod alone.
+      - alertname: KagentControllerDown
+        eval_time: 35m
+        exp_alerts:
+          - exp_labels:
+              alertname: KagentControllerDown
+              all_pipelines: "true"
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: graveler
+              cluster_type: management_cluster
+              deployment: kagent-controller
+              installation: graveler
+              namespace: kagent
+              pipeline: testing
+              provider: $provider
+              severity: page
+              team: bumblebee
+              topic: agent-platform
+            exp_annotations:
+              description: "kagent-controller in kagent on graveler has had no available replica for 30 minutes; agents on this installation are down."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/kagent-controller-down/?INSTALLATION=graveler&CLUSTER=graveler"
+      # Only the second pod's series exist now. Had `pod` been part of the
+      # alert's labels, the alert would be pending here until 68m.
+      - alertname: KagentControllerDown
+        eval_time: 45m
+        exp_alerts:
+          - exp_labels:
+              alertname: KagentControllerDown
+              all_pipelines: "true"
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: graveler
+              cluster_type: management_cluster
+              deployment: kagent-controller
+              installation: graveler
               namespace: kagent
               pipeline: testing
               provider: $provider


### PR DESCRIPTION
Towards: https://github.com/giantswarm/prometheus-rules/issues/2154

`AgentPlatformHelmReleaseNotReady` and `KagentControllerDown` alerted directly on `gotk_resource_info` and `kube_deployment_status_replicas_available`, so every label of the scraped series was part of the alert's identity, including the exporter's scrape-target labels `pod`, `instance`, `endpoint`, `service`, `container` and `node`. Whenever flux-ksm or kube-state-metrics was rescheduled (node rotation, restart), the old series ended and a new one began under a different `pod`/`instance`: the alert resolved, went pending again for the full `for` period and fired again. Alertmanager groups by `alertname, cluster_id, installation, status, team`, so one outage turned into a RESOLVED/FIRING pair per exporter replacement and, once routed to PagerDuty, a new incident each time.

The generic alerts these two defer to have the same weakness on the same installations: on graveler a single ten-day outage produced more than 30 notifications in 48 hours, with six `ALERTS` series for one HelmRelease differing only in the flux-ksm pod. That part is owned by honeybadger and atlas and is tracked in the linked issue; this PR only fixes Bumblebee's file, which shipped with the same shape in v4.119.0.

### What changed

Both expressions now aggregate with `max by (...)` down to the labels that routing, the description and the runbook URL use:

- `AgentPlatformHelmReleaseNotReady`: `cluster_id, cluster_type, installation, pipeline, provider, exported_namespace, name, team, ready`
- `KagentControllerDown`: `cluster_id, cluster_type, installation, pipeline, provider, namespace, deployment`

`max by` rather than `max without`, so that a newly added exporter label can never sneak back in. `cluster_type` stays because the PagerDuty payload prints it and the selector pins it, so it cannot churn. The `unless on (...) ALERTS{...}` deferral to the generic alerts is unchanged and every label in the `on()` sets survives the aggregation. `AgentPlatformPostgresClusterNotHealthy` already aggregated and is untouched.

For `KagentControllerDown` the comparison sits outside the aggregation (`max by (...) (available) == 0`): while two kube-state-metrics pods overlap during a rollout, the alert only fires if none of them reports an available replica.

### Tests

`exp_labels` shrink accordingly. Each alert gets a test that feeds two series differing only in the exporter's `pod`/`instance`/`node` labels over time, the old pod's ending and the new pod's beginning, and expects the alert to still be firing right after the hand-over. Against the previous expressions both of these evaluations fail because the alert is pending again.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [x] Dashboard: not applicable, no new alert
- [x] Request review from oncall area, as well as team
