### PR TITLE
fix: extract all rule files before running rules tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Rules test harness extracts all rule files before running tests, fixing flaky cross-directory `rule_files` references.
+
 ## [4.119.1] - 2026-09-06
 
 ### Fixed

--- a/test/hack/bin/verify-rules.sh
+++ b/test/hack/bin/verify-rules.sh
@@ -105,6 +105,28 @@ main() {
         # Look at each rules file for current provider
         cd "$outputPath/helm-chart/$provider/prometheus-rules/templates" || return 1
 
+        # Step 1 - extract every rules file from helm templates
+        while IFS= read -r -d '' file; do
+            file="${file#./}"
+
+            local extractDirname="${file%/*}"
+            local extractRuleFile="$outputPath/helm-chart/$provider/prometheus-rules/templates/$file"
+
+            if [[ -f "$extractRuleFile" ]]
+            then
+                [[ -d "$outputPath/generated/$provider/$extractDirname" ]] || mkdir -p "$outputPath/generated/$provider/$extractDirname"
+                "$GIT_WORKDIR/$YQ" '.spec' "$extractRuleFile" > "$outputPath/generated/$provider/$file"
+            else
+                # Fail when file is not found
+                echo "###  Warning: Failed extracting rules file $file"
+                failing_extraction+=("$provider:$file")
+            fi
+        done < <(find . -type f -regextype posix-egrep -regex "${rules_suffix_pattern}" -print0)
+
+        # Skip checks and tests if GENERATE_ONLY is set
+        if [[ "$GENERATE_ONLY" == "true" ]]; then continue; fi
+
+        # Step 2 - check and test rules
         while IFS= read -r -d '' file; do
             # Remove "./" at the vbeggining of the file path
             file="${file#./}"
@@ -120,20 +142,8 @@ main() {
 
             local ruleFile="$outputPath/helm-chart/$provider/prometheus-rules/templates/$file"
 
-            # Extract rules file from helm template
-            if [[ -f "$ruleFile" ]]
-            then
-                [[ -d "$outputPath/generated/$provider/$dirname" ]] || mkdir -p "$outputPath/generated/$provider/$dirname"
-                "$GIT_WORKDIR/$YQ" '.spec' "$ruleFile" > "$outputPath/generated/$provider/$file"
-            else
-                # Fail when file is not found
-                echo "###  Warning: Failed extracting rules file $file"
-                failing_extraction+=("$provider:$file")
-                continue
-            fi
-
-            # Skip next steps if GENERATE_ONLY is set
-            if [[ "$GENERATE_ONLY" == "true" ]]; then continue; fi
+            # Skip files that failed extraction in step 1
+            [[ -f "$ruleFile" ]] || continue
 
             # Verify tenant label exists and has the expected value
             local tenant_label


### PR DESCRIPTION
Noticed a flaky test in https://github.com/giantswarm/prometheus-rules/pull/2149/

`test/hack/bin/verify-rules.sh` extracted each rules file from the Helm output inside the
same loop that tested it, iterating in raw `find(1)` order. A test whose `rule_files`
names a rules file in another directory therefore only resolved when `find` happened to
yield the dependency first — and directory-entry order is not deterministic, so the
same commit passes on one runner and fails on another.

When the order is unlucky, promtool prints a *warning* rather than failing:

```
WARNING: no file match pattern .../generated/<provider>/kaas/tenet/recording-rules/<name>.rules.yml
```

then quietly loads only the rules it could find. Tests depending on the missing
recording fail with a confusing failure a long way from its cause.

### The fix

Split the test loop into two passes: extract every rules file first, then check
and test.

No alerting rule changes, so no new unit tests; the change is to the harness that runs
them.

### Checklist

- [x] Update CHANGELOG.md
- [ ] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing) — n/a, test harness change
- [ ] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured) — n/a
- [ ] Consider creating a dashboard — n/a
- [ ] Request review from oncall area, as well as team
