### PR TITLE
fix: cover grafana-postgresql PVCs in ObservabilityStorageSpaceTooLow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CoreDNSMaxHPAReplicasReached` - description now names the HPA instead of rendering an empty deployment name.
 - `ExternalDNSCantAccessRegistry`, `ExternalDNSCantAccessSource` and `ExternalDNSDown` - removed a stray bracket from the descriptions.
 - Rules test harness extracts all rule files before running tests, fixing flaky cross-directory `rule_files` references.
+- `ObservabilityStorageSpaceTooLow` - now covers `grafana-postgresql` PVCs, which the mismatched denominator selector silently dropped.
 
 ## [4.119.1] - 2026-09-06
 

--- a/helm/prometheus-rules/templates/platform/atlas/alerting-rules/storage.rules.yml
+++ b/helm/prometheus-rules/templates/platform/atlas/alerting-rules/storage.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`The free space on the Data Disk for instance: {{ $labels.instance }} and PVC: {{ $labels.persistentvolumeclaim}} was below 10 percent for longer than 1 hour (current value {{ $value | printf "%.2f" }}).`}}'
         runbook_url: '{{`https://intranet.giantswarm.io/docs/support-and-ops/runbooks/low-disk-space/#persistent-volume?INSTALLATION={{ $labels.installation }}&CLUSTER={{ $labels.cluster_id }}`}}'
-      expr: kubelet_volume_stats_available_bytes{cluster_type="management_cluster", persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo|grafana-postgresql).*"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo).*"} < 0.10
+      expr: kubelet_volume_stats_available_bytes{cluster_type="management_cluster", persistentvolumeclaim=~".*(alertmanager|grafana-postgresql|loki|mimir|prometheus|pyroscope|tempo).*"}/kubelet_volume_stats_capacity_bytes{cluster_type="management_cluster", persistentvolumeclaim=~".*(alertmanager|grafana-postgresql|loki|mimir|prometheus|pyroscope|tempo).*"} < 0.10
       for: 1h
       labels:
         area: platform

--- a/test/conf/promtool_ignore
+++ b/test/conf/promtool_ignore
@@ -11,7 +11,6 @@ platform/atlas/alerting-rules/inhibit.oncall.rules.yml
 platform/atlas/alerting-rules/keda.rules.yml
 platform/atlas/alerting-rules/kube-state-metrics.rules.yml
 platform/atlas/alerting-rules/prometheus-operator.rules.yml
-platform/atlas/alerting-rules/storage.rules.yml
 platform/atlas/recording-rules/grafana-cloud.rules.yml
 platform/atlas/recording-rules/loki-mixins.rules.yml
 platform/atlas/recording-rules/mimir-mixins.rules.yml

--- a/test/tests/providers/global/platform/atlas/alerting-rules/storage.rules.test.yml
+++ b/test/tests/providers/global/platform/atlas/alerting-rules/storage.rules.test.yml
@@ -1,0 +1,68 @@
+---
+rule_files:
+- storage.rules.yml
+
+tests:
+  # Every observability PVC listed in the selector must be covered, on management clusters only.
+  - interval: 1m
+    input_series:
+      # Below threshold (5% free) - must alert.
+      - series: 'kubelet_volume_stats_available_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.1:10250", persistentvolumeclaim="grafana-postgresql-1"}'
+        values: "5x180"
+      - series: 'kubelet_volume_stats_capacity_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.1:10250", persistentvolumeclaim="grafana-postgresql-1"}'
+        values: "100x180"
+      # Below threshold (5% free) - must alert.
+      - series: 'kubelet_volume_stats_available_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.2:10250", persistentvolumeclaim="storage-mimir-store-gateway-0"}'
+        values: "5x180"
+      - series: 'kubelet_volume_stats_capacity_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.2:10250", persistentvolumeclaim="storage-mimir-store-gateway-0"}'
+        values: "100x180"
+      # Healthy (50% free) - must stay silent.
+      - series: 'kubelet_volume_stats_available_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.1:10250", persistentvolumeclaim="grafana-postgresql-2"}'
+        values: "50x180"
+      - series: 'kubelet_volume_stats_capacity_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.1:10250", persistentvolumeclaim="grafana-postgresql-2"}'
+        values: "100x180"
+      # Workload cluster - out of scope, must stay silent.
+      - series: 'kubelet_volume_stats_available_bytes{cluster_type="workload_cluster", cluster_id="baz", installation="myinstall", instance="10.0.0.3:10250", persistentvolumeclaim="grafana-postgresql-1"}'
+        values: "5x180"
+      - series: 'kubelet_volume_stats_capacity_bytes{cluster_type="workload_cluster", cluster_id="baz", installation="myinstall", instance="10.0.0.3:10250", persistentvolumeclaim="grafana-postgresql-1"}'
+        values: "100x180"
+      # PVC outside the observability selector - must stay silent.
+      - series: 'kubelet_volume_stats_available_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.4:10250", persistentvolumeclaim="data-unrelated-app-0"}'
+        values: "5x180"
+      - series: 'kubelet_volume_stats_capacity_bytes{cluster_type="management_cluster", cluster_id="bar", installation="myinstall", instance="10.0.0.4:10250", persistentvolumeclaim="data-unrelated-app-0"}'
+        values: "100x180"
+    alert_rule_test:
+      # `for: 1h` not yet satisfied.
+      - alertname: ObservabilityStorageSpaceTooLow
+        eval_time: 30m
+      - alertname: ObservabilityStorageSpaceTooLow
+        eval_time: 90m
+        exp_alerts:
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: bar
+              cluster_type: management_cluster
+              installation: myinstall
+              instance: 10.0.0.1:10250
+              persistentvolumeclaim: grafana-postgresql-1
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "The free space on the Data Disk for instance: 10.0.0.1:10250 and PVC: grafana-postgresql-1 was below 10 percent for longer than 1 hour (current value 0.05)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/low-disk-space/#persistent-volume?INSTALLATION=myinstall&CLUSTER=bar"
+          - exp_labels:
+              area: platform
+              cancel_if_outside_working_hours: "true"
+              cluster_id: bar
+              cluster_type: management_cluster
+              installation: myinstall
+              instance: 10.0.0.2:10250
+              persistentvolumeclaim: storage-mimir-store-gateway-0
+              severity: page
+              team: atlas
+              topic: observability
+            exp_annotations:
+              description: "The free space on the Data Disk for instance: 10.0.0.2:10250 and PVC: storage-mimir-store-gateway-0 was below 10 percent for longer than 1 hour (current value 0.05)."
+              runbook_url: "https://intranet.giantswarm.io/docs/support-and-ops/runbooks/low-disk-space/#persistent-volume?INSTALLATION=myinstall&CLUSTER=bar"


### PR DESCRIPTION
## What

`ObservabilityStorageSpaceTooLow` cannot fire for `grafana-postgresql` PVCs today. The selector was extended with `grafana-postgresql` on the **numerator only** in #1584:

```promql
kubelet_volume_stats_available_bytes{cluster_type="management_cluster", persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo|grafana-postgresql).*"}
/
kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".*(alertmanager|loki|mimir|prometheus|pyroscope|tempo).*"}
< 0.10
```

PromQL binary operations match on the full label set, so `grafana-postgresql` samples on the left have no counterpart on the right and the division drops them. The alert looks configured for those volumes but covers nothing.

This PR makes both selectors identical, and sorts the alternation so the next addition is harder to get wrong.

Adding `cluster_type="management_cluster"` to the denominator is **not** a behaviour change: the join already required `cluster_type` to match and the left side was already pinned to management clusters. It only narrows the series loaded before the join.

## Tests

There was no test file for this alert, and `storage.rules.yml` sat in `test/conf/promtool_ignore`, which exempts a rule file from *requiring* tests. Adding a test alone would have been skipped silently, so the ignore entry is removed too.

`test/tests/providers/global/platform/atlas/alerting-rules/storage.rules.test.yml` covers:

- `grafana-postgresql` PVC below threshold → fires (the regression guard)
- `mimir` PVC below threshold → fires (pre-existing behaviour preserved)
- healthy PVC at 50% free → silent
- `cluster_type="workload_cluster"` → silent
- PVC outside the observability selector → silent
- `for: 1h` not yet satisfied at 30m → silent

Verified the guard actually bites: reverting just the `expr` to the old version makes the suite fail with the `grafana-postgresql` alert missing (exit 2). With the fix, `make test-rules test_filter=storage.rules` is green across all five providers.

### Checklist

- [x] Update CHANGELOG.md
- [x] Add [Unit tests](https://github.com/giantswarm/prometheus-rules/#testing)
- [x] Follow [Alert structure](https://github.com/giantswarm/prometheus-rules/#how-alerts-are-structured)
- [ ] Consider creating a dashboard — n/a, no new alert
- [ ] Request review from oncall area, as well as team
