### PR TITLE
feat(atlas): add log-export loss-detection alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `log-export` alerts covering loss in the audit log export pipeline: exporter down, receiving nothing, Envoy mirror failures, upload failures and queue saturation.
+
 ### Changed
 
 - Rewrote all cabbage alert descriptions to a single line naming what broke and where.

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/log-export.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/log-export.rules.yml
@@ -1,0 +1,130 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: log-export.rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+    - name: log-export
+      rules:
+        # Mirrored requests are fire-and-forget: Envoy never retries them and the primary write
+        # path succeeds regardless, so every alert here is about an archive gap nobody would
+        # otherwise notice. The exporter's StatefulSet only exists where a LogExport does, which is
+        # what keeps these quiet on the installations that never use the feature.
+        - alert: LogExportExporterDown
+          annotations:
+            summary: The log export pipeline has no running exporter.
+            description: '{{`alloy-logexporter has no ready replica, so everything mirrored to it is being dropped and nothing is reaching the archive.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            count by (cluster_id, installation, pipeline, provider) (
+              kube_statefulset_status_replicas_ready{statefulset="alloy-logexporter"} == 0
+            )
+            > 0
+          for: 15m
+          labels:
+            area: platform
+            severity: page
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+            cancel_if_kube_state_metrics_down: "true"
+        # The exporter is up but nothing arrives: the mirror was never enabled on this
+        # installation, its ReferenceGrant is missing, or the route stopped resolving. Written as
+        # `unless` rather than `rate(...) == 0` because the receiver only registers its metrics on
+        # the first request -- with no traffic at all the series is absent, and `== 0` would never
+        # fire.
+        - alert: LogExportNotReceiving
+          annotations:
+            summary: The log export pipeline is running but receiving nothing.
+            description: '{{`alloy-logexporter has a ready replica but has received no pushes for 15 minutes, so the archive is silently empty.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            count by (cluster_id, installation, pipeline, provider) (
+              kube_statefulset_status_replicas_ready{statefulset="alloy-logexporter"} > 0
+            )
+            unless
+            count by (cluster_id, installation, pipeline, provider) (
+              rate (
+                loki_source_api_request_duration_seconds_count{job="alloy-logexporter", route="loki_api_v1_push"}[15m]
+              )
+              > 0
+            )
+          for: 30m
+          labels:
+            area: platform
+            severity: page
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+            cancel_if_kube_state_metrics_down: "true"
+            cancel_if_monitoring_agent_down: "true"
+        # Losses at the Envoy hop, before the exporter ever sees the request. The cluster is named
+        # after the route rule and mirror index, not the backend.
+        - alert: LogExportMirrorDropping
+          annotations:
+            summary: Envoy is failing to mirror writes to the log exporter.
+            description: '{{`{{ $value | printf "%.2f" }} mirrored requests per second are failing at the Envoy hop, so those log lines never reach the archive.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            sum by (cluster_id, installation, pipeline, provider) (
+              rate (
+                envoy_cluster_upstream_rq_xx{envoy_cluster_name=~"httproute/loki/loki-gateway/rule/[0-9]+-mirror-[0-9]+", envoy_response_code_class="5"}[10m]
+              )
+            )
+            > 0
+          for: 15m
+          labels:
+            area: platform
+            severity: ticket
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+        # The exporter gave up on an upload. It retries with backoff first, so a non-zero counter
+        # means those records are gone for good rather than delayed.
+        - alert: LogExportSendFailures
+          annotations:
+            summary: The log exporter is failing to write to its destination.
+            description: '{{`alloy-logexporter has given up on {{ $value | printf "%.2f" }} log records per second, which are permanently missing from the archive.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            sum by (cluster_id, installation, pipeline, provider) (
+              rate (
+                otelcol_exporter_send_failed_log_records_total{job="alloy-logexporter"}[10m]
+              )
+            )
+            > 0
+          for: 15m
+          labels:
+            area: platform
+            severity: ticket
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+            cancel_if_monitoring_agent_down: "true"
+        # Fires before data is lost rather than after: the queue drops silently once full, visible
+        # only as a counter nobody watches.
+        - alert: LogExportQueueSaturated
+          annotations:
+            summary: The log exporter's sending queue is filling up.
+            description: '{{`The sending queue on alloy-logexporter is {{ $value | printf "%.0f" }}% full. It drops records silently once full.`}}'
+            runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
+          expr: |-
+            100
+            *
+              max by (cluster_id, installation, pipeline, provider) (
+                  otelcol_exporter_queue_size{job="alloy-logexporter"}
+                /
+                  otelcol_exporter_queue_capacity{job="alloy-logexporter"}
+              )
+            > 80
+          for: 15m
+          labels:
+            area: platform
+            severity: ticket
+            team: atlas
+            topic: observability
+            cancel_if_outside_working_hours: "true"
+            cancel_if_monitoring_agent_down: "true"

--- a/test/tests/providers/global/platform/atlas/alerting-rules/log-export.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/log-export.rules.test.yml
@@ -1,0 +1,169 @@
+---
+rule_files:
+  - log-export.rules.yml
+
+tests:
+  # LogExportExporterDown: ready replicas drop to zero, then recover.
+  - interval: 1m
+    input_series:
+      - series: 'kube_statefulset_status_replicas_ready{statefulset="alloy-logexporter", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable"}'
+        values: "2x30 0x30 2x30"
+    alert_rule_test:
+      - alertname: LogExportExporterDown
+        eval_time: 25m
+      # Ready hits zero at 30m; 15m of `for` means nothing before 45m.
+      - alertname: LogExportExporterDown
+        eval_time: 40m
+      - alertname: LogExportExporterDown
+        eval_time: 55m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              installation: myinstall
+              pipeline: stable
+              provider: $provider
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              summary: The log export pipeline has no running exporter.
+              description: "alloy-logexporter has no ready replica, so everything mirrored to it is being dropped and nothing is reaching the archive."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION=myinstall&CLUSTER=myinstall
+      - alertname: LogExportExporterDown
+        eval_time: 75m
+
+  # LogExportNotReceiving: exporter ready throughout; pushes stop after 60m.
+  - interval: 1m
+    input_series:
+      - series: 'kube_statefulset_status_replicas_ready{statefulset="alloy-logexporter", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable"}'
+        values: "2x180"
+      - series: 'loki_source_api_request_duration_seconds_count{job="alloy-logexporter", route="loki_api_v1_push", status_code="204", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable", pod="alloy-logexporter-0"}'
+        values: "0+60x60 3600x120"
+    alert_rule_test:
+      # Traffic flowing: quiet.
+      - alertname: LogExportNotReceiving
+        eval_time: 45m
+      # Flat from 60m. The 15m rate window has to empty out before the 30m `for` starts.
+      - alertname: LogExportNotReceiving
+        eval_time: 80m
+      - alertname: LogExportNotReceiving
+        eval_time: 130m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_kube_state_metrics_down: "true"
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              installation: myinstall
+              pipeline: stable
+              provider: $provider
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              summary: The log export pipeline is running but receiving nothing.
+              description: "alloy-logexporter has a ready replica but has received no pushes for 15 minutes, so the archive is silently empty."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION=myinstall&CLUSTER=myinstall
+
+  # The feature is not in use here: no StatefulSet, so nothing may fire.
+  - interval: 1m
+    input_series:
+      - series: 'kube_statefulset_status_replicas_ready{statefulset="loki-write", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable"}'
+        values: "3x120"
+    alert_rule_test:
+      - alertname: LogExportExporterDown
+        eval_time: 60m
+      - alertname: LogExportNotReceiving
+        eval_time: 90m
+      - alertname: LogExportSendFailures
+        eval_time: 60m
+      - alertname: LogExportQueueSaturated
+        eval_time: 60m
+
+  # LogExportMirrorDropping: 5xx at the Envoy hop.
+  - interval: 1m
+    input_series:
+      - series: 'envoy_cluster_upstream_rq_xx{envoy_cluster_name="httproute/loki/loki-gateway/rule/0-mirror-0", envoy_response_code_class="5", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable"}'
+        values: "0x60 0+12x60"
+      - series: 'envoy_cluster_upstream_rq_xx{envoy_cluster_name="httproute/loki/loki-gateway/rule/0-mirror-0", envoy_response_code_class="2", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable"}'
+        values: "0+600x120"
+    alert_rule_test:
+      - alertname: LogExportMirrorDropping
+        eval_time: 45m
+      - alertname: LogExportMirrorDropping
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              installation: myinstall
+              pipeline: stable
+              provider: $provider
+              severity: ticket
+              team: atlas
+              topic: observability
+            exp_annotations:
+              summary: Envoy is failing to mirror writes to the log exporter.
+              description: "0.20 mirrored requests per second are failing at the Envoy hop, so those log lines never reach the archive."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION=myinstall&CLUSTER=myinstall
+
+  # LogExportSendFailures: uploads given up on.
+  - interval: 1m
+    input_series:
+      - series: 'otelcol_exporter_send_failed_log_records_total{job="alloy-logexporter", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable", component_id="otelcol.exporter.awss3.audit"}'
+        values: "0x60 0+60x60"
+    alert_rule_test:
+      - alertname: LogExportSendFailures
+        eval_time: 45m
+      - alertname: LogExportSendFailures
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              installation: myinstall
+              pipeline: stable
+              provider: $provider
+              severity: ticket
+              team: atlas
+              topic: observability
+            exp_annotations:
+              summary: The log exporter is failing to write to its destination.
+              description: "alloy-logexporter has given up on 1.00 log records per second, which are permanently missing from the archive."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION=myinstall&CLUSTER=myinstall
+
+  # LogExportQueueSaturated: queue crosses 80% of capacity.
+  - interval: 1m
+    input_series:
+      - series: 'otelcol_exporter_queue_size{job="alloy-logexporter", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable", component_id="otelcol.exporter.awss3.audit"}'
+        values: "1000x60 180000x60"
+      - series: 'otelcol_exporter_queue_capacity{job="alloy-logexporter", cluster_id="myinstall", installation="myinstall", provider="$provider", pipeline="stable", component_id="otelcol.exporter.awss3.audit"}'
+        values: "200000x120"
+    alert_rule_test:
+      - alertname: LogExportQueueSaturated
+        eval_time: 45m
+      - alertname: LogExportQueueSaturated
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_monitoring_agent_down: "true"
+              cancel_if_outside_working_hours: "true"
+              cluster_id: myinstall
+              installation: myinstall
+              pipeline: stable
+              provider: $provider
+              severity: ticket
+              team: atlas
+              topic: observability
+            exp_annotations:
+              summary: The log exporter's sending queue is filling up.
+              description: "The sending queue on alloy-logexporter is 90% full. It drops records silently once full."
+              runbook_url: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/log-export/?INSTALLATION=myinstall&CLUSTER=myinstall


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37251

The audit log export pipeline is mirrored off the Loki write path, fire-and-forget. That is what stops it affecting log ingestion — and equally what lets it lose archive data while every dashboard stays green: Envoy never retries a mirrored request and the primary write succeeds regardless.

Measured during design work: with the mirror target scaled to zero for five minutes under load, **80,444 audit lines were sent and none captured**, with nothing observable from the exporter because the requests never reached it.

## The alerts

| Alert | Fires when | Severity |
|---|---|---|
| `LogExportExporterDown` | no ready exporter replica | page |
| `LogExportNotReceiving` | exporter up, nothing arriving for 15m | page |
| `LogExportMirrorDropping` | Envoy 5xx on the mirror cluster | ticket |
| `LogExportSendFailures` | uploads given up on — permanent loss | ticket |
| `LogExportQueueSaturated` | sending queue over 80% — loss not yet happened | ticket |

The two `page` alerts are total silent loss; the three `ticket` ones are partial or pre-emptive. All carry `cancel_if_outside_working_hours: "true"`. **`LogExportSendFailures` is the one I would most expect you to want promoted** — it means records are permanently missing from a compliance archive — but I kept it at `ticket` for a first iteration rather than guess at the noise level.

## Only fires where the feature is used

The exporter's StatefulSet exists only where a `LogExport` does, so `kube_statefulset_*{statefulset="alloy-logexporter"}` is the presence gate. Verified on an installation with no `LogExport`: the StatefulSet, the exporter's `up` series and the Envoy mirror cluster series are all absent while Mimir is otherwise healthy. A dedicated not-in-use test case asserts all five stay silent.

## Two things worth reviewing

**`LogExportNotReceiving` is written as `unless`, not `rate(...) == 0`.** `loki.source.api` registers its metrics on the first request, so with no traffic at all the series is absent and a comparison to zero never fires — which is exactly the case the alert exists to catch.

**`otelcol_exporter_enqueue_failed_log_records_total` does not exist** in this Alloy version, despite being the obvious counterpart to the `tracing-pipeline` rules. I checked the metric names actually present and used `otelcol_exporter_queue_size / otelcol_exporter_queue_capacity` instead, which is a better signal anyway — it fires before records are dropped rather than after.

All `otelcol_exporter_*` selectors are scoped `job="alloy-logexporter"` so they cannot overlap with the existing `tracing-pipeline` alerts on `job="alloy-events"`.

## Verification

Every expression was run against a real installation's Mimir before being written into a rule, including the queue-saturation division, which silently returns nothing if the two metrics' label sets disagree.

- `make test-rules test_filter=log-export` — green across all five providers, firing and not-firing cases.
- `make test-inhibitions` — exit 0.
- `make pint PINT_TEAM_FILTER=atlas` reports `Fatal=1, Information=2`, **identical on clean `main`** — the Fatal is a pre-existing LogQL-parsed-as-PromQL error in `mimir.logs.yml`. These rules add nothing.

## Depends on

giantswarm/giantswarm#37716 — the runbook. `make test-runbooks` validates `runbook_url` resolves, so this stays red until that merges.

## Not included

A recording rule for exported-vs-received lines. The exporter only handles what the `LogExport` selectors match, so a naive ratio reads as permanent massive loss; doing it properly needs a like-for-like Loki-side count using the same selector, which is a design decision rather than a rule to type out. Worth its own issue.
